### PR TITLE
fix: close stale weekly triage reports before creating a new one

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -494,6 +494,12 @@ All work is tracked in the [GitHub Project board](https://github.com/users/Danie
 
 All three labels trigger the `add-to-project.yml` workflow, which automatically adds the issue to the Project board.
 
+### Weekly Triage Report Hygiene
+
+- There must never be more than one open `Weekly Triage Report - YYYY-MM-DD` issue at the same time.
+- Before a new weekly triage report issue is created, close any older open weekly triage report issue and leave a short closing comment.
+- If automation creates a new weekly report without closing the old one first, treat that as workflow drift and fix the workflow or close the stale report immediately.
+
 ---
 
 ## Complete Workflow Summary

--- a/.github/workflows/weekly-triage-report.yml
+++ b/.github/workflows/weekly-triage-report.yml
@@ -68,6 +68,36 @@ jobs:
             const title = `${{ steps.summary.outputs.title }}`;
             const body = `${{ steps.summary.outputs.body }}`;
 
+            const existingReports = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'triage',
+              per_page: 100,
+            });
+
+            for (const issue of existingReports) {
+              if (issue.pull_request) {
+                continue;
+              }
+
+              if (issue.title.startsWith('Weekly Triage Report - ') && issue.title !== title) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: 'Closing this older weekly triage report before publishing the next one so only one weekly report issue stays open at a time.',
+                });
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                });
+              }
+            }
+
             await github.rest.issues.create({
               owner,
               repo,

--- a/doku/memory_notes.md
+++ b/doku/memory_notes.md
@@ -19,3 +19,12 @@ Purpose: persistent agent work memory to survive context loss.
 - Decisions: Kept the stock/refill doku history entries while resolving add/add conflicts and combined both branches' MedicationsPage tests in the shared file.
 - Files touched: doku/memory_notes.md, doku/report.md, frontend/src/test/pages/MedicationsPage.test.tsx.
 - Follow-up: Re-run the minimum frontend validation and push the conflict-resolution commit for PR #475.
+
+- Task: Review and merge the open Dependabot pull requests after verifying scope and CI state.
+- Decisions: Merged only dependency-only PRs with acceptable checks; accepted skipped jobs on the root-only tooling bump because the diff did not touch frontend or backend runtime code.
+- Merged PRs: #468 (`@biomejs/biome` root bump), #469 (frontend dependency group bump), #470 (backend dependency group bump).
+- Follow-up: Synced local `main` to commit `39c19ab` and confirmed there are no remaining open Dependabot PRs from this reviewed set.
+
+- Task: Investigate why last week's weekly triage report issue stayed open after a newer report was created.
+- Root cause: `.github/workflows/weekly-triage-report.yml` always created a new issue and had no cleanup step for older open weekly report issues; `.github/agents/release-manager.agent.md` also lacked an explicit weekly-report closure rule.
+- Fix: Added workflow logic to close older open weekly triage reports before publishing the new one and added a dedicated "Weekly Triage Report Hygiene" rule to the release-manager agent instructions.

--- a/doku/report.md
+++ b/doku/report.md
@@ -33,3 +33,26 @@
 - Validation:
   - Minimum frontend validation is rerun after conflict resolution before pushing the refreshed branch.
 - Result: The feature branch is conflict-free locally and ready for the final revalidation/push cycle.
+
+### 2026-03-25
+- Scope: Review and merge the currently open Dependabot PRs.
+- What changed:
+  - Reviewed the three open Dependabot PRs and verified each diff was limited to package manifest and lockfile updates.
+  - Confirmed the frontend and backend dependency-group PRs had green relevant checks before merge.
+  - Accepted the skipped frontend/backend/E2E jobs on the root-level Biome bump because the change was tooling-only at repository root scope.
+  - Squash-merged PRs `#468`, `#469`, and `#470`.
+- Validation:
+  - Synced local `main` with `github/main` after the merges.
+  - Confirmed there are no remaining open Dependabot PRs in this reviewed batch.
+- Result: All currently reviewed Dependabot updates are merged and local `main` matches the remote shipping branch again.
+
+### 2026-03-25
+- Scope: Prevent duplicate open weekly triage report issues.
+- What changed:
+  - Confirmed the weekly triage workflow was creating a new report issue every Monday without closing older open weekly report issues first.
+  - Updated `.github/workflows/weekly-triage-report.yml` so older open `Weekly Triage Report - ...` issues are commented on and closed before the next report issue is created.
+  - Added an explicit weekly-report closure rule to `.github/agents/release-manager.agent.md`.
+- Validation:
+  - Reviewed the current open weekly triage reports and confirmed both `#451` and `#471` were open before the workflow fix.
+  - Performed a local YAML parse check for the updated workflow.
+- Result: Future weekly triage runs will keep only one open weekly report issue, and the release-manager guidance now states that requirement explicitly.


### PR DESCRIPTION
Closes #476

## Summary
- close older open weekly triage report issues before publishing the next weekly report
- add an explicit weekly report hygiene rule to the release-manager instructions
- record the investigation and fix in the required doku logs