### PR TITLE
fix: Strip ANSI escape codes in test badge workflow

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -47,8 +47,9 @@ jobs:
         run: |
           OUTPUT=$(npm run test:run 2>&1) || true
           echo "$OUTPUT"
-          # Extract "Tests  X passed" from output
-          PASSED=$(echo "$OUTPUT" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
+          # Strip ANSI escape codes, then extract "Tests  X passed" from output
+          CLEAN=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+          PASSED=$(echo "$CLEAN" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
           echo "count=$PASSED" >> $GITHUB_OUTPUT
 
       - name: Run frontend tests and capture count
@@ -60,8 +61,9 @@ jobs:
         run: |
           OUTPUT=$(npm run test:run 2>&1) || true
           echo "$OUTPUT"
-          # Extract "Tests  X passed" from output
-          PASSED=$(echo "$OUTPUT" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
+          # Strip ANSI escape codes, then extract "Tests  X passed" from output
+          CLEAN=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+          PASSED=$(echo "$CLEAN" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
           echo "count=$PASSED" >> $GITHUB_OUTPUT
 
       - name: Update README badges


### PR DESCRIPTION
## Problem

The test badge workflow failed to extract test counts from Vitest 4 output because of ANSI color escape codes embedded in the results. The grep regex expects only whitespace between 'Tests' and the number, but Vitest 4 inserts color codes there.

This caused the workflow to silently skip the README badge update, leaving stale test counts (454/611 instead of 461/627).

## Fix

Add a sed pass to strip ANSI escape sequences from the captured output before grepping for the test count pattern.

## Verified

Tested locally — correctly extracts 461 (backend) and 627 (frontend).