### PR TITLE
revert: undo "fix: update backend and frontend images to use main tag"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:main
+    image: ghcr.io/danielvolz/medassist-ng-backend:latest
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -33,7 +33,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:main
+    image: ghcr.io/danielvolz/medassist-ng-frontend:latest
     container_name: medassist-ng-frontend
     environment:
       - BACKEND_URL=backend:3000


### PR DESCRIPTION
Reverts commit cdf0088 which changed Docker image tags from `:latest` to `:main` in docker-compose.yml.