### PR TITLE
fix: prevent badge workflow push rejection on concurrent runs

### DIFF
--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: write
 
+# Prevent parallel badge workflows from racing each other
+concurrency:
+  group: update-test-badges
+  cancel-in-progress: true
+
 jobs:
   update-badges:
     name: Update Test Count Badges
@@ -99,5 +104,8 @@ jobs:
             echo "No badge changes to commit"
           else
             git commit -m "chore: update test count badges [skip ci]"
+            # Rebase on latest main to avoid push rejection when concurrent
+            # badge workflows or other [skip ci] commits land between checkout and push
+            git pull --rebase origin main
             git push
           fi


### PR DESCRIPTION
## Problem

The 'Update Test Badges' workflow failed with:

```
! [rejected] main -> main (fetch first)
error: failed to push some refs
```

This happens when two Docker builds (from two PRs merged close together) both trigger badge update workflows. The second one fails because main has moved since checkout.

## Fix

1. **`git pull --rebase`** before push — handles cases where main moved between checkout and push
2. **`concurrency` group** with `cancel-in-progress: true` — prevents duplicate badge workflows from running simultaneously