### PR TITLE
fix(ci): disable provenance/sbom to remove unknown/unknown image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -118,6 +118,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
 
   # =============================================================================
   # Create GitHub Release (only on tag push)


### PR DESCRIPTION
Disables SBOM and provenance attestations in the Docker build workflow to prevent the 'unknown/unknown' platform image from appearing in the container registry.