### PR TITLE
fix: add frontend tests to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
 echo "Running backend tests before push..."
-cd backend && CI=true npm test
+cd "$ROOT_DIR/backend" && CI=true npm test
 
 if [ $? -ne 0 ]; then
   echo "❌ Backend tests failed. Push aborted."
@@ -10,3 +14,18 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "✅ Backend tests passed!"
+
+echo ""
+echo "Running frontend tests before push..."
+cd "$ROOT_DIR/frontend" && CI=true npm test
+
+if [ $? -ne 0 ]; then
+  echo "❌ Frontend tests failed. Push aborted."
+  echo "Use 'git push --no-verify' to skip tests if needed."
+  exit 1
+fi
+
+echo "✅ Frontend tests passed!"
+
+echo ""
+echo "✅ All tests passed! Pushing..."


### PR DESCRIPTION
The pre-push hook was only running backend tests. This adds frontend tests as well to catch issues before pushing.

Changes:
- Added frontend test execution to pre-push hook
- Used absolute paths to handle any working directory
- Added clear success/failure messages for both test suites

Previously only backend tests were run, now both test suites must pass before pushing.