### PR TITLE
feat: respect LOG_LEVEL in frontend nginx container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ PGID=1000
 PORT=3000
 CORS_ORIGINS=http://localhost:4174
 LOG_LEVEL=info
+# Levels: debug, info, warn, error, silent
+# Controls: backend Fastify logging, frontend nginx access logs (Docker),
+#           and frontend browser console (via build-time injection)
 
 # Rate limit: max requests per minute per IP (default: 100)
 # Increase for development/testing environments

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
   frontend:
     image: ghcr.io/danielvolz/medassist-ng-frontend:latest
     container_name: medassist-ng-frontend
+    env_file:
+      - .env
     environment:
       - BACKEND_URL=backend:3000
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -41,6 +41,10 @@ RUN sed -i 's|include /etc/nginx/conf.d/\*.conf;|include /tmp/default.conf;|' /e
 # nginx-unprivileged automatically substitutes env vars in .template files
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 
+# Copy entrypoint wrapper (translates LOG_LEVEL → nginx access log control)
+COPY nginx-entrypoint.sh /nginx-entrypoint.sh
+RUN chmod +x /nginx-entrypoint.sh
+
 # Copy built static files with correct ownership (nginx user = uid 101)
 COPY --from=builder --chown=101:101 /app/dist /usr/share/nginx/html
 
@@ -50,5 +54,6 @@ EXPOSE 8080
 # Already runs as non-root (nginx user, uid 101)
 USER nginx
 
-# Start nginx (entrypoint processes templates automatically)
+# Use wrapper entrypoint that maps LOG_LEVEL to nginx config
+ENTRYPOINT ["/nginx-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx-entrypoint.sh
+++ b/frontend/nginx-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# =============================================================================
+# Frontend entrypoint wrapper
+# Translates LOG_LEVEL into nginx access log control before
+# delegating to the standard nginx-unprivileged entrypoint.
+#
+# LOG_LEVEL=debug|info  → access logs enabled  (default)
+# LOG_LEVEL=warn|error|fatal|silent → access logs suppressed
+# =============================================================================
+
+case "${LOG_LEVEL:-info}" in
+  warn|error|fatal|silent)
+    export NGINX_ACCESS_LOG="off"
+    ;;
+  *)
+    export NGINX_ACCESS_LOG="/dev/stdout"
+    ;;
+esac
+
+# Delegate to the original nginx-unprivileged entrypoint
+exec /docker-entrypoint.sh "$@"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,6 +6,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Access log control (suppressed when LOG_LEVEL is warn or higher)
+    access_log ${NGINX_ACCESS_LOG};
+
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
Closes #211

## What

The `LOG_LEVEL` env var now controls frontend nginx access logs in Docker. When set to `warn` or higher, nginx access logs are suppressed.

## How

- **`frontend/nginx-entrypoint.sh`** (new): Lightweight wrapper that translates `LOG_LEVEL` → `NGINX_ACCESS_LOG` before delegating to the standard nginx-unprivileged entrypoint.
- **`frontend/nginx.conf`**: Uses `${NGINX_ACCESS_LOG}` variable for the `access_log` directive.
- **`frontend/Dockerfile`**: Copies the entrypoint wrapper and sets it as `ENTRYPOINT`.
- **`docker-compose.yml`**: Frontend container receives `LOG_LEVEL` via `env_file: .env` — no new env vars.
- **`.env.example`**: Documents LOG_LEVEL scope (backend + frontend).

## Behavior

| LOG_LEVEL | nginx access logs |
|-----------|------------------|
| `debug`, `info` | Enabled (default) |
| `warn`, `error`, `silent` | Suppressed |