### PR TITLE
fix: expose provider message ids in notification delivery

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -583,7 +583,7 @@ export async function sendShoutrrrNotification(
 	urlStr: string,
 	title: string,
 	message: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; providerMessageId?: string }> {
 	try {
 		if (urlStr.startsWith("pushover://")) {
 			const pushoverAuthority = urlStr.slice("pushover://".length).split("/")[0] ?? "";
@@ -736,7 +736,7 @@ export async function sendShoutrrrNotification(
 		}
 
 		// Use ONLY the reconstructed URL from validation - never the original urlStr
-		const { url: sanitizedUrl, isNtfy: _isNtfy, auth } = validation;
+		const { url: sanitizedUrl, isNtfy, auth } = validation;
 
 		let targetUrl: string;
 		const method = "POST";
@@ -823,7 +823,17 @@ export async function sendShoutrrrNotification(
 		});
 
 		if (response.ok) {
-			return { success: true };
+			let providerMessageId: string | undefined;
+			if (isNtfy) {
+				try {
+					const payload = (await response.json()) as { id?: unknown };
+					providerMessageId = typeof payload.id === "string" && payload.id.length > 0 ? payload.id : undefined;
+				} catch {
+					providerMessageId = undefined;
+				}
+			}
+
+			return { success: true, providerMessageId };
 		} else {
 			const errorText = await response.text();
 			return { success: false, error: `HTTP ${response.status}: ${errorText}` };

--- a/backend/src/services/notifications/delivery.ts
+++ b/backend/src/services/notifications/delivery.ts
@@ -123,13 +123,13 @@ export async function sendPushNotification(
 	url: string,
 	title: string,
 	message: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; providerMessageId?: string }> {
 	try {
 		const result = await sendShoutrrrNotification(url, title, message);
 		if (!result.success) {
 			return { success: false, error: result.error };
 		}
-		return { success: true };
+		return { success: true, providerMessageId: result.providerMessageId };
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : "Unknown error";
 		return { success: false, error: errorMessage };


### PR DESCRIPTION
Closes #601

Refs #600
Refs #591

## Summary
- add `providerMessageId?: string` to the backend notification delivery contract on `main`
- parse the ntfy response id in `sendShoutrrrNotification`
- pass that id through `sendPushNotification` without pulling in the broader ntfy action stack