### PR TITLE
fix: Add workflow_dispatch trigger to test badge workflow

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -1,6 +1,7 @@
 name: Update Test Badges
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger so the badge update can be run manually from the Actions tab. Useful after workflow-only changes (like the ANSI fix in #101) where no source code paths match.