### PR TITLE
chore: rename MedAssist to MedAssist-ng in all frontend UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,7 +44,7 @@ function AppRouter() {
 		return (
 			<div className="auth-container">
 				<div className="auth-card" style={{ textAlign: "center" }}>
-					<h1 className="auth-title">💊 MedAssist</h1>
+					<h1 className="auth-title">💊 MedAssist-ng</h1>
 					<p>Loading...</p>
 				</div>
 			</div>
@@ -56,7 +56,7 @@ function AppRouter() {
 		return (
 			<div className="auth-container">
 				<div className="auth-card" style={{ textAlign: "center" }}>
-					<h1 className="auth-title">💊 MedAssist</h1>
+					<h1 className="auth-title">💊 MedAssist-ng</h1>
 					<div className="auth-error" style={{ marginBottom: "1rem" }}>
 						<strong>Connection Error</strong>
 						<br />
@@ -78,7 +78,7 @@ function AppRouter() {
 		return (
 			<div className="auth-container">
 				<div className="auth-card" style={{ textAlign: "center" }}>
-					<h1 className="auth-title">💊 MedAssist</h1>
+					<h1 className="auth-title">💊 MedAssist-ng</h1>
 					<p>Initializing...</p>
 				</div>
 			</div>

--- a/frontend/src/components/AboutModal.tsx
+++ b/frontend/src/components/AboutModal.tsx
@@ -80,7 +80,7 @@ export default function AboutModal({ isOpen, onClose }: AboutModalProps) {
 							<path d="M9 2h6M12 2v2" />
 						</svg>
 					</div>
-					<h2>{t("about.appName", "MedAssist")}</h2>
+					<h2>{t("about.appName", "MedAssist-ng")}</h2>
 					<p className="about-tagline">{t("about.description", "Personal medication tracking and reminder app")}</p>
 				</div>
 				<div className="about-versions">

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -339,7 +339,7 @@ export function LoginForm({
 	return (
 		<div className="auth-container">
 			<div className="auth-card">
-				<h1 className="auth-title">💊 MedAssist</h1>
+				<h1 className="auth-title">💊 MedAssist-ng</h1>
 				<h2 className="auth-subtitle">{t("auth.login", "Login")}</h2>
 
 				{/* SSO Login Button */}
@@ -455,7 +455,7 @@ export function RegisterForm({ onSuccess, onSwitchToLogin }: { onSuccess?: () =>
 	return (
 		<div className="auth-container">
 			<div className="auth-card">
-				<h1 className="auth-title">💊 MedAssist</h1>
+				<h1 className="auth-title">💊 MedAssist-ng</h1>
 				<h2 className="auth-subtitle">{t("auth.register", "Create Account")}</h2>
 
 				{/* SSO Login Button - also show on registration */}

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -455,7 +455,7 @@ export function SharedSchedule() {
 		return (
 			<div className="shared-schedule-page">
 				<div className="shared-schedule-loading">
-					<h1>💊 MedAssist</h1>
+					<h1>💊 MedAssist-ng</h1>
 					<p>{t("common.loading")}</p>
 				</div>
 			</div>
@@ -466,7 +466,7 @@ export function SharedSchedule() {
 		return (
 			<div className="shared-schedule-page">
 				<div className="shared-schedule-error expired">
-					<h1>💊 MedAssist</h1>
+					<h1>💊 MedAssist-ng</h1>
 					<div className="expired-icon">⏰</div>
 					<h2>{t("share.expired.title")}</h2>
 					<p className="expired-message">{t("share.expired.message", { takenBy: expiredData.takenBy })}</p>
@@ -485,7 +485,7 @@ export function SharedSchedule() {
 		return (
 			<div className="shared-schedule-page">
 				<div className="shared-schedule-error">
-					<h1>💊 MedAssist</h1>
+					<h1>💊 MedAssist-ng</h1>
 					<p className="error-message">{error || "Unknown error"}</p>
 				</div>
 			</div>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -410,7 +410,7 @@
     "importSuccess": "Daten erfolgreich importiert",
     "importSuccessDetails": "Importiert: {{medications}} Medikamente, {{doses}} Dosen, {{shares}} Teilen-Links",
     "importError": "Daten konnten nicht importiert werden",
-    "invalidFile": "Ungültiges Dateiformat. Bitte wähle eine gültige MedAssist-Exportdatei.",
+    "invalidFile": "Ungültiges Dateiformat. Bitte wähle eine gültige MedAssist-ng-Exportdatei.",
     "downloadFilename": "medassist-export"
   },
   "refill": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -412,7 +412,7 @@
     "importSuccess": "Data imported successfully",
     "importSuccessDetails": "Imported: {{medications}} medications, {{doses}} doses, {{shares}} share links",
     "importError": "Failed to import data",
-    "invalidFile": "Invalid file format. Please select a valid MedAssist export file.",
+    "invalidFile": "Invalid file format. Please select a valid MedAssist-ng export file.",
     "downloadFilename": "medassist-export"
   },
   "refill": {

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -1369,7 +1369,7 @@ describe("SharedSchedule footer and branding", () => {
 
 		const link = footer?.querySelector('a[href="/"]');
 		expect(link).toBeInTheDocument();
-		expect(link?.textContent).toBe("MedAssist");
+		expect(link?.textContent).toBe("MedAssist-ng");
 	});
 
 	it("displays sharedBy username in footer", async () => {


### PR DESCRIPTION
Update all visible text from 'MedAssist' to 'MedAssist-ng':
- Auth page titles (login, register)
- Loading/error/initializing states
- SharedSchedule page (loading, expired, error, footer)
- AboutModal fallback text
- i18n strings for export file validation (EN/DE)
- Related test expectations