### PR TITLE
fix: disable nginx temp file buffering for proxied responses

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -44,10 +44,8 @@ server {
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;
 
-        # Increase proxy buffers to avoid buffering images/responses to temp files
-        # Default is 8 x 4k/8k which is too small for medication images
-        proxy_buffer_size 16k;
-        proxy_buffers 8 256k;
-        proxy_busy_buffers_size 512k;
+        # Prevent buffering upstream responses to temp files (images can be large)
+        # nginx streams directly to client instead of buffering the full response
+        proxy_max_temp_file_size 0;
     }
 }


### PR DESCRIPTION
Follow-up to #229 — the increased proxy buffer sizes (8×256k) were still not enough for large medication images (phone photos). Instead of further increasing buffer sizes (more RAM), disable temp file buffering entirely with `proxy_max_temp_file_size 0`. nginx now streams responses directly to clients.

Eliminates the `an upstream response is buffered to a temporary file` warnings.