### PR TITLE
ci: add automatic version bump on GitHub release

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,57 @@
+name: Version Bump on Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version from tag
+        id: version
+        run: |
+          # Extract version from tag (e.g., v1.6.0 -> 1.6.0)
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Update package.json versions
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          
+          # Update backend/package.json
+          jq --arg v "$VERSION" '.version = $v' backend/package.json > backend/package.json.tmp
+          mv backend/package.json.tmp backend/package.json
+          
+          # Update frontend/package.json
+          jq --arg v "$VERSION" '.version = $v' frontend/package.json > frontend/package.json.tmp
+          mv frontend/package.json.tmp frontend/package.json
+          
+          echo "Updated versions to $VERSION"
+          cat backend/package.json | head -5
+          cat frontend/package.json | head -5
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git add backend/package.json frontend/package.json
+          
+          # Only commit if there are changes
+          if git diff --staged --quiet; then
+            echo "No version changes needed"
+          else
+            git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
+            git push origin main
+          fi


### PR DESCRIPTION
Creates a workflow that triggers when a release is published and automatically updates package.json versions in backend/ and frontend/ to match the release tag version.

This ensures the About modal always shows the correct version without manual intervention.