### PR TITLE
ci: remove redundant test jobs from docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,50 +25,12 @@ env:
 
 jobs:
   # =============================================================================
-  # Run Tests First
-  # =============================================================================
-  backend-test:
-    name: Backend Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci
-      - run: npx tsc --noEmit
-      - run: npm run test:run
-
-  frontend-build:
-    name: Frontend Build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
-      - run: npm run build
-
-  # =============================================================================
-  # Build and Push Docker Images (only after tests pass)
+  # Build and Push Docker Images
+  # Tests are NOT run here — branch protection on main requires all PR checks
+  # (backend-test + frontend-build from test.yml) to pass before merge.
+  # Tags are created from main, so code is already tested.
   # =============================================================================
   build-and-push:
-    needs: [backend-test, frontend-build]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Removes the redundant backend-test and frontend-build jobs from `docker-build.yml`.

### Problem

Tests were running **3x** for every code change:
1. `test.yml` on PR (required by branch protection)
2. `docker-build.yml` on push to main (redundant)
3. `update-test-badges.yml` on push to main (needed for badge counts)

### Solution

Remove test jobs from `docker-build.yml`. Branch protection already guarantees that all tests passed before code can be merged to main. Tags are created from main, so that code is also already tested.

### Result

- Tests reduced from **3x → 2x** per code change
- Docker image builds start **immediately** after merge (no waiting for tests)
- `update-test-badges.yml` still runs tests (needed to count test numbers for badges)