### PR TITLE
docs: add rule to never release without explicit permission

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 ## General Rules
 
 - **English is the primary language**: All code, comments, documentation, commit messages, PR descriptions, and GitHub releases MUST be written in English. The user may communicate in German, but all project artifacts must be in English.
+- **NEVER release without explicit permission**: Do NOT create tags, releases, or version bumps unless the user explicitly asks for it. Always wait for explicit confirmation before any release action.
 - **No temporary files**: Delete temporary scripts/files immediately after use. Do not commit temporary debug scripts, test files, or one-off utilities to the repository.
 - **Clean workspace**: Always clean up after yourself. If you create a file for a specific task, delete it once done.
 


### PR DESCRIPTION
Adds explicit rule to copilot-instructions.md:

> **NEVER release without explicit permission**: Do NOT create tags, releases, or version bumps unless the user explicitly asks for it.