### PR TITLE
ci: add path filtering to skip unnecessary CI runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,30 @@ name: "CodeQL"
 on:
   push:
     branches: [main]
+    paths:
+      - '**.js'
+      - '**.ts'
+      - '**.tsx'
+      - '**.jsx'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - '.github/codeql/**'
+      - '.github/workflows/codeql.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**.js'
+      - '**.ts'
+      - '**.tsx'
+      - '**.jsx'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - '.github/codeql/**'
+      - '.github/workflows/codeql.yml'
   schedule:
     - cron: "0 6 * * 1" # Weekly on Monday at 6am UTC
   workflow_dispatch: # Allow manual trigger

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,38 @@ permissions:
 
 jobs:
   # =============================================================================
-  # Backend Tests
+  # Detect which paths changed to skip unnecessary jobs
+  # =============================================================================
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'biome.json'
+              - '.github/workflows/test.yml'
+            frontend:
+              - 'frontend/**'
+              - 'biome.json'
+              - '.github/workflows/test.yml'
+
+  # =============================================================================
+  # Backend Tests (skipped if no backend-related files changed)
   # =============================================================================
   backend-test:
     name: Backend Tests
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,10 +81,12 @@ jobs:
           retention-days: 7
 
   # =============================================================================
-  # Frontend Build Validation
+  # Frontend Build Validation (skipped if no frontend-related files changed)
   # =============================================================================
   frontend-build:
     name: Frontend Build
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

CI workflows (tests, CodeQL) ran on **every** PR regardless of what changed. A docs-only change (e.g., editing `.github/agents/`) triggered full backend tests + frontend build unnecessarily.

## Solution

### test.yml
- Added `dorny/paths-filter@v3` to detect which paths changed
- **Backend Tests** only run when `backend/**`, `biome.json`, or the workflow itself changes
- **Frontend Build** only run when `frontend/**`, `biome.json`, or the workflow itself changes
- Uses job-level `if:` conditions — GitHub treats skipped conditional jobs as **passed** for required checks, so docs-only PRs can still merge

### codeql.yml
- Added `paths:` filter to `push` and `pull_request` triggers
- Only runs when JS/TS source files, package files, or CodeQL config changes
- Weekly schedule and manual dispatch remain unfiltered

### What's NOT changed
- `docker-build.yml` — already had path filtering
- `update-test-badges.yml` — already had path filtering

## Effect

| Change Type | Before | After |
|---|---|---|
| Docs only (`.md`, `.github/agents/`) | Backend Tests + Frontend Build + CodeQL | Nothing |
| Backend code | Backend Tests + Frontend Build + CodeQL | Backend Tests only |
| Frontend code | Backend Tests + Frontend Build + CodeQL | Frontend Build only |
| Both backend + frontend | Backend Tests + Frontend Build + CodeQL | Backend Tests + Frontend Build |