### PR TITLE
chore: add .claude/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ Thumbs.db
 .turbo/
 .roo/
 .roomodes
+.claude/
 AGENTS.md
 docs/TECH_STACK.md
 doku


### PR DESCRIPTION
Adds .claude/ directory (external tooling config) to .gitignore to keep it out of the repository.