### PR TITLE
fix: add CI=true to test badge workflow

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Run backend tests and capture count
         id: backend-tests
         working-directory: backend
+        env:
+          CI: true
         run: |
           OUTPUT=$(npm run test:run 2>&1) || true
           echo "$OUTPUT"
@@ -51,6 +53,8 @@ jobs:
       - name: Run frontend tests and capture count
         id: frontend-tests
         working-directory: frontend
+        env:
+          CI: true
         run: |
           OUTPUT=$(npm run test -- --run 2>&1) || true
           echo "$OUTPUT"


### PR DESCRIPTION
Frontend tests were running in watch mode without CI=true env var, causing the workflow to hang for 30+ minutes.