### PR TITLE
fix: close report modal on browser back

### DIFF
--- a/frontend/e2e/mobile-modal-history.spec.ts
+++ b/frontend/e2e/mobile-modal-history.spec.ts
@@ -43,6 +43,39 @@ test.describe("Mobile modal browser back", () => {
 		await expect(exportModal).toBeHidden({ timeout: 10000 });
 	});
 
+	test("closes the medication report modal with browser back on mobile", async ({ page }) => {
+		const medicationName = `Mobile Report Back ${Date.now().toString(36)}`;
+
+		await deleteAllMedicationsViaAPI();
+		await createMedicationViaAPI({
+			name: medicationName,
+			takenBy: ["Mobile Report"],
+			packageType: "blister",
+			packCount: 1,
+			blistersPerPack: 1,
+			pillsPerBlister: 10,
+		});
+
+		await page.goto("/medications", { waitUntil: "domcontentloaded" });
+		await expect(page.getByText(medicationName)).toBeVisible({ timeout: 15000 });
+
+		await page
+			.getByRole("button", { name: /Report|Bericht/i })
+			.first()
+			.click();
+		const reportModal = page.locator(".modal-content.report-modal");
+		await expect(reportModal).toBeVisible({ timeout: 10000 });
+
+		const medicationsUrl = page.url();
+		await page.goBack({ waitUntil: "commit", timeout: 10000 }).catch(() => undefined);
+
+		await expect(reportModal).toBeHidden({ timeout: 10000 });
+		await expect(page).toHaveURL(medicationsUrl);
+		await expect(page.getByText(medicationName)).toBeVisible();
+
+		await deleteAllMedicationsViaAPI();
+	});
+
 	test("closes the shared intake journal modal with browser back on mobile", async ({ page }) => {
 		const uniqueSuffix = Date.now().toString(36);
 		const person = `Mobile Journal ${uniqueSuffix}`;

--- a/frontend/src/components/ReportModal.tsx
+++ b/frontend/src/components/ReportModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEscapeKey } from "../hooks/useEscapeKey";
+import { useModalHistory } from "../hooks/useModalHistory";
 import { useScrollLock } from "../hooks/useScrollLock";
 import type { Medication } from "../types";
 import {
@@ -77,6 +78,7 @@ export function ReportModal({ isOpen, onClose, medications }: ReportModalProps) 
 
 	useScrollLock(isOpen);
 	useEscapeKey(isOpen, onClose);
+	useModalHistory(isOpen, "report", onClose);
 
 	// Collect all unique "taken by" people across all medications
 	const allPeople = useMemo(() => {

--- a/frontend/src/pages/MedicationsPage.tsx
+++ b/frontend/src/pages/MedicationsPage.tsx
@@ -489,7 +489,6 @@ export function MedicationsPage() {
 	const [showObsolete, setShowObsolete] = useState(true);
 	const [readOnlyView, setReadOnlyView] = useState(false);
 	const [showReportModal, setShowReportModal] = useState(false);
-	useModalHistory(showReportModal, "report", () => setShowReportModal(false));
 	useModalHistory(!!lightboxImage, "medication-image-lightbox", closeLightbox);
 	useModalHistory(showUnsavedConfirm, "medication-unsaved-confirm", handleCancelClose);
 	const [showNameValidation, setShowNameValidation] = useState(false);

--- a/frontend/src/test/components/ReportModal.test.tsx
+++ b/frontend/src/test/components/ReportModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ReportModal from "../../components/ReportModal";
 import type { Medication } from "../../types";
@@ -56,6 +56,25 @@ describe("ReportModal", () => {
 		expect(screen.getByText(/report\.title/i)).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: /common\.close/i }));
 		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("closes only the report modal when browser back is used", () => {
+		const onClose = vi.fn();
+		const parentPopState = vi.fn();
+		window.addEventListener("popstate", parentPopState);
+
+		try {
+			render(<ReportModal isOpen={true} onClose={onClose} medications={[createMedication()]} />);
+
+			act(() => {
+				window.dispatchEvent(new PopStateEvent("popstate"));
+			});
+
+			expect(onClose).toHaveBeenCalledTimes(1);
+			expect(parentPopState).not.toHaveBeenCalled();
+		} finally {
+			window.removeEventListener("popstate", parentPopState);
+		}
 	});
 
 	it("generates txt and md previews in-app without closing the modal", async () => {


### PR DESCRIPTION
Closes #656

## Summary
- close the report modal when browser history navigates back
- keep the medications page state consistent during modal/back interactions
- add regression coverage for the browser-back flow