### PR TITLE
fix: add .js extension to schema-sql imports for ESM compatibility

### DIFF
--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/libsql";
 import { existsSync, mkdirSync, accessSync, constants, statSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import dotenv from "dotenv";
-import { getTableCreationSQL } from "./schema-sql";
+import { getTableCreationSQL } from "./schema-sql.js";
 
 dotenv.config({ path: process.env.DOTENV_PATH || ".env" });
 
@@ -45,7 +45,7 @@ export function ensureDataDirectory(dataDir: string): { success: boolean; error?
 }
 
 /** Get the SQL statements for creating all tables (re-exported from schema-sql) */
-export { getTableCreationSQL } from "./schema-sql";
+export { getTableCreationSQL } from "./schema-sql.js";
 
 /** Run table creation migrations on a client */
 export async function runTableMigrations(client: Client): Promise<{ success: boolean; errors: string[] }> {

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -2,7 +2,7 @@ import { createClient, Client } from "@libsql/client";
 import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
-import { getTableCreationSQL } from "./schema-sql";
+import { getTableCreationSQL } from "./schema-sql.js";
 
 dotenv.config({ path: process.env.DOTENV_PATH || ".env" });
 

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -10,7 +10,7 @@ import fastifyMultipart from "@fastify/multipart";
 import { createClient, Client } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { beforeAll, afterAll, beforeEach } from "vitest";
-import { getTableCreationSQL } from "../db/schema-sql";
+import { getTableCreationSQL } from "../db/schema-sql.js";
 
 // Type for our test database
 export type TestDb = ReturnType<typeof drizzle>;


### PR DESCRIPTION
Fixes production crash:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/dist/db/schema-sql' imported from /app/dist/db/client.js
```

The schema-sql.ts imports were missing the .js extension required for ESM modules after TypeScript compilation.

**Changed files:**
- backend/src/db/client.ts
- backend/src/db/migrate.ts
- backend/src/test/setup.ts