### PR TITLE
fix: improve import error handling and add refill_history table migration

### DIFF
--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -88,6 +88,30 @@ export async function runAlterMigrations(client: Client): Promise<{ success: boo
     }
   }
 
+  // Create tables that might be missing (silently fail if already exists)
+  const createTableMigrations = [
+    // Added in v1.3.x - refill history tracking
+    `CREATE TABLE IF NOT EXISTS refill_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      medication_id INTEGER NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      packs_added INTEGER NOT NULL DEFAULT 0,
+      loose_pills_added INTEGER NOT NULL DEFAULT 0,
+      refill_date INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+    )`,
+  ];
+
+  for (const sql of createTableMigrations) {
+    try {
+      await client.execute(sql);
+    } catch (e: any) {
+      // Silently ignore "table already exists" errors
+      if (!e.message?.includes("already exists")) {
+        errors.push(e.message);
+      }
+    }
+  }
+
   return { success: errors.length === 0, errors };
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1151,17 +1151,26 @@ function AppContent() {
 				body: JSON.stringify(pendingImportData),
 			});
 			
-			if (!res.ok) {
-				const err = await res.json();
-				alert(t('exportImport.importError') + ": " + (err.error || "Unknown error"));
+			// Get the response text first to handle non-JSON responses
+			const text = await res.text();
+			let data;
+			try {
+				data = text ? JSON.parse(text) : {};
+			} catch {
+				console.error("Import response parse error:", text);
+				alert(t('exportImport.importError') + ": Server returned invalid response");
 				return;
 			}
 			
-			const result = await res.json();
+			if (!res.ok) {
+				alert(t('exportImport.importError') + ": " + (data.error || `HTTP ${res.status}`));
+				return;
+			}
+			
 			alert(t('exportImport.importSuccess') + "\n" + t('exportImport.importSuccessDetails', {
-				medications: result.imported.medications,
-				doses: result.imported.doseHistory,
-				shares: result.imported.shareLinks,
+				medications: data.imported?.medications || 0,
+				doses: data.imported?.doseHistory || 0,
+				shares: data.imported?.shareLinks || 0,
 			}));
 			
 			// Reload all data


### PR DESCRIPTION
## Problem
Import was failing with `JSON.parse: unexpected character at line 1 column 1` error.

## Cause
1. The `refill_history` table might not exist in older production databases
2. Frontend was trying to parse non-JSON error responses as JSON, causing the cryptic error

## Fix
1. Added `CREATE TABLE IF NOT EXISTS refill_history` migration in `client.ts`
2. Improved frontend import error handling:
   - Parse response as text first
   - Properly handle non-JSON responses
   - Show actual server error messages to user
   - Safe fallbacks for all edge cases