### PR TITLE
fix: use PAT for badge workflow to bypass branch protection

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BADGE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The badge update workflow was failing because `GITHUB_TOKEN` cannot push to `main` due to branch protection rules.

### Changes
- Use `BADGE_TOKEN` (Fine-Grained PAT) for checkout, falling back to `GITHUB_TOKEN` if not set
- Added `Maintain` role as bypass actor in the branch protection ruleset

This allows the badge workflow to push directly to `main` without requiring a PR.