### PR TITLE
fix: nginx read_only filesystem compatibility for envsubst

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - /tmp:noexec,nosuid,size=64m
       - /var/cache/nginx:noexec,nosuid,size=64m
       - /var/run:noexec,nosuid,size=64m
+      - /etc/nginx/conf.d:noexec,nosuid,size=1m
     cap_drop:
       - ALL
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,6 +32,11 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
 
+# Redirect envsubst output to /tmp (writable under read_only: true)
+# and update nginx main config to include from there instead of /etc/nginx/conf.d/
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/tmp
+RUN sed -i 's|include /etc/nginx/conf.d/\*.conf;|include /tmp/default.conf;|' /etc/nginx/nginx.conf
+
 # Copy custom nginx config as template for envsubst processing
 # nginx-unprivileged automatically substitutes env vars in .template files
 COPY nginx.conf /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
## Problem

Frontend container crashes in production with `read_only: true` because nginx's envsubst tries to write to `/etc/nginx/conf.d/default.conf` which is read-only.

## Solution

- Set `NGINX_ENVSUBST_OUTPUT_DIR=/tmp` in Dockerfile so envsubst writes to `/tmp/default.conf`
- Use `sed` at build time to update nginx.conf include path from `/etc/nginx/conf.d/*.conf` to `/tmp/default.conf`
- Add tmpfs mount for `/etc/nginx/conf.d` in docker-compose.yml

Tested with `docker run --read-only` and with renamed services (`BACKEND_URL` confirmed working).