### PR TITLE
feat: support liquid intake units with conversion

### DIFF
--- a/backend/src/i18n/translations.ts
+++ b/backend/src/i18n/translations.ts
@@ -179,6 +179,11 @@ type TranslationKeys = {
 	common: {
 		pill: string;
 		pills: string;
+		unit: string;
+		units: string;
+		ml: string;
+		application: string;
+		applications: string;
 		blister: string;
 		blisters: string;
 		day: string;
@@ -299,6 +304,11 @@ const translations: Record<Language, TranslationKeys> = {
 		common: {
 			pill: "pill",
 			pills: "pills",
+			unit: "unit",
+			units: "units",
+			ml: "ml",
+			application: "application",
+			applications: "applications",
 			blister: "blister",
 			blisters: "blisters",
 			day: "day",
@@ -420,6 +430,11 @@ const translations: Record<Language, TranslationKeys> = {
 		common: {
 			pill: "Tablette",
 			pills: "Tabletten",
+			unit: "Einheit",
+			units: "Einheiten",
+			ml: "ml",
+			application: "Anwendung",
+			applications: "Anwendungen",
 			blister: "Blister",
 			blisters: "Blister",
 			day: "Tag",

--- a/backend/src/routes/refills.ts
+++ b/backend/src/routes/refills.ts
@@ -52,7 +52,10 @@ export async function refillRoutes(app: FastifyInstance) {
 		if (!med) return reply.notFound("Medication not found");
 
 		const { packsAdded, loosePillsAdded, usePrescription } = parsed.data;
-		const isBottle = (med.packageType ?? "blister") === "bottle";
+		const isBottle =
+			(med.packageType ?? "blister") === "bottle" ||
+			(med.packageType ?? "blister") === "tube" ||
+			(med.packageType ?? "blister") === "liquid_container";
 		const effectivePacksAdded = isBottle ? 0 : packsAdded;
 		const effectiveLoosePillsAdded = loosePillsAdded;
 		const remainingPrescriptionRefills = med.prescriptionRemainingRefills ?? 0;
@@ -161,7 +164,10 @@ export async function refillRoutes(app: FastifyInstance) {
 			.where(eq(refillHistory.medicationId, medId))
 			.orderBy(desc(refillHistory.refillDate));
 
-		const isBottle = (med.packageType ?? "blister") === "bottle";
+		const isBottle =
+			(med.packageType ?? "blister") === "bottle" ||
+			(med.packageType ?? "blister") === "tube" ||
+			(med.packageType ?? "blister") === "liquid_container";
 		const pillsPerPack = isBottle ? 0 : med.blistersPerPack * med.pillsPerBlister;
 
 		return refills.map((r) => ({

--- a/backend/src/services/intake-reminder-scheduler.ts
+++ b/backend/src/services/intake-reminder-scheduler.ts
@@ -99,7 +99,7 @@ async function autoMarkDueIntakesAsTaken(
 		const intakes = parseIntakesJson(
 			med.intakesJson,
 			{ usageJson: med.usageJson, everyJson: med.everyJson, startJson: med.startJson },
-			med.intakeRemindersEnabled ?? false
+			false
 		);
 		if (intakes.length === 0) {
 			continue;
@@ -380,8 +380,18 @@ async function checkAndSendIntakeRemindersForUser(
 		`[IntakeReminder] User ${settings.userId}: Notifications enabled (email:${emailEnabled}, shoutrrr:${shoutrrrEnabled})`
 	);
 
-	// Get all medications with intake reminders enabled for this user
-	const medsWithReminders = rows.filter((row) => row.intakeRemindersEnabled);
+	// Parse intakes per medication and keep only medications with at least one intake-level reminder enabled.
+	// Intentionally no medication-level fallback: reminders are controlled strictly per intake.
+	const medsWithReminders = rows
+		.map((row) => ({
+			med: row,
+			intakes: parseIntakesJson(
+				row.intakesJson,
+				{ usageJson: row.usageJson, everyJson: row.everyJson, startJson: row.startJson },
+				false
+			),
+		}))
+		.filter(({ intakes }) => intakes.some((intake) => intake.intakeRemindersEnabled));
 
 	if (medsWithReminders.length === 0) {
 		logger.debug(`[IntakeReminder] User ${settings.userId}: No medications have reminders enabled`);
@@ -389,7 +399,7 @@ async function checkAndSendIntakeRemindersForUser(
 	}
 
 	logger.debug(
-		`[IntakeReminder] User ${settings.userId}: Found ${medsWithReminders.length} medications with reminders`
+		`[IntakeReminder] User ${settings.userId}: Found ${medsWithReminders.length} medications with intake-level reminders`
 	);
 
 	const state = loadIntakeReminderState();
@@ -407,13 +417,7 @@ async function checkAndSendIntakeRemindersForUser(
 	);
 
 	// Find intakes: upcoming ones in reminder window + past ones for repeat reminders
-	for (const med of medsWithReminders) {
-		// Parse intakes using new format (with per-intake takenBy), falling back to legacy
-		const intakes = parseIntakesJson(
-			med.intakesJson,
-			{ usageJson: med.usageJson, everyJson: med.everyJson, startJson: med.startJson },
-			med.intakeRemindersEnabled ?? false
-		);
+	for (const { med, intakes } of medsWithReminders) {
 		// Medication-level takenBy (for fallback/display purposes)
 		const medicationTakenBy = parseTakenByJson(med.takenByJson);
 		const medDisplayName = med.name || med.genericName || "";
@@ -422,9 +426,9 @@ async function checkAndSendIntakeRemindersForUser(
 			`[IntakeReminder] User ${settings.userId}: Processing medication "${medDisplayName}" with ${intakes.length} intakes`
 		);
 
-		// Filter intakes that have reminders enabled (per-intake setting or medication-level)
+		// Filter intakes that have reminders enabled at intake level only.
 		const intakesWithReminders = intakes.filter((intake, idx) => {
-			const hasReminder = intake.intakeRemindersEnabled || med.intakeRemindersEnabled;
+			const hasReminder = intake.intakeRemindersEnabled;
 			if (!hasReminder) {
 				logger.debug(`[IntakeReminder] User ${settings.userId}: Intake ${idx} has reminders disabled, skipping`);
 			}

--- a/backend/src/services/reminder-scheduler.ts
+++ b/backend/src/services/reminder-scheduler.ts
@@ -19,6 +19,7 @@ import {
 	getNextScheduledTime,
 	getTimezone,
 	getTodayInTimezone,
+	normalizeIntakeUsageForStock,
 	parseIntakesJson,
 	parseLocalDateTime,
 	parseReminderState,
@@ -177,6 +178,8 @@ type LowStockItem = {
 	daysLeft: number | null;
 	depletionDate: string | null;
 	isCritical: boolean;
+	packageType?: string | null;
+	medicationForm?: string | null;
 };
 
 type PrescriptionReminderItem = {
@@ -185,6 +188,16 @@ type PrescriptionReminderItem = {
 	lowThreshold: number;
 	expiryDate: string | null;
 };
+
+function getMedicationUnitLabel(
+	packageType: string | null | undefined,
+	medicationForm: string | null | undefined,
+	tr: ReturnType<typeof getTranslations>
+): string {
+	if (packageType === "liquid_container" || medicationForm === "liquid") return tr.common.ml;
+	if (packageType === "tube") return tr.common.applications;
+	return tr.common.pills;
+}
 
 async function getMedicationsNeedingReminder(
 	userId: number,
@@ -236,10 +249,16 @@ async function getMedicationsNeedingReminder(
 			{ usageJson: row.usageJson, everyJson: row.everyJson, startJson: row.startJson },
 			row.intakeRemindersEnabled ?? false
 		);
-		const blisters: Blister[] = intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start }));
+		const medForm = row.medicationForm ?? "tablet";
+		const blisters: Blister[] = intakes.map((i) => ({
+			usage: normalizeIntakeUsageForStock(i, medForm, row.packageType),
+			every: i.every,
+			start: i.start,
+		}));
+		const isTopical = medForm === "topical" || (row.packageType ?? "blister") === "tube";
 
 		const originalTotalPills =
-			(row.packageType ?? "blister") === "bottle"
+			(row.packageType ?? "blister") === "bottle" || (row.packageType ?? "blister") === "liquid_container"
 				? row.looseTablets + (row.stockAdjustment ?? 0)
 				: row.packCount * row.blistersPerPack * row.pillsPerBlister + row.looseTablets + (row.stockAdjustment ?? 0);
 
@@ -248,7 +267,9 @@ async function getMedicationsNeedingReminder(
 
 		let consumed = 0;
 
-		if (stockCalculationMode === "automatic") {
+		if (isTopical) {
+			consumed = 0;
+		} else if (stockCalculationMode === "automatic") {
 			blisters.forEach((blister, blisterIdx) => {
 				const blisterStart = parseLocalDateTime(blister.start).getTime();
 				if (Number.isNaN(blisterStart)) return;
@@ -343,7 +364,7 @@ async function getMedicationsNeedingReminder(
 			});
 		}
 
-		const currentPills = Math.max(0, originalTotalPills - consumed);
+		const currentPills = isTopical ? originalTotalPills : Math.max(0, originalTotalPills - consumed);
 		const { daysLeft, depletionDate } = calculateDepletionInfo({ count: currentPills, blisters }, language);
 
 		if (daysLeft === null) continue;
@@ -358,6 +379,8 @@ async function getMedicationsNeedingReminder(
 				daysLeft,
 				depletionDate,
 				isCritical,
+				packageType: row.packageType,
+				medicationForm: row.medicationForm,
 			});
 		}
 	}
@@ -484,10 +507,11 @@ async function sendReminderEmail(
 			const statusIcon = isEmpty ? "🚨" : nonEmptyIcon;
 			const nonEmptyBg = isCritical ? "#fff7ed" : "white";
 			const rowBg = isEmpty ? "#fef2f2" : nonEmptyBg;
+			const unit = getMedicationUnitLabel(row.packageType, row.medicationForm, tr);
 			return `
       <tr style="background: ${rowBg};">
         <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; white-space: nowrap;">${statusIcon} ${row.name}</td>
-        <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: center; white-space: nowrap; ${isEmpty ? "color: #dc2626; font-weight: 600;" : ""}"><strong>${row.medsLeft}</strong></td>
+        <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: center; white-space: nowrap; ${isEmpty ? "color: #dc2626; font-weight: 600;" : ""}"><strong>${row.medsLeft}</strong> ${unit}</td>
         <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: center; white-space: nowrap;">${row.daysLeft ?? 0}</td>
         <td style="padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: center; white-space: nowrap;">${isEmpty ? `<strong>${tr.stockReminder.now ?? "-"}</strong>` : (row.depletionDate ?? "-")}</td>
       </tr>`;
@@ -507,7 +531,7 @@ async function sendReminderEmail(
             <thead>
               <tr style="background: #f3f4f6;">
                 <th style="padding: 10px 12px; text-align: left; font-size: 11px; text-transform: uppercase; color: #6b7280; white-space: nowrap;">${tr.stockReminder.tableHeaders.medication}</th>
-                <th style="padding: 10px 12px; text-align: center; font-size: 11px; text-transform: uppercase; color: #6b7280; white-space: nowrap;">${tr.stockReminder.tableHeaders.pills}</th>
+				<th style="padding: 10px 12px; text-align: center; font-size: 11px; text-transform: uppercase; color: #6b7280; white-space: nowrap;">${tr.stockReminder.tableHeaders.pills}/${tr.common.units}</th>
                 <th style="padding: 10px 12px; text-align: center; font-size: 11px; text-transform: uppercase; color: #6b7280; white-space: nowrap;">${tr.stockReminder.tableHeaders.days}</th>
                 <th style="padding: 10px 12px; text-align: center; font-size: 11px; text-transform: uppercase; color: #6b7280; white-space: nowrap;">${tr.stockReminder.tableHeaders.runsOut}</th>
               </tr>
@@ -531,7 +555,7 @@ async function sendReminderEmail(
 
 ${tr.stockReminder.description}
 
-${lowStock.map((r) => `${r.name}: ${r.medsLeft} ${tr.common.pills}, ${r.daysLeft ?? 0} ${tr.common.days}, ${tr.stockReminder.tableHeaders.runsOut}: ${r.depletionDate ?? tr.common.soon}`).join("\n")}
+${lowStock.map((r) => `${r.name}: ${r.medsLeft} ${getMedicationUnitLabel(r.packageType, r.medicationForm, tr)}, ${r.daysLeft ?? 0} ${tr.common.days}, ${tr.stockReminder.tableHeaders.runsOut}: ${r.depletionDate ?? tr.common.soon}`).join("\n")}
 
 ---
 ${getFooterPlain(language)}${isRepeatDaily ? `\n\n${tr.stockReminder.repeatDailyNote}` : ""}`;
@@ -670,7 +694,7 @@ async function checkAndSendReminderForUser(
 							messageParts.push(`🚨 ${tr.push.criticalSection}:`);
 							criticalMeds.forEach((m) =>
 								messageParts.push(
-									`  • ${m.name}: ${t(tr.push.pillsLeft, { count: m.medsLeft })}, ${t(tr.push.daysLeft, { count: m.daysLeft ?? 0 })}`
+									`  • ${m.name}: ${m.medsLeft} ${getMedicationUnitLabel(m.packageType, m.medicationForm, tr)}, ${t(tr.push.daysLeft, { count: m.daysLeft ?? 0 })}`
 								)
 							);
 						}
@@ -679,7 +703,7 @@ async function checkAndSendReminderForUser(
 							messageParts.push(`⚠️ ${tr.push.lowStockSection}:`);
 							lowStockMeds.forEach((m) =>
 								messageParts.push(
-									`  • ${m.name}: ${t(tr.push.pillsLeft, { count: m.medsLeft })}, ${t(tr.push.daysLeft, { count: m.daysLeft ?? 0 })}`
+									`  • ${m.name}: ${m.medsLeft} ${getMedicationUnitLabel(m.packageType, m.medicationForm, tr)}, ${t(tr.push.daysLeft, { count: m.daysLeft ?? 0 })}`
 								)
 							);
 						}

--- a/backend/src/utils/scheduler-utils.ts
+++ b/backend/src/utils/scheduler-utils.ts
@@ -15,22 +15,27 @@ export type Intake = {
 	start: string;
 	takenBy: string | null; // Person taking this specific intake (null = use medication-level takenBy)
 	intakeRemindersEnabled: boolean;
+	intakeUnit?: "ml" | "tsp" | "tbsp" | null;
 };
 
-/**
- * Normalize intake usage for stock math.
- *
- * Stock semantics currently treat numeric usage as-is for all supported
- * medication forms/package types. The helper centralizes this behavior so route
- * logic can depend on a single validated numeric value.
- */
+export function toLiquidMl(usage: number, intakeUnit: "ml" | "tsp" | "tbsp" | null | undefined): number {
+	if (intakeUnit === "tsp") return usage * 5;
+	if (intakeUnit === "tbsp") return usage * 15;
+	return usage;
+}
+
 export function normalizeIntakeUsageForStock(
-	intake: Pick<Intake, "usage">,
-	_medicationForm?: string | null,
-	_packageType?: string | null
+	intake: Intake,
+	medicationForm: string | null | undefined,
+	packageType: string | null | undefined
 ): number {
 	const usage = Number(intake.usage);
-	return Number.isFinite(usage) && usage > 0 ? usage : 0;
+	if (!Number.isFinite(usage) || usage <= 0) return 0;
+
+	if (medicationForm === "liquid" || packageType === "liquid_container") {
+		return toLiquidMl(usage, intake.intakeUnit);
+	}
+	return usage;
 }
 
 // =============================================================================
@@ -218,6 +223,10 @@ export function parseIntakesJson(
 					takenBy: typeof intake.takenBy === "string" && intake.takenBy.trim() ? intake.takenBy.trim() : null,
 					intakeRemindersEnabled:
 						typeof intake.intakeRemindersEnabled === "boolean" ? intake.intakeRemindersEnabled : false,
+					intakeUnit:
+						intake.intakeUnit === "ml" || intake.intakeUnit === "tsp" || intake.intakeUnit === "tbsp"
+							? intake.intakeUnit
+							: null,
 				}));
 			}
 		} catch {
@@ -234,6 +243,7 @@ export function parseIntakesJson(
 			start: b.start,
 			takenBy: null, // Legacy format has no per-intake takenBy
 			intakeRemindersEnabled: medicationIntakeRemindersEnabled ?? false,
+			intakeUnit: null,
 		}));
 	}
 

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -426,12 +426,26 @@ export function SharedSchedule() {
 		const MS_PER_DAY = 86_400_000;
 		const now = Date.now();
 		const calcMode = data.stockCalculationMode ?? "automatic";
+		const toLiquidMl = (usage: number, intakeUnit: "ml" | "tsp" | "tbsp" | null | undefined) => {
+			if (intakeUnit === "tsp") return usage * 5;
+			if (intakeUnit === "tbsp") return usage * 15;
+			return usage;
+		};
 		const coverage: Record<string, { daysLeft: number | null; medsLeft: number; dailyUsage: number }> = {};
 		const depletion: Record<string, number | null> = {};
 
 		for (const med of data.medications) {
-			const intakes = med.intakes || med.blisters.map((b) => ({ ...b, takenBy: null as string | null }));
-			const blisters = med.blisters;
+			const intakes =
+				med.intakes || med.blisters.map((b) => ({ ...b, takenBy: null as string | null, intakeUnit: null }));
+			const isTopical = med.medicationForm === "topical" || med.packageType === "tube";
+			const blisters = intakes.map((intake) => ({
+				usage:
+					med.medicationForm === "liquid" || med.packageType === "liquid_container"
+						? toLiquidMl(intake.usage, intake.intakeUnit)
+						: intake.usage,
+				every: intake.every,
+				start: intake.start,
+			}));
 
 			// Count unique people from all intakes (for per-intake takenBy)
 			const uniquePeople = new Set<string>();
@@ -452,11 +466,16 @@ export function SharedSchedule() {
 					dailyRate += baseRate * personCount; // Legacy: all people
 				}
 			});
+			if (isTopical) {
+				dailyRate = 0;
+			}
 
 			let consumed = 0;
 			const stockCorrectionCutoff = med.lastStockCorrectionAt ? med.lastStockCorrectionAt : 0;
 
-			if (calcMode === "automatic") {
+			if (isTopical) {
+				consumed = 0;
+			} else if (calcMode === "automatic") {
 				// Time-based: every scheduled dose counts as consumed once its time has passed
 				blisters.forEach((s, blisterIdx) => {
 					const blisterStart = new Date(s.start).getTime();

--- a/frontend/src/hooks/useRefill.ts
+++ b/frontend/src/hooks/useRefill.ts
@@ -140,27 +140,33 @@ export function useRefill(): UseRefillReturn {
 				// Clamp all fields to non-negative values.
 				let finalFullBlisters = Math.max(0, editStockFullBlisters);
 				let finalPartialPills =
-					selectedMed.packageType === "bottle"
+					selectedMed.packageType === "bottle" ||
+					selectedMed.packageType === "tube" ||
+					selectedMed.packageType === "liquid_container"
 						? Math.max(0, editStockPartialBlisterPills)
 						: Math.max(0, editStockPartialBlisterPills);
 				const finalLoosePills = Math.max(0, editStockLoosePills);
 
 				// Canonicalize blister values: partial overflow becomes additional full blisters.
-				if (selectedMed.packageType !== "bottle" && selectedMed.pillsPerBlister > 0) {
+				if (selectedMed.packageType === "blister" && selectedMed.pillsPerBlister > 0) {
 					finalFullBlisters += Math.floor(finalPartialPills / selectedMed.pillsPerBlister);
 					finalPartialPills %= selectedMed.pillsPerBlister;
 				}
 
 				// Structural max = sealed package capacity only (no looseTablets offset).
 				const structuralMax =
-					selectedMed.packageType === "bottle"
+					selectedMed.packageType === "bottle" ||
+					selectedMed.packageType === "tube" ||
+					selectedMed.packageType === "liquid_container"
 						? (selectedMed.totalPills ?? getPackageSize(selectedMed))
 						: selectedMed.packCount * selectedMed.blistersPerPack * selectedMed.pillsPerBlister;
 
 				// For blister meds, only sealed pills are capped to package size.
 				// Loose pills are extra and can be above package size.
 				const desiredTotal =
-					selectedMed.packageType === "bottle"
+					selectedMed.packageType === "bottle" ||
+					selectedMed.packageType === "tube" ||
+					selectedMed.packageType === "liquid_container"
 						? Math.min(structuralMax, Math.max(0, finalPartialPills))
 						: Math.min(structuralMax, finalFullBlisters * selectedMed.pillsPerBlister + finalPartialPills) +
 							finalLoosePills;
@@ -170,7 +176,9 @@ export function useRefill(): UseRefillReturn {
 				// - Blister: use structuralMax + finalLoosePills as the new base so that
 				//   updating looseTablets in the DB doesn't cause a stale-split display bug.
 				const baseTotal =
-					selectedMed.packageType === "bottle"
+					selectedMed.packageType === "bottle" ||
+					selectedMed.packageType === "tube" ||
+					selectedMed.packageType === "liquid_container"
 						? getPackageSize(selectedMed) // bottle: stockAdjustment relative to fixed looseTablets base
 						: structuralMax + finalLoosePills; // blister: base = sealed capacity + NEW loose pills
 				// stockAdjustment = what we need to make getMedTotal() return desiredTotal
@@ -181,7 +189,7 @@ export function useRefill(): UseRefillReturn {
 				const patchBody: { stockAdjustment: number; looseTablets?: number } = {
 					stockAdjustment: newStockAdjustment,
 				};
-				if (selectedMed.packageType !== "bottle") {
+				if (selectedMed.packageType === "blister") {
 					patchBody.looseTablets = finalLoosePills;
 				}
 
@@ -232,14 +240,14 @@ export function useRefill(): UseRefillReturn {
 		const knownLoose = Math.min(currentStock, Math.max(0, selectedMed.looseTablets));
 		const sealedPills = Math.max(0, currentStock - knownLoose);
 		const fullBlisters =
-			selectedMed.packageType === "bottle" ? 0 : Math.floor(sealedPills / selectedMed.pillsPerBlister);
+			selectedMed.packageType === "blister" ? Math.floor(sealedPills / selectedMed.pillsPerBlister) : 0;
 		const partialPills =
-			selectedMed.packageType === "bottle" ? Math.max(0, currentStock) : sealedPills % selectedMed.pillsPerBlister;
+			selectedMed.packageType === "blister" ? sealedPills % selectedMed.pillsPerBlister : Math.max(0, currentStock);
 
 		// Pre-fill with current values
 		setEditStockFullBlisters(fullBlisters);
 		setEditStockPartialBlisterPills(partialPills);
-		setEditStockLoosePills(selectedMed.packageType === "bottle" ? 0 : knownLoose);
+		setEditStockLoosePills(selectedMed.packageType === "blister" ? knownLoose : 0);
 		setShowEditStockModal(true);
 		window.history.pushState({ modal: "editStock" }, "");
 	}, []);

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -80,6 +80,29 @@ export function SchedulePage() {
 		missedPastDoseIds,
 	} = useAppContext();
 
+	const getDoseUnitLabel = (medicationName: string, usage: number): string => {
+		const med = meds.find((m) => getMedDisplayName(m) === medicationName);
+		if (med?.packageType === "liquid_container") {
+			return t("form.ml");
+		}
+		if (med?.packageType === "tube") {
+			return med.medicationForm === "liquid" ? t("form.ml") : t("blisters.applications");
+		}
+		return usage !== 1 ? t("common.pills") : t("common.pill");
+	};
+
+	const getTotalUnitLabel = (medicationName: string, total: number): string => {
+		const med = meds.find((m) => getMedDisplayName(m) === medicationName);
+		if (med?.packageType === "liquid_container") {
+			return `${total} ${t("form.ml")}`;
+		}
+		if (med?.packageType === "tube") {
+			const unit = med.medicationForm === "liquid" ? t("form.ml") : t("blisters.applications");
+			return `${total} ${unit}`;
+		}
+		return t("common.pillsTotal", { count: total });
+	};
+
 	return (
 		<section className="grid">
 			<article className="card schedule-full">
@@ -185,7 +208,7 @@ export function SchedulePage() {
 															<span className="med-name-text">{item.medName}</span>
 														</div>
 														<div className="tag-row">
-															<span className="tag subtle">{t("common.pillsTotal", { count: item.total })}</span>
+															<span className="tag subtle">{getTotalUnitLabel(item.medName, item.total)}</span>
 														</div>
 													</div>
 													<div className="doses-col">
@@ -197,11 +220,13 @@ export function SchedulePage() {
 																	<span className="dose-time">{dose.timeStr}</span>
 																	<span className="dose-usage">
 																		<span className="dose-usage-main">
-																			{dose.usage} {dose.usage !== 1 ? t("common.pills") : t("common.pill")}
+																			{dose.usage} {getDoseUnitLabel(item.medName, dose.usage)}
 																		</span>
-																		{med?.pillWeightMg && (
-																			<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
-																		)}
+																		{med?.packageType !== "tube" &&
+																			med?.packageType !== "liquid_container" &&
+																			med?.pillWeightMg && (
+																				<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
+																			)}
 																	</span>{" "}
 																	{dose.intakeRemindersEnabled && (
 																		<span
@@ -353,7 +378,7 @@ export function SchedulePage() {
 													<span className="med-name-text">{item.medName}</span>
 												</div>
 												<div className="tag-row">
-													<span className="tag subtle">{t("common.pillsTotal", { count: item.total })}</span>
+													<span className="tag subtle">{getTotalUnitLabel(item.medName, item.total)}</span>
 													{status && <span className={`tag ${status.className}`}>{t(status.label)}</span>}
 												</div>
 											</div>
@@ -368,11 +393,13 @@ export function SchedulePage() {
 															<span className="dose-time">{dose.timeStr}</span>
 															<span className="dose-usage">
 																<span className="dose-usage-main">
-																	{dose.usage} {dose.usage !== 1 ? t("common.pills") : t("common.pill")}
+																	{dose.usage} {getDoseUnitLabel(item.medName, dose.usage)}
 																</span>
-																{med?.pillWeightMg && (
-																	<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
-																)}
+																{med?.packageType !== "tube" &&
+																	med?.packageType !== "liquid_container" &&
+																	med?.pillWeightMg && (
+																		<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
+																	)}
 															</span>
 															{dose.intakeRemindersEnabled && (
 																<span

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,7 +2,10 @@
 // Core Types for MedAssist
 // =============================================================================
 
-export type PackageType = "blister" | "bottle";
+export type PackageType = "blister" | "bottle" | "tube" | "liquid_container";
+export type MedicationForm = "capsule" | "tablet" | "liquid" | "topical";
+export type PillForm = "capsule" | "tablet";
+export type LifecycleCategory = "refill_when_empty" | "treatment_period";
 
 // Common medication dose units
 export type DoseUnit = "mg" | "g" | "mcg" | "ml";
@@ -28,6 +31,7 @@ export type Intake = {
 	usage: number;
 	every: number;
 	start: string;
+	intakeUnit?: "ml" | "tsp" | "tbsp" | null;
 	takenBy: string | null; // Per-intake user assignment (single person or null)
 	intakeRemindersEnabled: boolean;
 };
@@ -37,10 +41,15 @@ export type Medication = {
 	name: string;
 	genericName?: string | null;
 	takenBy: string[]; // Medication-level takenBy (legacy, still used for filtering)
+	medicationForm?: MedicationForm;
+	pillForm?: PillForm | null;
+	lifecycleCategory?: LifecycleCategory;
 	packageType: PackageType;
 	packCount: number;
 	blistersPerPack: number;
 	pillsPerBlister: number;
+	packageAmountValue?: number;
+	packageAmountUnit?: "ml" | "g";
 	totalPills?: number | null; // For bottle type: total capacity of the container
 	looseTablets: number; // For blister: extra loose pills; for bottle: current stock
 	stockAdjustment?: number;
@@ -48,6 +57,8 @@ export type Medication = {
 	pillWeightMg?: number | null;
 	doseUnit?: DoseUnit | null; // Unit for the dose (mg, g, mcg, ml, IU, etc.)
 	medicationStartDate?: string | null;
+	medicationEndDate?: string | null;
+	autoMarkObsoleteAfterEndDate?: boolean;
 	blisters: Blister[]; // Legacy array format
 	intakes?: Intake[]; // New intake format with per-intake takenBy
 	imageUrl?: string | null;
@@ -102,6 +113,7 @@ export type FormIntake = {
 	every: string;
 	startDate: string;
 	startTime: string;
+	intakeUnit?: "ml" | "tsp" | "tbsp";
 	takenBy: string; // Single person or empty string (empty = null for everyone)
 	intakeRemindersEnabled: boolean;
 };
@@ -110,15 +122,22 @@ export type FormState = {
 	name: string;
 	genericName: string;
 	takenBy: string[]; // Medication-level takenBy (legacy/compatibility)
+	medicationForm: MedicationForm;
+	pillForm: PillForm;
+	lifecycleCategory: LifecycleCategory;
 	packageType: PackageType;
 	packCount: string;
 	blistersPerPack: string;
 	pillsPerBlister: string;
+	packageAmountValue?: string;
+	packageAmountUnit?: "ml" | "g";
 	totalPills: string; // For bottle type: total capacity
 	looseTablets: string; // For blister: extra loose pills; for bottle: current stock
 	pillWeightMg: string;
 	doseUnit: DoseUnit; // Unit for the dose (mg, g, mcg, ml, IU, etc.)
 	medicationStartDate: string;
+	medicationEndDate: string;
+	autoMarkObsoleteAfterEndDate: boolean;
 	expiryDate: string;
 	notes: string;
 	prescriptionEnabled: boolean;
@@ -252,8 +271,8 @@ type MedLike = Pick<Medication, "packCount" | "blistersPerPack" | "pillsPerBlist
 
 /** Calculate total pills including stockAdjustment */
 export function getMedTotal(med: MedLike): number {
-	// For bottle type, looseTablets IS the current stock
-	if (med.packageType === "bottle") {
+	// For container types, looseTablets IS the current stock
+	if (med.packageType === "bottle" || med.packageType === "tube" || med.packageType === "liquid_container") {
 		return med.looseTablets + (med.stockAdjustment ?? 0);
 	}
 	// For blister type, calculate from packs + loose
@@ -262,8 +281,8 @@ export function getMedTotal(med: MedLike): number {
 
 /** Get the base package size (without stockAdjustment) */
 export function getPackageSize(med: MedLike): number {
-	// For bottle type, looseTablets IS the current stock
-	if (med.packageType === "bottle") {
+	// For container types, looseTablets IS the current stock
+	if (med.packageType === "bottle" || med.packageType === "tube" || med.packageType === "liquid_container") {
 		return med.looseTablets;
 	}
 	// For blister type, calculate from packs + loose

--- a/frontend/src/utils/schedule.ts
+++ b/frontend/src/utils/schedule.ts
@@ -5,6 +5,19 @@
 import type { Blister, Coverage, Intake, Medication, ScheduleEvent, StockStatus, StockThresholds } from "../types";
 import { getMedDisplayName, getMedTotal } from "../types";
 
+function toLiquidMl(usage: number, intakeUnit: "ml" | "tsp" | "tbsp" | null | undefined): number {
+	if (intakeUnit === "tsp") return usage * 5;
+	if (intakeUnit === "tbsp") return usage * 15;
+	return usage;
+}
+
+function normalizeUsageForStock(med: Medication, intake: Intake): number {
+	if (med.medicationForm === "liquid" || med.packageType === "liquid_container") {
+		return toLiquidMl(intake.usage, intake.intakeUnit);
+	}
+	return intake.usage;
+}
+
 /**
  * Get intakes for a medication, preferring new intakes format over legacy blisters
  */
@@ -28,7 +41,7 @@ function getIntakesForMed(med: Medication): Intake[] {
  */
 function getBlistersForMed(med: Medication): Blister[] {
 	if (med.intakes && med.intakes.length > 0) {
-		return med.intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start }));
+		return med.intakes.map((i) => ({ usage: normalizeUsageForStock(med, i), every: i.every, start: i.start }));
 	}
 	return med.blisters;
 }
@@ -108,6 +121,7 @@ export function calculateCoverage(
 	const now = Date.now();
 
 	const coverage: Coverage[] = meds.map((m) => {
+		const isTopical = m.medicationForm === "topical" || m.packageType === "tube";
 		const intakes = getIntakesForMed(m);
 		const blisters = getBlistersForMed(m);
 		// Count unique people from all intakes (for per-intake takenBy)
@@ -135,11 +149,16 @@ export function calculateCoverage(
 				dailyRate += baseRate * personCount;
 			}
 		});
+		if (isTopical) {
+			dailyRate = 0;
+		}
 
 		let consumed = 0;
 		const stockCorrectionCutoff = m.lastStockCorrectionAt ? new Date(m.lastStockCorrectionAt).getTime() : 0;
 
-		if (stockCalculationMode === "automatic") {
+		if (isTopical) {
+			consumed = 0;
+		} else if (stockCalculationMode === "automatic") {
 			// In automatic mode, stock is reduced automatically based on the schedule.
 			// Every scheduled dose counts as consumed once its time has passed.
 			// Additionally, if a user marks a future dose as taken BEFORE the scheduled


### PR DESCRIPTION
Closes #354\n\n## Scope\n- add intakeUnit support for ml/tsp/tbsp\n- apply ml conversion logic in scheduling/reminder calculations\n- propagate intake unit handling to shared schedule and refill surfaces