### PR TITLE
fix: use dynamic BACKEND_URL for nginx reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
   frontend:
     image: ghcr.io/danielvolz/medassist-ng-frontend:latest
     container_name: medassist-ng-frontend
+    environment:
+      - BACKEND_URL=backend:3000
     ports:
       - "4174:8080"
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,8 +32,9 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
 
-# Copy custom nginx config (must listen on 8080, not 80)
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy custom nginx config as template for envsubst processing
+# nginx-unprivileged automatically substitutes env vars in .template files
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 # Copy built static files with correct ownership (nginx user = uid 101)
 COPY --from=builder --chown=101:101 /app/dist /usr/share/nginx/html
@@ -44,5 +45,5 @@ EXPOSE 8080
 # Already runs as non-root (nginx user, uid 101)
 USER nginx
 
-# Start nginx
+# Start nginx (entrypoint processes templates automatically)
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,7 +20,14 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://medassist-ng-backend:3000/;
+        # Use variable for runtime DNS resolution (nginx resolves at startup by default)
+        # Docker embedded DNS (127.0.0.11) with 10s cache
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $backend_upstream ${BACKEND_URL};
+
+        # Strip /api prefix (nginx doesn't auto-rewrite when using variables in proxy_pass)
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://$backend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Fixes #96
Supersedes #113

## Summary

The frontend nginx config now uses a dynamic `BACKEND_URL` environment variable instead of a hardcoded container name, preventing breakage when users customize container names in their `docker-compose.yml`.

## Changes

- **`frontend/nginx.conf`**: Converted to an nginx template using `${BACKEND_URL}` variable, Docker DNS resolver (`127.0.0.11`), and variable-based upstream for dynamic resolution
- **`frontend/Dockerfile`**: Copies nginx.conf as `/etc/nginx/templates/default.conf.template` so `nginx-unprivileged` processes it via `envsubst` at container start
- **`docker-compose.yml`**: Adds `BACKEND_URL=backend:3000` environment variable to the frontend service

## How It Works

`nginx-unprivileged` automatically processes `.template` files in `/etc/nginx/templates/` using `envsubst`, replacing `${BACKEND_URL}` with the actual value at container startup. Users who rename their backend service just need to set `BACKEND_URL=my-custom-name:3000` in the frontend environment.

## Why not hardcode?

The previous hardcoded `medassist-ng-backend:3000` breaks when users set custom `container_name` values or change the project name. This pattern (env var + template) is standard across apps like Immich, Paperless-ngx, etc.