### PR TITLE
fix(stock): ignore doses from other medications

### DIFF
--- a/backend/src/services/current-stock.ts
+++ b/backend/src/services/current-stock.ts
@@ -99,9 +99,16 @@ export function computeMedicationCurrentStock(options: {
 				const match = doseIdPattern.exec(dose.doseId);
 				if (!match) continue;
 
+				const parsedMedicationId = Number.parseInt(match[1], 10);
 				const parsedIntakeIndex = Number.parseInt(match[2], 10);
 				const doseDateOnlyMs = Number.parseInt(match[3], 10);
-				if (Number.isNaN(parsedIntakeIndex) || Number.isNaN(doseDateOnlyMs) || parsedIntakeIndex !== intakeIndex) {
+				if (
+					Number.isNaN(parsedMedicationId) ||
+					Number.isNaN(parsedIntakeIndex) ||
+					Number.isNaN(doseDateOnlyMs) ||
+					parsedMedicationId !== medication.id ||
+					parsedIntakeIndex !== intakeIndex
+				) {
 					continue;
 				}
 
@@ -125,9 +132,16 @@ export function computeMedicationCurrentStock(options: {
 				const match = doseIdPattern.exec(dose.doseId);
 				if (!match) continue;
 
+				const parsedMedicationId = Number.parseInt(match[1], 10);
 				const parsedIntakeIndex = Number.parseInt(match[2], 10);
 				const doseDateOnlyMs = Number.parseInt(match[3], 10);
-				if (Number.isNaN(parsedIntakeIndex) || Number.isNaN(doseDateOnlyMs) || parsedIntakeIndex !== intakeIndex) {
+				if (
+					Number.isNaN(parsedMedicationId) ||
+					Number.isNaN(parsedIntakeIndex) ||
+					Number.isNaN(doseDateOnlyMs) ||
+					parsedMedicationId !== medication.id ||
+					parsedIntakeIndex !== intakeIndex
+				) {
 					continue;
 				}
 

--- a/backend/src/test/e2e-routes.test.ts
+++ b/backend/src/test/e2e-routes.test.ts
@@ -123,6 +123,7 @@ async function createSchema(client: Client) {
 		`CREATE TABLE IF NOT EXISTS user_settings (
       id integer PRIMARY KEY AUTOINCREMENT,
       user_id integer NOT NULL UNIQUE,
+		timezone text NOT NULL DEFAULT '',
       email_enabled integer NOT NULL DEFAULT 0,
       notification_email text,
       email_stock_reminders integer NOT NULL DEFAULT 1,

--- a/backend/src/test/integration.test.ts
+++ b/backend/src/test/integration.test.ts
@@ -117,6 +117,7 @@ async function createSchema(client: Client) {
 		`CREATE TABLE IF NOT EXISTS user_settings (
       id integer PRIMARY KEY AUTOINCREMENT,
       user_id integer NOT NULL UNIQUE,
+		timezone text NOT NULL DEFAULT '',
       email_enabled integer NOT NULL DEFAULT 0,
       notification_email text,
       email_stock_reminders integer NOT NULL DEFAULT 1,

--- a/backend/src/test/planner.test.ts
+++ b/backend/src/test/planner.test.ts
@@ -134,6 +134,7 @@ async function createSchema(client: Client) {
 		`CREATE TABLE IF NOT EXISTS user_settings (
       id integer PRIMARY KEY AUTOINCREMENT,
       user_id integer NOT NULL UNIQUE,
+		timezone text NOT NULL DEFAULT '',
       email_enabled integer NOT NULL DEFAULT 0,
       notification_email text,
       email_stock_reminders integer NOT NULL DEFAULT 1,


### PR DESCRIPTION
Closes #530

## What changed
- filtered parsed dose IDs by medication ID in `computeMedicationCurrentStock`
- prevents cross-medication dose contamination in stock deduction

## Validation
- targeted backend doses tests pass