### PR TITLE
chore(release): bump app version to 1.22.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.22.2",
+  "version": "1.22.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #526

## Summary
- bump frontend package version from 1.22.2 to 1.22.3
- bump backend package version from 1.22.2 to 1.22.3
- align the About modal and backend health endpoint with the manual 1.22.3 release

## Validation
- backend /health returned 1.22.3 after restart in local runtime verification
- Settings -> About displayed 1.22.3 and linked to the v1.22.3 release URL
- PR diff is intentionally limited to backend/package.json and frontend/package.json
