### PR TITLE
fix: close medication detail modal before navigating to edit

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3285,7 +3285,7 @@ function AppContent() {
 								<button className="success" onClick={openRefillModal}>
 									{t('refill.button')}
 								</button>
-								<button className="info" onClick={() => { closeMedDetail(); navigate("/medications"); startEdit(selectedMed); }}>
+								<button className="info" onClick={() => { setSelectedMed(null); navigate("/medications"); startEdit(selectedMed); }}>
 									{t('common.edit')}
 								</button>
 								{selectedMed.blisters.length > 0 && (


### PR DESCRIPTION
## Summary

Fixes an issue where clicking 'Edit' (Bearbeiten) in the medication detail modal would open the edit form, but the detail modal would remain visible behind it.

## What's Changed

When clicking 'Edit' in the medication detail modal, the modal now properly closes before navigating to the medications page. Changed from `closeMedDetail()` (which uses history.back() asynchronously) to directly setting `setSelectedMed(null)` for immediate closure.

## Testing

1. Open a medication detail modal (click on a coverage card)
2. Click 'Bearbeiten' (Edit)
3. The edit form should open without the detail modal being visible in the background