### PR TITLE
fix: Clean up Export/Import UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "i18next": "^24.2.2",
         "i18next-browser-languagedetector": "^8.0.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -354,7 +354,7 @@ function AppContent() {
 	// Export/Import state
 	const [exporting, setExporting] = useState(false);
 	const [importing, setImporting] = useState(false);
-	const [includeSensitiveData, setIncludeSensitiveData] = useState(false);
+
 	const [showImportConfirm, setShowImportConfirm] = useState(false);
 	const [pendingImportData, setPendingImportData] = useState<any>(null);
 	// Collapsed days state (manually collapsed days are persisted)
@@ -788,7 +788,7 @@ function AppContent() {
 	async function handleExport() {
 		setExporting(true);
 		try {
-			const res = await fetch(`/api/export?includeSensitive=${includeSensitiveData}`, {
+			const res = await fetch('/api/export?includeSensitive=true', {
 				credentials: "include",
 			});
 			if (!res.ok) throw new Error("Export failed");
@@ -2423,19 +2423,6 @@ function AppContent() {
 											<div className="export-import-card">
 												<h3>{t('exportImport.exportTitle')}</h3>
 												<p className="export-import-desc">{t('exportImport.exportDesc')}</p>
-												<label className="export-import-checkbox">
-													<input
-														type="checkbox"
-														checked={includeSensitiveData}
-														onChange={(e) => setIncludeSensitiveData(e.target.checked)}
-													/>
-													<span>{t('exportImport.includeSensitive')}</span>
-												</label>
-												{includeSensitiveData && (
-													<p className="export-import-warning">
-														⚠️ {t('exportImport.sensitiveWarning')}
-													</p>
-												)}
 												<button
 													type="button"
 													className="secondary"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3979,6 +3979,14 @@ h3 .reminder-icon.info-tooltip {
 }
 
 /* Export/Import Section */
+.card:has(.export-import-grid) {
+  overflow: visible;
+}
+
+.card:has(.export-import-grid) .card-head {
+  overflow: visible;
+}
+
 .export-import-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -4016,32 +4024,6 @@ h3 .reminder-icon.info-tooltip {
   margin: 0;
   line-height: 1.5;
   flex: 1;
-}
-
-.export-import-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  text-transform: none !important;
-}
-
-.export-import-checkbox input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-}
-
-.export-import-warning {
-  font-size: 0.8rem;
-  color: var(--warning);
-  margin: 0;
-  padding: 0.5rem;
-  background: rgba(234, 179, 8, 0.1);
-  border-radius: 4px;
-  line-height: 1.4;
 }
 
 .export-import-card button,


### PR DESCRIPTION
## Changes

- Fix tooltip visibility (overflow: visible for export card)
- Remove unnecessary 'Include sensitive data' checkbox  
- Always export all data including notification URLs
- Remove unused CSS styles for checkbox and warning

## Why

The 'sensitive data' checkbox was confusing - the only 'sensitive' data was the Shoutrrr notification URL, which isn't really sensitive in most cases. Simplifies the UI.

The tooltip was hidden due to overflow: hidden on the card element.