### PR TITLE
fix: nginx proxy buffering warnings and LOG_LEVEL propagation

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,8 @@ services:
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
+    env_file:
+      - .env
     environment:
       - BACKEND_URL=http://backend-dev:3000
     ports:

--- a/frontend/nginx-entrypoint.sh
+++ b/frontend/nginx-entrypoint.sh
@@ -8,12 +8,17 @@
 # LOG_LEVEL=warn|error|fatal|silent → access logs suppressed
 # =============================================================================
 
-case "${LOG_LEVEL:-info}" in
+# Normalize: lowercase + trim whitespace
+level=$(printf '%s' "${LOG_LEVEL:-info}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+case "$level" in
   warn|error|fatal|silent)
     export NGINX_ACCESS_LOG="off"
+    echo "[nginx-entrypoint] LOG_LEVEL=${LOG_LEVEL} → access_log off"
     ;;
   *)
     export NGINX_ACCESS_LOG="/dev/stdout"
+    echo "[nginx-entrypoint] LOG_LEVEL=${LOG_LEVEL:-info} → access_log /dev/stdout"
     ;;
 esac
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -43,5 +43,11 @@ server {
         # Timeout for uploads
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;
+
+        # Increase proxy buffers to avoid buffering images/responses to temp files
+        # Default is 8 x 4k/8k which is too small for medication images
+        proxy_buffer_size 16k;
+        proxy_buffers 8 256k;
+        proxy_busy_buffers_size 512k;
     }
 }


### PR DESCRIPTION
Closes #226

Fixes nginx proxy buffering warnings for medication images and improves LOG_LEVEL handling:
- Increased proxy buffer sizes in nginx.conf (16k header + 8x256k body + 512k busy) to prevent upstream responses being written to temp files
- Added `env_file: .env` to frontend service in `docker-compose.dev.yml` so LOG_LEVEL is passed through
- Normalized LOG_LEVEL in `nginx-entrypoint.sh` (case-insensitive, whitespace-trimmed)
- Added startup log line showing LOG_LEVEL → access_log mapping for easier debugging