### PR TITLE
fix: stock correction no longer neutralized by phantom consumption

### DIFF
--- a/backend/src/test/e2e-routes.test.ts
+++ b/backend/src/test/e2e-routes.test.ts
@@ -1731,6 +1731,161 @@ describe("E2E Tests with Real Routes", () => {
 	});
 
 	// ---------------------------------------------------------------------------
+	// Real Stock Correction (PATCH /medications/:id/stock-adjustment) Tests
+	// ---------------------------------------------------------------------------
+
+	describe("Real /medications/:id/stock-adjustment routes", () => {
+		it("should update stockAdjustment and lastStockCorrectionAt", async () => {
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: {
+					name: "Stock Correction Med",
+					packCount: 1,
+					blistersPerPack: 14,
+					pillsPerBlister: 14,
+					blisters: [{ usage: 1, every: 1, start: "2025-01-01T08:00:00.000Z" }],
+				},
+			});
+			expect(createResponse.statusCode).toBe(200);
+			const medId = createResponse.json().id;
+
+			// Correct stock: set adjustment to -83 (196 base - 83 = 113 pills)
+			const response = await app.inject({
+				method: "PATCH",
+				url: `/medications/${medId}/stock-adjustment`,
+				payload: { stockAdjustment: -83 },
+			});
+
+			expect(response.statusCode).toBe(200);
+			const data = response.json();
+			expect(data.stockAdjustment).toBe(-83);
+			expect(data.lastStockCorrectionAt).toBeTruthy();
+			expect(data.updatedAt).toBeTruthy();
+		});
+
+		it("should persist stockAdjustment in GET /medications", async () => {
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: {
+					name: "Persist Stock Med",
+					packCount: 1,
+					blistersPerPack: 1,
+					pillsPerBlister: 30,
+					blisters: [{ usage: 1, every: 1, start: "2025-01-01T08:00:00.000Z" }],
+				},
+			});
+			const medId = createResponse.json().id;
+
+			// Apply stock correction
+			await app.inject({
+				method: "PATCH",
+				url: `/medications/${medId}/stock-adjustment`,
+				payload: { stockAdjustment: -7 },
+			});
+
+			// Verify via GET
+			const getResponse = await app.inject({
+				method: "GET",
+				url: "/medications",
+			});
+
+			expect(getResponse.statusCode).toBe(200);
+			const meds = getResponse.json();
+			const med = meds.find((m: any) => m.id === medId);
+			expect(med).toBeDefined();
+			expect(med.stockAdjustment).toBe(-7);
+			expect(med.lastStockCorrectionAt).toBeTruthy();
+		});
+
+		it("should not reset stockAdjustment when editing medication via PUT", async () => {
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: {
+					name: "Keep Adjustment Med",
+					packCount: 1,
+					blistersPerPack: 1,
+					pillsPerBlister: 30,
+					blisters: [{ usage: 1, every: 1, start: "2025-01-01T08:00:00.000Z" }],
+				},
+			});
+			const medId = createResponse.json().id;
+
+			// Set stock adjustment
+			await app.inject({
+				method: "PATCH",
+				url: `/medications/${medId}/stock-adjustment`,
+				payload: { stockAdjustment: -5 },
+			});
+
+			// Edit the medication (change name) - should preserve stockAdjustment
+			await app.inject({
+				method: "PUT",
+				url: `/medications/${medId}`,
+				payload: {
+					name: "Renamed Med",
+					packCount: 1,
+					blistersPerPack: 1,
+					pillsPerBlister: 30,
+					looseTablets: 0,
+					blisters: [{ usage: 1, every: 1, start: "2025-01-01T08:00:00.000Z" }],
+				},
+			});
+
+			// Verify stockAdjustment is preserved
+			const getResponse = await app.inject({
+				method: "GET",
+				url: "/medications",
+			});
+			const med = getResponse.json().find((m: any) => m.id === medId);
+			expect(med.name).toBe("Renamed Med");
+			expect(med.stockAdjustment).toBe(-5);
+		});
+
+		it("should return 400 for non-numeric stockAdjustment", async () => {
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: {
+					name: "Bad Adjustment Med",
+					blisters: [{ usage: 1, every: 1, start: "2025-01-01T08:00:00.000Z" }],
+				},
+			});
+			const medId = createResponse.json().id;
+
+			const response = await app.inject({
+				method: "PATCH",
+				url: `/medications/${medId}/stock-adjustment`,
+				payload: { stockAdjustment: "not-a-number" },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it("should return 404 for non-existent medication", async () => {
+			const response = await app.inject({
+				method: "PATCH",
+				url: "/medications/99999/stock-adjustment",
+				payload: { stockAdjustment: 5 },
+			});
+
+			expect(response.statusCode).toBe(404);
+		});
+
+		it("should return 400 for invalid medication id", async () => {
+			const response = await app.inject({
+				method: "PATCH",
+				url: "/medications/invalid/stock-adjustment",
+				payload: { stockAdjustment: 5 },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
 	// Real Export/Import Routes Tests
 	// ---------------------------------------------------------------------------
 

--- a/frontend/src/test/utils/schedule.test.ts
+++ b/frontend/src/test/utils/schedule.test.ts
@@ -366,6 +366,123 @@ describe("calculateCoverage", () => {
 		expect(result.all).toHaveLength(1);
 		// Daily rate should be doubled for 2 people
 	});
+
+	it("stock correction immediately reflects new stock without phantom consumption", () => {
+		// BUG: After a stock correction of +1 pill, the coverage calculation
+		// immediately consumed 1 dose (due to the +1 in occurrences formula),
+		// making the correction appear to have no effect.
+		//
+		// Scenario: User has 112 pills, corrects to 113 (+1 pill).
+		// Expected: medsLeft = 113 immediately after correction.
+		// Bug: medsLeft stayed at 112 because 1 dose was counted as consumed.
+		const correctionTime = new Date("2024-03-15T12:00:00Z");
+
+		const meds: Medication[] = [
+			{
+				id: 1,
+				name: "TestMed",
+				packCount: 1,
+				blistersPerPack: 14,
+				pillsPerBlister: 14,
+				looseTablets: 0,
+				stockAdjustment: -83, // 196 - 83 = 113 pills
+				lastStockCorrectionAt: correctionTime.toISOString(),
+				takenBy: [],
+				blisters: [
+					{
+						usage: 1,
+						every: 1,
+						start: "2024-01-01T08:00:00",
+					},
+				],
+				updatedAt: correctionTime.toISOString(),
+			},
+		];
+
+		// Calculate coverage immediately after correction (same second)
+		const result = calculateCoverage(meds, [], "en", 7, "automatic", new Set());
+
+		expect(result.all).toHaveLength(1);
+		// getMedTotal = 1*14*14 + 0 + (-83) = 113
+		// Consumed since correction should be 0 (not 1!)
+		expect(result.all[0].medsLeft).toBe(113);
+	});
+
+	it("stock correction with dose tracking data also reflects correctly", () => {
+		// When the user has dose tracking data, the actualConsumed path is used.
+		// Verify that no phantom dose is generated right after a stock correction.
+		const correctionTime = new Date("2024-03-15T12:00:00Z");
+		const march14 = new Date("2024-03-14T00:00:00").getTime();
+
+		const meds: Medication[] = [
+			{
+				id: 1,
+				name: "TestMed",
+				packCount: 1,
+				blistersPerPack: 1,
+				pillsPerBlister: 30,
+				looseTablets: 0,
+				stockAdjustment: -7, // 30 - 7 = 23 pills
+				lastStockCorrectionAt: correctionTime.toISOString(),
+				takenBy: [],
+				blisters: [
+					{
+						usage: 1,
+						every: 1,
+						start: "2024-03-01T08:00:00",
+					},
+				],
+				updatedAt: correctionTime.toISOString(),
+			},
+		];
+
+		// User has tracked a dose yesterday (before the correction)
+		const takenDoses = new Set([`1-0-${march14}`]);
+
+		const result = calculateCoverage(meds, [], "en", 7, "automatic", takenDoses);
+
+		expect(result.all).toHaveLength(1);
+		// getMedTotal = 30 - 7 = 23.
+		// The taken dose from yesterday should NOT be counted (it's before the correction).
+		// No new doses should exist since the correction just happened.
+		expect(result.all[0].medsLeft).toBe(23);
+	});
+
+	it("stock correction consumption resumes after one full period", () => {
+		// After 1 day (for daily medication), the next dose should be consumed.
+		// Set system time to 1 day + 1 hour after correction.
+		const correctionTime = new Date("2024-03-14T12:00:00Z");
+		vi.setSystemTime(new Date("2024-03-15T13:00:00Z")); // 25 hours after correction
+
+		const meds: Medication[] = [
+			{
+				id: 1,
+				name: "TestMed",
+				packCount: 1,
+				blistersPerPack: 1,
+				pillsPerBlister: 30,
+				looseTablets: 0,
+				stockAdjustment: -7, // 30 - 7 = 23 pills
+				lastStockCorrectionAt: correctionTime.toISOString(),
+				takenBy: [],
+				blisters: [
+					{
+						usage: 1,
+						every: 1,
+						start: "2024-03-01T08:00:00",
+					},
+				],
+				updatedAt: correctionTime.toISOString(),
+			},
+		];
+
+		const result = calculateCoverage(meds, [], "en", 7, "automatic", new Set());
+
+		expect(result.all).toHaveLength(1);
+		// After 1 full period since correction, 1 dose should be consumed.
+		// medsLeft = 23 - 1 = 22
+		expect(result.all[0].medsLeft).toBe(22);
+	});
 });
 
 describe("getStockStatus", () => {

--- a/frontend/src/utils/schedule.ts
+++ b/frontend/src/utils/schedule.ts
@@ -126,9 +126,18 @@ export function calculateCoverage(
 			// but also account for manual corrections (doses marked as not taken)
 			blisters.forEach((s, blisterIdx) => {
 				const blisterStart = new Date(s.start).getTime();
-				const effectiveStart = Math.max(blisterStart, stockCorrectionCutoff);
-				if (Number.isNaN(effectiveStart) || effectiveStart > now) return;
 				const period = Math.max(1, s.every) * MS_PER_DAY;
+
+				// After a stock correction, start counting consumption from the NEXT
+				// scheduled dose, because the user's pill count already reflects all
+				// consumption up to the correction time.
+				let effectiveStart: number;
+				if (stockCorrectionCutoff > 0 && stockCorrectionCutoff >= blisterStart) {
+					effectiveStart = stockCorrectionCutoff + period;
+				} else {
+					effectiveStart = blisterStart;
+				}
+				if (Number.isNaN(effectiveStart) || effectiveStart > now) return;
 				const occurrences = Math.floor((now - effectiveStart) / period) + 1;
 				const intake = intakes[blisterIdx];
 				const intakePerson = intake?.takenBy;


### PR DESCRIPTION
## Problem

When correcting medication stock via the "Correct Stock" modal (e.g., +1 pill), the displayed stock did not change. The correction was immediately neutralized.

## Root Cause

In `calculateCoverage()` (`frontend/src/utils/schedule.ts`), the formula `occurrences = Math.floor((now - effectiveStart) / period) + 1` counted 1 dose as consumed immediately when `effectiveStart` was set to the stock correction time. This phantom consumption neutralized small corrections like +1.

## Fix

After a stock correction, consumption counting now starts from `stockCorrectionCutoff + period` (the **next** scheduled dose) instead of from the correction time itself. This ensures the corrected stock is accurately displayed until the next dose is actually due.

## Tests

- 3 new frontend tests for stock correction scenarios
- 6 new backend e2e tests for the PATCH `/medications/:id/stock-adjustment` endpoint
- All 485 backend + 639 frontend tests passing