### PR TITLE
fix: trim whitespace from username on login and registration

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -53,6 +53,7 @@ const sensitiveRateLimitConfig = {
 const registerSchema = z.object({
 	username: z
 		.string()
+		.trim()
 		.min(3, "Username must be at least 3 characters")
 		.max(50, "Username must be at most 50 characters")
 		.regex(/^[a-zA-Z0-9_-]+$/, "Username can only contain letters, numbers, underscores, and hyphens"),
@@ -63,7 +64,7 @@ const registerSchema = z.object({
 });
 
 const loginSchema = z.object({
-	username: z.string().min(1, "Username is required"),
+	username: z.string().trim().min(1, "Username is required"),
 	password: z.string().min(1, "Password is required"),
 	rememberMe: z.boolean().optional().default(false),
 });

--- a/backend/src/test/auth.test.ts
+++ b/backend/src/test/auth.test.ts
@@ -245,6 +245,57 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 			expect(response.json().code).toBe("VALIDATION_ERROR");
 		});
 
+		it("should register with trimmed username when input has whitespace", async () => {
+			const response = await app.inject({
+				method: "POST",
+				url: "/auth/register",
+				payload: {
+					username: "  trimuser  ",
+					password: "TestPassword123",
+				},
+			});
+
+			expect(response.statusCode).toBe(201);
+			expect(response.json().user.username).toBe("trimuser");
+		});
+
+		it("should reject whitespace-only username on registration", async () => {
+			const response = await app.inject({
+				method: "POST",
+				url: "/auth/register",
+				payload: {
+					username: "   ",
+					password: "TestPassword123",
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(response.json().code).toBe("VALIDATION_ERROR");
+		});
+
+		it("should reject duplicate username even with surrounding whitespace", async () => {
+			await app.inject({
+				method: "POST",
+				url: "/auth/register",
+				payload: {
+					username: "spacedupe",
+					password: "TestPassword123",
+				},
+			});
+
+			const response = await app.inject({
+				method: "POST",
+				url: "/auth/register",
+				payload: {
+					username: "  spacedupe  ",
+					password: "AnotherPassword123",
+				},
+			});
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json().code).toBe("USERNAME_EXISTS");
+		});
+
 		it("should reject invalid username characters", async () => {
 			const response = await app.inject({
 				method: "POST",
@@ -339,6 +390,35 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 
 			expect(response.statusCode).toBe(401);
 			expect(response.json().code).toBe("INVALID_CREDENTIALS");
+		});
+
+		it("should login successfully when username has leading/trailing whitespace", async () => {
+			const response = await app.inject({
+				method: "POST",
+				url: "/auth/login",
+				payload: {
+					username: "  loginuser  ",
+					password: "TestPassword123",
+				},
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json().ok).toBe(true);
+			expect(response.json().user.username).toBe("loginuser");
+		});
+
+		it("should reject whitespace-only username on login", async () => {
+			const response = await app.inject({
+				method: "POST",
+				url: "/auth/login",
+				payload: {
+					username: "   ",
+					password: "TestPassword123",
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(response.json().code).toBe("VALIDATION_ERROR");
 		});
 
 		it("should support rememberMe option", async () => {


### PR DESCRIPTION
Closes #276

## Summary

Usernames with leading/trailing whitespace (e.g. `"Daniel "`) were not normalized before validation and DB lookup. This caused login mismatches or inconsistent stored usernames.

## Changes

- Added `.trim()` to `loginSchema` in `backend/src/routes/auth.ts` — trims before the DB lookup
- Added `.trim()` to `registerSchema` in `backend/src/routes/auth.ts` — trims before regex validation and DB insert
- Added 5 new test cases in `backend/src/test/auth.test.ts`:
  - Login with surrounding whitespace succeeds
  - Whitespace-only username rejected on login
  - Registration with surrounding whitespace stores trimmed name
  - Whitespace-only username rejected on registration
  - Duplicate detection works through whitespace