### PR TITLE
feat: display actual reminder schedule from server config

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -326,6 +326,8 @@ export async function settingsRoutes(app: FastifyInstance) {
 		const userId = await getUserId(request, reply);
 
 		const settings = await getOrCreateUserSettings(userId);
+		const reminderHour = envInt("REMINDER_HOUR", 6);
+		const reminderMinutesBefore = envInt("REMINDER_MINUTES_BEFORE", 15);
 
 		return reply.send({
 			// User notification settings (from DB)
@@ -376,6 +378,8 @@ export async function settingsRoutes(app: FastifyInstance) {
 			lastPrescriptionReminderChannel: settings.lastPrescriptionReminderChannel ?? null,
 			lastPrescriptionReminderMedNames: settings.lastPrescriptionReminderMedNames ?? null,
 			// Server settings (from .env, read-only)
+			reminderHour,
+			reminderMinutesBefore,
 			expiryWarningDays: parseInt(process.env.EXPIRY_WARNING_DAYS ?? "30", 10),
 		});
 	});

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -49,6 +49,8 @@ export interface Settings {
 	upcomingTodayOnly: boolean;
 	shareScheduleTodayOnly: boolean;
 	swapDashboardMainSections: boolean;
+	reminderHour: number;
+	reminderMinutesBefore: number;
 	expiryWarningDays: number;
 }
 
@@ -96,6 +98,8 @@ const defaultSettings: Settings = {
 	upcomingTodayOnly: false,
 	shareScheduleTodayOnly: false,
 	swapDashboardMainSections: false,
+	reminderHour: 6,
+	reminderMinutesBefore: 15,
 	expiryWarningDays: 30,
 };
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -323,9 +323,9 @@
     "schedule": {
       "title": "Erinnerungsplan",
       "stockCheck": "Bestands- & Rezeptprüfung",
-      "dailyAt6": "Täglich um 6:00 Uhr",
+      "dailyAtHour": "Täglich um {{hour}}:00 Uhr",
       "intakeCheck": "Einnahmeprüfung",
-      "15minBefore": "15 Min. vor geplanter Zeit",
+      "minutesBefore": "{{minutes}} Min. vor geplanter Zeit",
       "nextCheck": "Nächste Bestandsprüfung",
       "lastSent": "Letzte Benachrichtigung",
       "lastStockSent": "Letzte Bestands-Erinnerung",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -323,9 +323,9 @@
     "schedule": {
       "title": "Reminder Schedule",
       "stockCheck": "Stock & prescription check",
-      "dailyAt6": "Daily at 6:00 AM",
+      "dailyAtHour": "Daily at {{hour}}:00",
       "intakeCheck": "Intake check",
-      "15minBefore": "15 min before scheduled time",
+      "minutesBefore": "{{minutes}} min before scheduled time",
       "nextCheck": "Next stock check",
       "lastSent": "Last notification sent",
       "lastStockSent": "Last stock reminder",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -479,11 +479,15 @@ export function SettingsPage() {
 							</div>
 							<div className="schedule-row">
 								<span className="schedule-label">{t("settings.schedule.stockCheck")}</span>
-								<span className="schedule-value">{t("settings.schedule.dailyAt6")}</span>
+								<span className="schedule-value">
+									{t("settings.schedule.dailyAtHour", { hour: settings.reminderHour })}
+								</span>
 							</div>
 							<div className="schedule-row">
 								<span className="schedule-label">{t("settings.schedule.intakeCheck")}</span>
-								<span className="schedule-value">{t("settings.schedule.15minBefore")}</span>
+								<span className="schedule-value">
+									{t("settings.schedule.minutesBefore", { minutes: settings.reminderMinutesBefore })}
+								</span>
 							</div>
 							{settings.nextScheduledCheck && (
 								<div className="schedule-row">


### PR DESCRIPTION
Closes #385

## Summary

The settings page previously showed hardcoded reminder schedule values ("Daily at 6:00 AM", "15 min before scheduled time"). This change makes those values dynamic by reading the actual server configuration.

## Changes

### Backend (settings.ts)
- Expose `REMINDER_HOUR` and `REMINDER_MINUTES_BEFORE` env values in the settings GET response

### Frontend
- **useSettings.ts**: Add `reminderHour` and `reminderMinutesBefore` to Settings interface with defaults
- **i18n (en/de)**: Replace hardcoded strings with parameterized translations (`dailyAtHour`, `minutesBefore`)
- **SettingsPage.tsx**: Render schedule using actual server values