### PR TITLE
chore: release v1.25.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #631

Patch release from current `main`.

Included changes since `v1.25.0`:
- `a95c6e36` fix: preserve ntfy action buttons on reminder replay
- `db602d83` chore: update test count badges [skip ci]

Release branch scope:
- bump `backend/package.json` to `1.25.1`
- bump `frontend/package.json` to `1.25.1`
