### PR TITLE
fix: remove array index keys from intake rows

### DIFF
--- a/frontend/src/components/MedDetailModal.tsx
+++ b/frontend/src/components/MedDetailModal.tsx
@@ -980,17 +980,15 @@ export function MedDetailModal({
 								)}
 							</h3>
 							<div className="med-detail-schedules">
-								{scheduleIntakes.map((intake, idx) => {
+								{scheduleIntakes.map((intake) => {
 									const hasPerIntakeTakenBy = !!intake.takenBy;
 									const personCount = Math.max(1, selectedMed.takenBy?.length ?? 0);
 									const totalUsage = hasPerIntakeTakenBy ? intake.usage : intake.usage * personCount;
 									const showIntakeBell = intake.intakeRemindersEnabled === true;
+									const intakeKey = `${intake.start}-${intake.usage}-${intake.every}-${intake.takenBy ?? ""}-${intake.intakeRemindersEnabled ? "reminder" : "silent"}`;
 
 									return (
-										<div
-											key={`${intake.start}-${intake.usage}-${intake.every}-${idx}`}
-											className="med-schedule-row blister-row-simple"
-										>
+										<div key={intakeKey} className="med-schedule-row blister-row-simple">
 											<span className="med-schedule-usage">
 												{getScheduleUsageLabel(totalUsage, intake.intakeUnit)}
 												{showPillWeightDetails && ` (${totalUsage * pillWeightMg} ${selectedMed.doseUnit ?? "mg"})`}

--- a/frontend/src/components/MobileEditModal.tsx
+++ b/frontend/src/components/MobileEditModal.tsx
@@ -814,106 +814,106 @@ export function MobileEditModal({
 												</button>
 											)}
 										</div>
-										{form.intakes.map((intake, idx) => (
-											<div
-												key={`${intake.startDate}-${intake.startTime}-${intake.usage}-${intake.every}-${intake.takenBy ?? ""}-${idx}`}
-												className="blister-row"
-											>
-												<label className="compact">
-													<span>{getUsageLabel(intake)}</span>
-													<FormNumberStepper
-														value={intake.usage}
-														onChange={(nextValue) => onSetIntakeValue(idx, "usage", nextValue)}
-														min={allowFractionalIntake ? 0.5 : 1}
-														step={allowFractionalIntake ? 0.5 : 1}
-														allowDecimal={allowFractionalIntake}
-														decrementLabel={decrementValueLabel}
-														incrementLabel={incrementValueLabel}
-													/>
-												</label>
-												<label className="compact">
-													<span>{t("form.blisters.everyDays")}</span>
-													<FormNumberStepper
-														value={intake.every}
-														onChange={(nextValue) => onSetIntakeValue(idx, "every", nextValue)}
-														min={1}
-														decrementLabel={decrementValueLabel}
-														incrementLabel={incrementValueLabel}
-													/>
-												</label>
-												<label className="compact full-row">
-													<span>{t("form.blisters.startDate")}</span>
-													<DateInput
-														value={intake.startDate}
-														onChange={(e) => onSetIntakeValue(idx, "startDate", e.target.value)}
-													/>
-												</label>
-												<label className="compact time-label">
-													<span>{t("form.blisters.startTime")}</span>
-													<input
-														type="time"
-														value={intake.startTime}
-														onChange={(e) => onSetIntakeValue(idx, "startTime", e.target.value)}
-													/>
-												</label>
-												{isLiquidContainerPackageType(form.packageType) && (
-													<label className="compact full-row">
-														<span>{t("form.blisters.intakeUnit")}</span>
-														<select
-															className="select-field"
-															value={intake.intakeUnit}
-															onChange={(e) =>
-																onSetIntakeValue(idx, "intakeUnit", e.target.value as "ml" | "tsp" | "tbsp")
-															}
-														>
-															<option value="ml">{t("form.blisters.intakeUnitMl")}</option>
-															<option value="tsp">{t("form.blisters.intakeUnitTsp")}</option>
-															<option value="tbsp">{t("form.blisters.intakeUnitTbsp")}</option>
-														</select>
-													</label>
-												)}
-												{form.takenBy.length === 0 ? null : (
-													<label className="compact full-row taken-by-field">
-														<span>{t("form.blisters.takenByIntake")}</span>
-														<select
-															className="select-field"
-															value={intake.takenBy}
-															onChange={(e) => onSetIntakeValue(idx, "takenBy", e.target.value)}
-														>
-															{form.takenBy.map((person) => (
-																<option key={person} value={person}>
-																	{person}
-																</option>
-															))}
-														</select>
-													</label>
-												)}
-												<div className="remind-toggle-row" title={t("form.blisters.remindTooltip")}>
-													<span className="legend-hint">
-														<Bell size={14} aria-hidden="true" />
-													</span>
-													<label className="toggle-switch small">
-														<input
-															type="checkbox"
-															checked={intake.intakeRemindersEnabled}
-															onChange={(e) => onSetIntakeValue(idx, "intakeRemindersEnabled", e.target.checked)}
+										{form.intakes.map((intake, idx) => {
+											const intakeKey = `${intake.startDate}-${intake.startTime}-${intake.usage}-${intake.every}-${intake.takenBy ?? ""}-${intake.intakeUnit ?? "unit"}-${intake.intakeRemindersEnabled ? "reminder" : "silent"}`;
+											return (
+												<div key={intakeKey} className="blister-row">
+													<label className="compact">
+														<span>{getUsageLabel(intake)}</span>
+														<FormNumberStepper
+															value={intake.usage}
+															onChange={(nextValue) => onSetIntakeValue(idx, "usage", nextValue)}
+															min={allowFractionalIntake ? 0.5 : 1}
+															step={allowFractionalIntake ? 0.5 : 1}
+															allowDecimal={allowFractionalIntake}
+															decrementLabel={decrementValueLabel}
+															incrementLabel={incrementValueLabel}
 														/>
-														<span className="toggle-slider"></span>
 													</label>
+													<label className="compact">
+														<span>{t("form.blisters.everyDays")}</span>
+														<FormNumberStepper
+															value={intake.every}
+															onChange={(nextValue) => onSetIntakeValue(idx, "every", nextValue)}
+															min={1}
+															decrementLabel={decrementValueLabel}
+															incrementLabel={incrementValueLabel}
+														/>
+													</label>
+													<label className="compact full-row">
+														<span>{t("form.blisters.startDate")}</span>
+														<DateInput
+															value={intake.startDate}
+															onChange={(e) => onSetIntakeValue(idx, "startDate", e.target.value)}
+														/>
+													</label>
+													<label className="compact time-label">
+														<span>{t("form.blisters.startTime")}</span>
+														<input
+															type="time"
+															value={intake.startTime}
+															onChange={(e) => onSetIntakeValue(idx, "startTime", e.target.value)}
+														/>
+													</label>
+													{isLiquidContainerPackageType(form.packageType) && (
+														<label className="compact full-row">
+															<span>{t("form.blisters.intakeUnit")}</span>
+															<select
+																className="select-field"
+																value={intake.intakeUnit}
+																onChange={(e) =>
+																	onSetIntakeValue(idx, "intakeUnit", e.target.value as "ml" | "tsp" | "tbsp")
+																}
+															>
+																<option value="ml">{t("form.blisters.intakeUnitMl")}</option>
+																<option value="tsp">{t("form.blisters.intakeUnitTsp")}</option>
+																<option value="tbsp">{t("form.blisters.intakeUnitTbsp")}</option>
+															</select>
+														</label>
+													)}
+													{form.takenBy.length === 0 ? null : (
+														<label className="compact full-row taken-by-field">
+															<span>{t("form.blisters.takenByIntake")}</span>
+															<select
+																className="select-field"
+																value={intake.takenBy}
+																onChange={(e) => onSetIntakeValue(idx, "takenBy", e.target.value)}
+															>
+																{form.takenBy.map((person) => (
+																	<option key={person} value={person}>
+																		{person}
+																	</option>
+																))}
+															</select>
+														</label>
+													)}
+													<div className="remind-toggle-row" title={t("form.blisters.remindTooltip")}>
+														<span className="legend-hint">
+															<Bell size={14} aria-hidden="true" />
+														</span>
+														<label className="toggle-switch small">
+															<input
+																type="checkbox"
+																checked={intake.intakeRemindersEnabled}
+																onChange={(e) => onSetIntakeValue(idx, "intakeRemindersEnabled", e.target.checked)}
+															/>
+															<span className="toggle-slider"></span>
+														</label>
+													</div>
+													{!readOnlyMode && form.intakes.length > 1 && (
+														<button
+															type="button"
+															className="danger remove-blister-btn icon-only tooltip-trigger"
+															onClick={() => onRemoveIntake(idx)}
+															aria-label={t("common.remove")}
+															data-tooltip={t("common.remove")}
+														>
+															<Minus size={18} aria-hidden="true" />
+														</button>
+													)}
 												</div>
-												{!readOnlyMode && form.intakes.length > 1 && (
-													<button
-														type="button"
-														className="danger remove-blister-btn icon-only tooltip-trigger"
-														onClick={() => onRemoveIntake(idx)}
-														aria-label={t("common.remove")}
-														data-tooltip={t("common.remove")}
-													>
-														<Minus size={18} aria-hidden="true" />
-													</button>
-												)}
-											</div>
-										))}
+											);
+										})}
 									</div>
 								</div>
 								<div className={`form-tab-panel${activeTab === "prescription" ? " active" : ""}`}>


### PR DESCRIPTION
Closes #449

## Summary
- replace array-index based keys in intake row rendering with stable intake-derived keys
- clear the existing `noArrayIndexKey` Biome error on `main`
- unblock unrelated frontend PRs that currently fail on the shared lint baseline