### PR TITLE
ci: remove paths filter to fix branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,6 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'package*.json'
-      - '.github/workflows/test.yml'
 
 # Minimal permissions for security
 permissions:


### PR DESCRIPTION
The paths filter in test.yml causes PRs with docs-only changes to hang forever because the required status checks never run.

This removes the paths filter so tests always run on every PR.