### PR TITLE
fix: remove duplicate ESC handlers causing double history.back()

### DIFF
--- a/frontend/src/components/AboutModal.tsx
+++ b/frontend/src/components/AboutModal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FRONTEND_VERSION, GITHUB_URL } from "../App";
-import { useEscapeKey } from "../hooks/useEscapeKey";
 
 interface UpdateCheckResult {
 	status: "up-to-date" | "update-available" | "error";
@@ -18,7 +17,7 @@ export default function AboutModal({ isOpen, onClose }: AboutModalProps) {
 	const [isChecking, setIsChecking] = useState(false);
 	const [updateCheckResult, setUpdateCheckResult] = useState<UpdateCheckResult | null>(null);
 
-	useEscapeKey(isOpen, onClose);
+	// ESC is handled by the global handler in App.tsx to avoid double history.back()
 
 	// Reset check result when modal opens so stale results are never shown
 	useEffect(() => {

--- a/frontend/src/components/ProfileModal.tsx
+++ b/frontend/src/components/ProfileModal.tsx
@@ -1,4 +1,3 @@
-import { useEscapeKey } from "../hooks/useEscapeKey";
 import { UserProfile } from "./Auth";
 
 interface ProfileModalProps {
@@ -7,7 +6,7 @@ interface ProfileModalProps {
 }
 
 export default function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
-	useEscapeKey(isOpen, onClose);
+	// ESC is handled by the global handler in App.tsx to avoid double history.back()
 
 	if (!isOpen) return null;
 

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -5,7 +5,6 @@
 
 import { Check, Copy, Link2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useEscapeKey } from "../hooks/useEscapeKey";
 
 export interface ShareDialogProps {
 	show: boolean;
@@ -44,7 +43,7 @@ export function ShareDialog({
 	const closeLabel = t("common.close");
 	const copyLabel = shareCopied ? t("share.copied") : t("share.copyLink");
 
-	useEscapeKey(show, onClose);
+	// ESC is handled by the global handler in App.tsx to avoid double history.back()
 
 	if (!show) return null;
 


### PR DESCRIPTION
## Summary

Removes redundant per-modal `useEscapeKey` hooks from **AboutModal**, **ProfileModal**, and **ShareDialog**. The global ESC handler in `App.tsx` already manages ESC priority for all modals, so the per-component hooks caused `history.back()` to fire twice on a single ESC press.

## Changes

- **`AboutModal.tsx`** — removed `useEscapeKey` hook call and unused import
- **`ProfileModal.tsx`** — removed `useEscapeKey` hook call and unused import
- **`ShareDialog.tsx`** — removed `useEscapeKey` hook call and unused import

## Testing

- Lint: clean (only 1 pre-existing warning, unrelated)
- Manual: ESC now correctly navigates back once when any modal is open

Closes #328