### PR TITLE
fix: use test:run script and add timeouts to badge workflow

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Run backend tests and capture count
         id: backend-tests
         working-directory: backend
+        timeout-minutes: 5
         env:
           CI: true
         run: |
@@ -53,10 +54,11 @@ jobs:
       - name: Run frontend tests and capture count
         id: frontend-tests
         working-directory: frontend
+        timeout-minutes: 10
         env:
           CI: true
         run: |
-          OUTPUT=$(npm run test -- --run 2>&1) || true
+          OUTPUT=$(npm run test:run 2>&1) || true
           echo "$OUTPUT"
           # Extract "Tests  X passed" from output
           PASSED=$(echo "$OUTPUT" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "format": "npx biome format --write .",
     "check": "npx biome check . && tsc --noEmit",
     "test": "vitest",
+    "test:run": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
- Add test:run script to frontend package.json (consistent with backend)
- Use npm run test:run instead of npm run test -- --run
- Add timeout-minutes to prevent infinite hangs (5min backend, 10min frontend)