### PR TITLE
chore: refine issue template chooser and metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,9 @@
-name: 🐛 Bug Report
+name: Bug Report
 description: Report a bug or unexpected behavior
+title: "[Bug]: "
 labels: ["bug", "triage"]
+assignees:
+  - DanielVolz
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: 💬 Discussions
-    url: https://github.com/DanielVolz/medassist-ng/discussions
-    about: Ask questions or share ideas in Discussions
-  - name: 📖 Documentation
-    url: https://github.com/DanielVolz/medassist-ng#readme
-    about: Check the README for setup and usage instructions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
-name: ✨ Feature Request
+name: Feature Request
 description: Suggest a new feature or improvement
+title: "[Feature]: "
 labels: ["enhancement", "triage"]
 body:
   - type: markdown


### PR DESCRIPTION
Closes #391

## Summary

Follow-up PR with scope limited to the three issue template files.

## Changes

- `.github/ISSUE_TEMPLATE/config.yml`
  - simplify issue chooser config for the 3-template structure
- `.github/ISSUE_TEMPLATE/bug_report.yml`
  - add bug title prefix `[Bug]:`
  - add default assignee `DanielVolz`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
  - add feature title prefix `[Feature]:`

## Scope Guard

This PR intentionally excludes unrelated local changes and contains only issue-template updates.
