### PR TITLE
fix: increase body size limit for large imports

### DIFF
--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -389,6 +389,13 @@ export async function exportRoutes(app: FastifyInstance) {
   // ---------------------------------------------------------------------------
   app.post(
     "/import",
+    {
+      config: {
+        // Increase body limit to 50MB to handle exports with base64 images
+        rawBody: true,
+      },
+      bodyLimit: 50 * 1024 * 1024, // 50 MB
+    },
     async (request, reply) => {
       const userId = await getUserId(request, reply);
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,8 +12,8 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
-    # Allow larger file uploads (for medication images)
-    client_max_body_size 10M;
+    # Allow larger file uploads (for medication images and data import/export)
+    client_max_body_size 50M;
 
     location / {
         try_files $uri /index.html;


### PR DESCRIPTION
## Problem
Import fails with `413 Request Entity Too Large` for exports larger than 10 MB.

This happens when the export contains many medications with base64-encoded images (e.g., ~13 MB export file).

## Solution
- Increase nginx `client_max_body_size` from 10 MB to 50 MB
- Add `bodyLimit: 50 MB` to Fastify `/import` route

## Testing
- All 453 tests pass
- Ready to test with 13 MB export file after deployment