### PR TITLE
fix: include shareMedicationOverview in unsaved settings detection

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -793,6 +793,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 			settings.maxNaggingReminders !== savedSettings.maxNaggingReminders ||
 			settings.stockCalculationMode !== savedSettings.stockCalculationMode ||
 			settings.shareStockStatus !== savedSettings.shareStockStatus ||
+			settings.shareMedicationOverview !== savedSettings.shareMedicationOverview ||
 			settings.upcomingTodayOnly !== savedSettings.upcomingTodayOnly ||
 			settings.shareScheduleTodayOnly !== savedSettings.shareScheduleTodayOnly ||
 			settings.expiryWarningDays !== savedSettings.expiryWarningDays

--- a/frontend/src/test/context/AppContext.test.tsx
+++ b/frontend/src/test/context/AppContext.test.tsx
@@ -132,6 +132,7 @@ describe("useAppContext", () => {
 				shoutrrrIntakeReminders: true,
 				stockCalculationMode: "automatic",
 				shareStockStatus: true,
+				shareMedicationOverview: false,
 				expiryWarningDays: 30,
 			},
 			setSettings: vi.fn(),
@@ -171,6 +172,7 @@ describe("useAppContext", () => {
 				shoutrrrIntakeReminders: true,
 				stockCalculationMode: "automatic",
 				shareStockStatus: true,
+				shareMedicationOverview: false,
 				expiryWarningDays: 30,
 			},
 			settingsLoading: false,
@@ -290,6 +292,27 @@ describe("useAppContext", () => {
 		expect(result.current.existingPeople).toEqual(["Anna", "Max"]);
 		expect(result.current.stockThresholds.lowStockDays).toBe(10);
 		expect(result.current.settingsChanged).toBe(false);
+	});
+
+	it("marks settings as changed when shareMedicationOverview differs", async () => {
+		const settingsValue = mockUseSettings();
+		mockUseSettings.mockReturnValue({
+			...settingsValue,
+			settings: {
+				...settingsValue.settings,
+				shareMedicationOverview: true,
+			},
+			savedSettings: {
+				...settingsValue.savedSettings,
+				shareMedicationOverview: false,
+			},
+		});
+
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		await waitFor(() => {
+			expect(result.current.settingsChanged).toBe(true);
+		});
 	});
 
 	it("exposes the settings load error from useSettings", async () => {


### PR DESCRIPTION
Closes #429

Add `shareMedicationOverview` to the `settingsChanged` memo in `AppContext.tsx` so toggling the shared medication overview setting correctly triggers the unsaved-changes indicator.

Includes regression test for the fix.