### PR TITLE
fix: make frontend image self-contained for read-only filesystems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - /tmp:noexec,nosuid,size=64m
       - /var/cache/nginx:noexec,nosuid,size=64m
       - /var/run:noexec,nosuid,size=64m
-      - /etc/nginx/conf.d:noexec,nosuid,size=1m,uid=101,gid=101
+      - /etc/nginx/conf.d:noexec,nosuid,size=1m
     cap_drop:
       - ALL
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,6 +32,11 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
 
+# Redirect envsubst output to /tmp (writable under read_only: true)
+# and update nginx main config to include from there instead of /etc/nginx/conf.d/
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/tmp
+RUN sed -i 's|include /etc/nginx/conf.d/\*.conf;|include /tmp/default.conf;|' /etc/nginx/nginx.conf
+
 # Copy custom nginx config as template for envsubst processing
 # nginx-unprivileged automatically substitutes env vars in .template files
 COPY nginx.conf /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
v1.8.5 introduced a breaking change: the Dockerfile relied on `uid=101,gid=101` in the docker-compose.yml tmpfs mount. Users who only pulled the new image without updating their compose file got a crash loop.

This reverts the Dockerfile to the v1.8.4 approach (`NGINX_ENVSUBST_OUTPUT_DIR=/tmp` + `sed`), making the image self-contained. No compose changes needed for `read_only: true` to work.

### Changes
- **Dockerfile**: Restored `/tmp` redirect for envsubst output
- **docker-compose.yml**: Removed `uid=101,gid=101` from tmpfs (not needed anymore)