### PR TITLE
fix: use date-only timestamp for stable dose IDs

### DIFF
--- a/frontend/src/utils/schedule.ts
+++ b/frontend/src/utils/schedule.ts
@@ -29,8 +29,11 @@ export function buildSchedulePreview(
 				const isPast = d < todayStart;
 				if (isPast && !includePast) continue;
 				const whenMs = d.getTime();
+				// Use date-only timestamp for stable ID (immune to time changes)
+				// This ensures changing intake times doesn't invalidate past dose tracking
+				const dateOnlyMs = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
 				events.push({
-					id: `${med.id}-${idx}-${whenMs}`,
+					id: `${med.id}-${idx}-${dateOnlyMs}`,
 					medName: med.name,
 					takenBy: med.takenBy || [],
 					usage: blister.usage,


### PR DESCRIPTION
## Problem

Dose IDs were generated using full timestamps including time, which made them unstable when users changed intake times.

## Solution

Use date-only timestamp for dose ID generation. This ensures:
- Changing intake times doesn't invalidate past dose tracking
- IDs are immune to time configuration changes

## Changes

- [schedule.ts](frontend/src/utils/schedule.ts): Use `dateOnlyMs` instead of `whenMs` for ID generation