### PR TITLE
fix: add stock_calculation_mode ALTER migration for backward compatibility

### DIFF
--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -73,6 +73,8 @@ export async function runAlterMigrations(client: Client): Promise<{ success: boo
     `ALTER TABLE user_settings ADD COLUMN max_nagging_reminders integer NOT NULL DEFAULT 5`,
     // Added in v1.2.3 - dismiss missed doses without deducting stock
     `ALTER TABLE dose_tracking ADD COLUMN dismissed integer NOT NULL DEFAULT 0`,
+    // Added in v1.3.x - stock calculation mode (automatic/manual)
+    `ALTER TABLE user_settings ADD COLUMN stock_calculation_mode text NOT NULL DEFAULT 'automatic'`,
   ];
 
   for (const sql of alterMigrations) {


### PR DESCRIPTION
## Problem
The `/export` endpoint was returning HTTP 500 errors in production.

## Cause
The `stock_calculation_mode` column was added to the `user_settings` table schema, but was missing from the ALTER migrations that ensure backward compatibility with older databases.

When the export route tried to access `settings.stockCalculationMode`, SQLite threw an error because the column didn't exist.

## Fix
Added the missing ALTER migration to `client.ts`:
```sql
ALTER TABLE user_settings ADD COLUMN stock_calculation_mode text NOT NULL DEFAULT 'automatic'
```

This migration runs automatically on server startup and silently ignores 'duplicate column' errors if the column already exists.