### PR TITLE
Hotfix v1.7.1: Fix crash when takenBy is not an array

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -480,7 +480,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 						return [];
 					}
 
-					return (dose.takenBy || []).length > 0 ? dose.takenBy.map((p: string) => `${dose.id}-${p}`) : [dose.id];
+					const takenByArray = Array.isArray(dose.takenBy) ? dose.takenBy : [];
+					return takenByArray.length > 0 ? takenByArray.map((p: string) => `${dose.id}-${p}`) : [dose.id];
 				});
 			})
 		);

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -126,9 +126,10 @@ export function SchedulePage() {
 					{showPastDays &&
 						pastDays.map((day) => {
 							const allDoseIds = day.meds.flatMap((item) =>
-								item.doses.flatMap((d) =>
-									(d.takenBy || []).length > 0 ? d.takenBy.map((p) => `${d.id}-${p}`) : [d.id]
-								)
+								item.doses.flatMap((d) => {
+									const takenByArray = Array.isArray(d.takenBy) ? d.takenBy : [];
+									return takenByArray.length > 0 ? takenByArray.map((p) => `${d.id}-${p}`) : [d.id];
+								})
 							);
 							const allDayTaken = allDoseIds.length > 0 && allDoseIds.every((id) => takenDoses.has(id));
 							const takenCount = allDoseIds.filter((id) => takenDoses.has(id)).length;
@@ -171,9 +172,10 @@ export function SchedulePage() {
 											const med = meds.find((m) => m.name === item.medName);
 											const medCov = coverageByMed[item.medName];
 											const isEmpty = medCov ? medCov.medsLeft <= 0 : false;
-											const itemDoseIds = item.doses.flatMap((d) =>
-												(d.takenBy || []).length > 0 ? d.takenBy.map((p) => `${d.id}-${p}`) : [d.id]
-											);
+											const itemDoseIds = item.doses.flatMap((d) => {
+												const takenByArray = Array.isArray(d.takenBy) ? d.takenBy : [];
+												return takenByArray.length > 0 ? takenByArray.map((p) => `${d.id}-${p}`) : [d.id];
+											});
 											const allTaken = itemDoseIds.every((id) => takenDoses.has(id));
 											return (
 												<div key={`${day.dateStr}-${item.medName}`} className={`time-row ${allTaken ? "taken" : ""}`}>
@@ -275,9 +277,10 @@ export function SchedulePage() {
 										: medCoverage
 											? getStockStatus(medCoverage.daysLeft, medCoverage.medsLeft, settings)
 											: null;
-									const itemDoseIds = item.doses.flatMap((d) =>
-										(d.takenBy || []).length > 0 ? d.takenBy.map((p) => `${d.id}-${p}`) : [d.id]
-									);
+									const itemDoseIds = item.doses.flatMap((d) => {
+										const takenByArray = Array.isArray(d.takenBy) ? d.takenBy : [];
+										return takenByArray.length > 0 ? takenByArray.map((p) => `${d.id}-${p}`) : [d.id];
+									});
 									const allTaken = itemDoseIds.every((id) => takenDoses.has(id));
 									return (
 										<div key={`${day.dateStr}-${item.medName}`} className={`time-row ${allTaken ? "taken" : ""}`}>


### PR DESCRIPTION
## Hotfix: Crash Prevention

This hotfix resolves a critical bug where the app crashes with `TypeError: dose.takenBy.map is not a function` when `dose.takenBy` is not an array.

### Changes
- Added `Array.isArray()` checks before calling `.map()` on `dose.takenBy`
- Fixed in **AppContext.tsx**: `missedPastDoseIds` calculation
- Fixed in **SchedulePage.tsx**: dose ID generation (3 locations)

### Issue
The app crashed when `takenBy` was `null`, `undefined`, or any non-array value. The code assumed it was always an array after the `|| []` fallback, but still called `takenBy.map()` directly instead of using the fallback result.

### Fix
```typescript
const takenByArray = Array.isArray(dose.takenBy) ? dose.takenBy : [];
return takenByArray.length > 0 ? takenByArray.map((p) => `${dose.id}-${p}`) : [dose.id];
```

### Testing
- ✅ App loads without crashes
- ✅ Schedule page renders correctly
- ✅ Dose tracking works with and without `takenBy` values