### PR TITLE
chore: ignore copilot tracking artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ doku/
 doku/memory_notes.md
 doku/report.md
 plan/
+.copilot-tracking


### PR DESCRIPTION
Closes #378

## Summary
- add .copilot-tracking paths to gitignore
- keep local copilot planning artifacts out of regular git status
- reduce repository noise during day-to-day development