### PR TITLE
fix(ci): disable provenance/sbom to remove unknown/unknown image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -118,6 +118,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
 
   # =============================================================================
   # Create GitHub Release (only on tag push)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,6 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/test.yml'
 
 # Minimal permissions for security
 permissions:


### PR DESCRIPTION
Disables SBOM and provenance attestations in the Docker build workflow to prevent the 'unknown/unknown' platform image from appearing in the container registry.