### PR TITLE
fix: show package size in user medications modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3827,8 +3827,8 @@ function AppContent() {
 							{meds.filter(m => (m.takenBy || []).includes(selectedUser)).map((med) => {
 								const medCoverage = coverage.all.find(c => c.name === med.name);
 								const status = medCoverage ? getStockStatus(medCoverage.daysLeft, medCoverage.medsLeft, settings) : null;
-								const totalPills = getMedTotal(med);
-								const currentStock = medCoverage ? formatNumber(medCoverage.medsLeft) : formatNumber(totalPills);
+								const packageSize = getPackageSize(med);
+								const currentStock = medCoverage ? formatNumber(medCoverage.medsLeft) : formatNumber(getMedTotal(med));
 								return (
 									<div 
 										key={med.id} 
@@ -3841,7 +3841,7 @@ function AppContent() {
 											{med.genericName && <span className="user-med-generic">{med.genericName}</span>}
 										</div>
 										<div className="user-med-stats">
-											<span className="user-med-pills">{currentStock}/{formatNumber(totalPills)} {t('common.pills')}</span>
+											<span className="user-med-pills">{currentStock}/{formatNumber(packageSize)} {t('common.pills')}</span>
 											{status && <span className={`status-chip ${status.className}`}>{t(status.label)}</span>}
 										</div>
 									</div>


### PR DESCRIPTION
## Problem
The user medications modal (clicking on a 'taken by' badge like 'Daniel') was showing the adjusted stock as total (e.g. 152/152 pills) instead of the package size (e.g. 152/196 pills).

## Solution
Changed from `getMedTotal()` to `getPackageSize()` for the denominator, consistent with other places in the app.