### PR TITLE
chore: add noNestedTernary biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,8 @@
 			"style": {
 				"noNonNullAssertion": "off",
 				"useConst": "error",
-				"noParameterAssign": "off"
+				"noParameterAssign": "off",
+				"noNestedTernary": "warn"
 			},
 			"correctness": {
 				"noUnusedVariables": "warn",


### PR DESCRIPTION
## Summary

Add `noNestedTernary: warn` to biome.json style rules to enforce readable conditional expressions.

## Changes

- **biome.json**: Add `noNestedTernary` rule at `warn` severity
- **AGENTS.md** (local-only): Added complementary "Clarity over brevity" global engineering guideline

## Rationale

From the code-simplifier evaluation: nested ternaries harm readability. This rule catches them at lint time. No existing violations were found in the codebase.

## Checklist

- [x] No existing code violations
- [x] Biome check passes
- [x] Rule severity matches project conventions (`warn`)