### PR TITLE
chore: tighten local agent workspace rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,16 @@
 # MedAssist-ng - Copilot Entry Point
 
-## VERY IMPORTANT
+## VERY IMPORTANT - Prioritized Constraints
 
+**First: Update Memory and Reports**
 - Always keep agent work memory updated in `doku/memory_notes.md` so progress and decisions remain recoverable across context loss.
+  - If `doku/memory_notes.md` is missing, create it immediately.
 - Always keep a user-facing work report updated in `doku/report.md` so completed work is easy to review.
+  - If `doku/report.md` is missing, create it immediately.
 - This memory/report rule replaces the previous `doku/APP_BEHAVIOR.md` persistence requirement.
+
+**Second: Follow Governance Rules**
+- Consult `AGENTS.md` for all governance, workflow, and skill rules.
 
 Use `AGENTS.md` as the single source of truth for all governance, workflow, and skill rules.
 

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,14 @@ docs/SPEC_KIT.md
 .github/skills/nodejs-best-practices/
 .github/skills/seo/
 .playwright-mcp
+
+# Local GSD/copilot generated workspace artifacts (not for upstream)
+.github/agents/medassist-feature-orchestrator.agent.md
+.github/agents/speckit.*.agent.md
+.github/get-shit-done/
+.github/gsd-file-manifest.json
+.github/prompts/speckit.*.prompt.md
+.github/skills/gsd-*/
+.planning/
+doku/memory_notes.md
+doku/report.md

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ docs/SPEC_KIT.md
 .playwright-mcp
 
 # Local GSD/copilot generated workspace artifacts (not for upstream)
+.github/agents/copilot-instructions.md
+.github/agents/gsd-*.agent.md
 .github/agents/medassist-feature-orchestrator.agent.md
 .github/agents/speckit.*.agent.md
 .github/get-shit-done/
@@ -119,3 +121,4 @@ docs/SPEC_KIT.md
 .planning/
 doku/memory_notes.md
 doku/report.md
+ops/medtest/


### PR DESCRIPTION
Closes #571

## Summary
- tighten local-only agent workspace instructions
- narrow the tracked ignore rules to generated local artifacts only
