### PR TITLE
chore: unify data folder for dev and prod

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@
 
 - **English is the primary language**: All code, comments, documentation, commit messages, PR descriptions, and GitHub releases MUST be written in English. The user may communicate in German, but all project artifacts must be in English.
 - **NEVER release without explicit permission**: Do NOT create tags, releases, or version bumps unless the user explicitly asks for it. Always wait for explicit confirmation before any release action.
+- **NEVER create PRs without explicit permission**: Do NOT create Pull Requests, push branches, or merge code unless the user explicitly asks for it. Always present changes and wait for the user to confirm before any git operations that affect the remote repository.
 - **No temporary files**: Delete temporary scripts/files immediately after use. Do not commit temporary debug scripts, test files, or one-off utilities to the repository.
 - **Clean workspace**: Always clean up after yourself. If you create a file for a specific task, delete it once done.
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ coverage/
 *.db-journal
 *.db-wal
 *.db-shm
-backend/data/
 data/
 
 # ===================

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./backend:/app
       - backend_node_modules:/app/node_modules
-      - ./backend/data:/app/data
+      - ./data:/app/data
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## Changes

- **Unified data folder**: Both dev and prod now use `./data` instead of separate folders
- **Removed `backend/data/`**: No longer needed, deleted
- **Updated AI instructions**: Added rule to never create PRs without explicit permission

This simplifies the project structure by eliminating the redundant `backend/data/` folder.