### PR TITLE
docs: Add Pushover support and improve push notification documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ### Notifications
 - Email via SMTP
-- Push notifications via ntfy, Gotify, Telegram, Discord (Shoutrrr)
+- Push notifications via ntfy, Pushover, Gotify, Telegram, Discord & more ([Shoutrrr](https://containrrr.dev/shoutrrr/))
 - Supports both stock warnings and intake reminders
 
 ### Privacy & Security
@@ -147,6 +147,54 @@ Generate secrets with: `openssl rand -hex 32`
 | `REMINDER_HOUR` | `6` | Hour to send daily reminders (24h format) |
 | `REMINDER_MINUTES_BEFORE` | `15` | Minutes before intake to send reminder |
 | `EXPIRY_WARNING_DAYS` | `30` | Days before expiry to show warning |
+
+### Push Notifications (Shoutrrr)
+
+MedAssist uses [Shoutrrr](https://containrrr.dev/shoutrrr/) for push notifications, supporting many services with a single URL format.
+
+**Supported services:** ntfy, Pushover, Gotify, Discord, Telegram, Slack, Matrix, and [many more](https://containrrr.dev/shoutrrr/v0.8/services/overview/).
+
+Configure push notifications in Settings → Push, or set defaults via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEFAULT_SHOUTRRR_ENABLED` | `false` | Enable push notifications by default |
+| `DEFAULT_SHOUTRRR_URL` | — | Shoutrrr URL (see examples below) |
+| `DEFAULT_SHOUTRRR_STOCK_REMINDERS` | `true` | Send stock warnings via push |
+| `DEFAULT_SHOUTRRR_INTAKE_REMINDERS` | `true` | Send intake reminders via push |
+
+#### URL Examples
+
+**ntfy** (free, self-hostable):
+```
+ntfy://ntfy.sh/your-topic
+ntfy://user:password@your-server.com/topic
+```
+
+**Pushover** (free app for iOS/Android):
+```
+pushover://shoutrrr:API_TOKEN@USER_KEY/
+```
+Get your keys at [pushover.net](https://pushover.net/):
+- **User Key**: Shown on your dashboard (top right)
+- **API Token**: Create an application → copy the API Token
+
+**Gotify** (self-hosted):
+```
+gotify://your-server.com/TOKEN
+```
+
+**Discord**:
+```
+discord://TOKEN@WEBHOOK_ID
+```
+
+**Telegram**:
+```
+telegram://TOKEN@telegram?chats=CHAT_ID
+```
+
+For all services and options, see the [Shoutrrr documentation](https://containrrr.dev/shoutrrr/v0.8/services/overview/).
 
 # Development
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2243,12 +2243,12 @@ function AppContent() {
 														<span className="field-label">{t('settings.push.url')}</span>
 														<div className="input-with-tooltip">
 															<input
-																type="url"
+																type="text"
 																value={settings.shoutrrrUrl}
 																onChange={(e) => setSettings({ ...settings, shoutrrrUrl: e.target.value })}
-																placeholder="https://ntfy.sh/your-topic"
+																placeholder={t('settings.push.urlPlaceholder')}
 															/>
-															<span className="info-tooltip" data-tooltip={t('settings.push.supports')}>ⓘ</span>
+															<span className="info-tooltip" data-tooltip={`${t('settings.push.supports')}\n\n${t('settings.push.docsLink')}`}>ⓘ</span>
 														</div>
 													</label>
 												</div>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -173,7 +173,9 @@
     },
     "push": {
       "url": "URL",
-      "supports": "Unterstützt ntfy, Discord, Telegram, Slack"
+      "urlPlaceholder": "ntfy://topic oder pushover://:token@userkey/",
+      "supports": "Unterstützt ntfy, Pushover, Gotify, Discord, Telegram, Slack & mehr",
+      "docsLink": "Siehe shoutrrr.dev für alle Services"
     },
     "schedule": {
       "title": "Erinnerungsplan",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -175,7 +175,9 @@
     },
     "push": {
       "url": "URL",
-      "supports": "Supports ntfy, Discord, Telegram, Slack"
+      "urlPlaceholder": "ntfy://topic or pushover://:token@userkey/",
+      "supports": "Supports ntfy, Pushover, Gotify, Discord, Telegram, Slack & more",
+      "docsLink": "See shoutrrr.dev for all services"
     },
     "schedule": {
       "title": "Reminder Schedule",


### PR DESCRIPTION
## Summary

Addresses feature request for Pushover support. Since we already use Shoutrrr, Pushover is already supported - this PR improves documentation and UI to make it clear.

## Changes

### UI Improvements
- Add Pushover and Gotify to supported services list
- Add URL placeholder with examples: `ntfy://topic or pushover://:token@userkey/`
- Add tooltip link to shoutrrr.dev for all available services
- Change input type from `url` to `text` (Shoutrrr URLs like `pushover://...` aren't valid HTTP URLs)

### README
- Add comprehensive "Push Notifications (Shoutrrr)" section
- Document all ENV variables for push configuration
- Include URL examples for popular services:
  - ntfy (free, self-hostable)
  - Pushover (iOS/Android)
  - Gotify (self-hosted)
  - Discord
  - Telegram

## Pushover URL Format
```
pushover://shoutrrr:API_TOKEN@USER_KEY/
```

Users get their keys from [pushover.net](https://pushover.net/).