### PR TITLE
fix: highlight empty medications in planner email

### DIFF
--- a/backend/src/routes/planner.ts
+++ b/backend/src/routes/planner.ts
@@ -221,8 +221,10 @@ ${getFooterPlain(language)}`;
 							}
 						}
 
+						const rowBg = row.enough ? "" : " background: #fef2f2;";
+
 						return `
-        <tr>
+        <tr style="${rowBg}">
           <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; white-space: nowrap;">${safeName}</td>
           <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: center; white-space: nowrap;"><strong>${safePlannerUsage}</strong> ${tr.common.pills}</td>
           <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: center; white-space: nowrap;">${neededCell}</td>


### PR DESCRIPTION
Closes #204

## Changes
- Add light red background (`#fef2f2`) to planner email table rows where a medication is out of stock
- Consistent with the stock reminder email styling where empty/critical rows are visually highlighted