### PR TITLE
chore: release v1.24.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #617

## Summary
- bump backend and frontend app version from 1.23.0 to 1.24.0
- prepare the minor release for the already-merged ntfy interactive reminder improvements and backend security updates on `main`
- keep the release PR diff limited to `backend/package.json` and `frontend/package.json`

## Validation
- release branch cut from `github/main` at `795aa59a`
- both package manifests parse correctly with version `1.24.0`
- release diff is limited to the two package version fields
