### PR TITLE
fix: add pull-requests write permission to badge workflow

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-badges:


### PR DESCRIPTION
peter-evans/create-pull-request requires pull-requests: write permission to create PRs via GITHUB_TOKEN.