### PR TITLE
fix: clean up nginx read-only filesystem approach

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - /tmp:noexec,nosuid,size=64m
       - /var/cache/nginx:noexec,nosuid,size=64m
       - /var/run:noexec,nosuid,size=64m
-      - /etc/nginx/conf.d:noexec,nosuid,size=1m
+      - /etc/nginx/conf.d:noexec,nosuid,size=1m,uid=101,gid=101
     cap_drop:
       - ALL
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,11 +32,6 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
 
-# Redirect envsubst output to /tmp (writable under read_only: true)
-# and update nginx main config to include from there instead of /etc/nginx/conf.d/
-ENV NGINX_ENVSUBST_OUTPUT_DIR=/tmp
-RUN sed -i 's|include /etc/nginx/conf.d/\*.conf;|include /tmp/default.conf;|' /etc/nginx/nginx.conf
-
 # Copy custom nginx config as template for envsubst processing
 # nginx-unprivileged automatically substitutes env vars in .template files
 COPY nginx.conf /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
Remove Dockerfile `/tmp` workaround hacks (`NGINX_ENVSUBST_OUTPUT_DIR` and `sed`). Instead, use `tmpfs` with `uid=101,gid=101` in `docker-compose.yml` so the nginx user (uid 101) can write to `/etc/nginx/conf.d` directly under `read_only: true`.

### Changes
- **`frontend/Dockerfile`**: Removed `ENV NGINX_ENVSUBST_OUTPUT_DIR=/tmp` and `RUN sed` lines
- **`docker-compose.yml`**: Added `uid=101,gid=101` to the `/etc/nginx/conf.d` tmpfs mount