### PR TITLE
fix: harden production auth defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,10 +36,13 @@ LOG_LEVEL=info
 # API documentation UI + OpenAPI JSON
 # Docs are served on /docs and /docs/json.
 # Default behavior: enabled outside production, disabled in production.
+# When AUTH_ENABLED=true, docs require authentication by default.
 # Recommended:
 #   development, staging: OPENAPI_DOCS_ENABLED=true
 #   production: leave unset or set OPENAPI_DOCS_ENABLED=false
+#   public staging/prod with docs enabled: keep DOCS_AUTH_REQUIRED=true
 # OPENAPI_DOCS_ENABLED=true
+# DOCS_AUTH_REQUIRED=true
 
 # =============================================================================
 # Authentication

--- a/.env.example
+++ b/.env.example
@@ -42,10 +42,15 @@ LOG_LEVEL=info
 # OPENAPI_DOCS_ENABLED=true
 
 # =============================================================================
-# Authentication (optional - disabled by default for easy setup)
+# Authentication
 # =============================================================================
-# Enable authentication (default: false = open access)
+# Enable authentication. Strongly recommended for every non-local deployment.
+# Production startup is blocked with AUTH_ENABLED=false unless
+# ALLOW_UNAUTHENTICATED=true is set explicitly.
 AUTH_ENABLED=false
+
+# Local/private-only escape hatch. Do not enable this on public deployments.
+# ALLOW_UNAUTHENTICATED=true
 
 # Allow new user registrations (auto-enabled when no users exist)
 # REGISTRATION_ENABLED=false
@@ -53,11 +58,11 @@ AUTH_ENABLED=false
 # Disable username/password form login (useful for OIDC-only setups)
 # FORM_LOGIN_ENABLED=true
 
-# JWT Secrets - REQUIRED when AUTH_ENABLED=true
-# Generate with: openssl rand -hex 32
-# JWT_SECRET=
-# REFRESH_SECRET=
-# COOKIE_SECRET=
+# JWT Secrets - REQUIRED when AUTH_ENABLED=true.
+# Generate unique values for each setting with: openssl rand -hex 32
+# JWT_SECRET=paste-a-unique-64-character-hex-value-here
+# REFRESH_SECRET=paste-a-different-unique-64-character-hex-value-here
+# COOKIE_SECRET=paste-another-unique-64-character-hex-value-here
 
 # Token TTL (optional - defaults shown)
 # ACCESS_TOKEN_TTL_MINUTES=15

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -260,6 +260,18 @@ The version number is displayed in the **About modal** (Settings → About) as a
 - The About modal will show the old version
 - The version link will point to a non-existent GitHub release page
 
+### Production Docker Compose Image Pinning (MANDATORY)
+
+The documented production `docker-compose.yml` must be pinned to the exact release image tags for the release being prepared.
+
+- On every release branch, update both production image references in `docker-compose.yml` from any previous version to the new release image tag.
+- Use the Docker image tag produced by `docker-build.yml` for release tags: `X.Y.Z` without the leading Git tag `v`.
+- Example for release tag `v1.23.0`:
+  - `ghcr.io/danielvolz/medassist-ng-backend:1.23.0`
+  - `ghcr.io/danielvolz/medassist-ng-frontend:1.23.0`
+- Do not leave production `docker-compose.yml` on `:latest` after a release PR. `:latest` may appear only in explicitly labeled floating/latest examples, not in the default production compose file.
+- If the release changes the image-tagging workflow, update these instructions and the user-facing deployment docs in the same release PR.
+
 ### Manual Release
 
 1. Create release branch:
@@ -268,8 +280,9 @@ The version number is displayed in the **About modal** (Settings → About) as a
    git checkout -b chore/release-X.Y.Z
    ```
 2. Update versions in **both** `backend/package.json` and `frontend/package.json` to `X.Y.Z`
-3. Commit, push, create PR, wait for CI, merge (same as Task 1)
-4. Create signed tag:
+3. Update production `docker-compose.yml` image references to `ghcr.io/danielvolz/medassist-ng-backend:X.Y.Z` and `ghcr.io/danielvolz/medassist-ng-frontend:X.Y.Z`
+4. Commit, push, create PR, wait for CI, merge (same as Task 1)
+5. Create signed tag:
    ```bash
    git checkout main && git pull origin main
    git tag -s "vX.Y.Z" -m "Release vX.Y.Z"
@@ -279,6 +292,7 @@ The version number is displayed in the **About modal** (Settings → About) as a
 ### After Tagging
 
 - The `docker-build.yml` workflow automatically builds and pushes Docker images to GHCR with both versioned tags (`1.8.7`, `1.8`) and `latest`.
+- Confirm that the production `docker-compose.yml` image tags in the merged release commit match the pushed release image tag (`X.Y.Z`, without the leading `v`).
 - The `update-test-badges.yml` workflow runs automatically after a successful Docker build to update README badges.
 - Track progress: `https://github.com/DanielVolz/medassist-ng/actions`
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,25 @@ cp .env.example .env
 docker compose -p medassist-ng up -d
 ```
 
+Before running `docker compose`, choose an authentication mode in `.env`.
+
+For non-local deployments, enable authentication:
+
+```bash
+AUTH_ENABLED=true
+JWT_SECRET=<output-of-openssl-rand-hex-32>
+REFRESH_SECRET=<output-of-openssl-rand-hex-32>
+COOKIE_SECRET=<output-of-openssl-rand-hex-32>
+```
+
+For a local/private-only trial that is not reachable from other networks, explicitly set:
+
+```bash
+ALLOW_UNAUTHENTICATED=true
+```
+
+Production startup refuses `AUTH_ENABLED=false` unless that local-only override is present.
+
 Open `http://localhost:4174` and start tracking your medications.
 
 ### Verify Deployment
@@ -196,10 +215,23 @@ Open `http://localhost:4174` and start tracking your medications.
 After the containers start, confirm the stack is actually healthy:
 
 1. Run `docker compose ps` and confirm the `backend` service is `healthy` and the `frontend` service is running.
-2. Open `http://localhost:3000/health` and confirm the backend responds with JSON that includes `"status":"ok"`.
+2. Open `http://localhost:4174/api/health` and confirm the backend responds through the frontend proxy with JSON that includes `"status":"ok"`.
 3. Open `http://localhost:4174` and confirm the app shell loads and can reach the API.
 
 If the frontend loads but API requests fail, check the backend health endpoint first and confirm `CORS_ORIGINS` includes the frontend origin you are using. If you plan to open reminder or share links from another device, set `PUBLIC_APP_URL` to the externally reachable app URL instead of relying on `localhost`.
+
+### Deployment Security
+
+Public deployments must enable `AUTH_ENABLED=true` with local username/password login or OIDC SSO. The default Docker Compose stack exposes only the frontend on `4174`; the backend stays internal on the Docker network and is reached through the frontend `/api` proxy.
+
+Do not expose the backend directly to the Internet. If you need a temporary direct backend port for local debugging, create a local `docker-compose.override.yml` like this and keep the binding on `127.0.0.1`:
+
+```yaml
+services:
+  backend:
+    ports:
+      - "127.0.0.1:4000:3000"
+```
 
 # Configuration
 
@@ -214,6 +246,8 @@ Configure the application with environment variables in `.env`. Keep the basic c
 | `PORT` | `3000` | Backend API port |
 | `CORS_ORIGINS` | `http://localhost:4174` | Allowed frontend origins |
 | `TZ` | `Europe/Berlin` | Default timezone for reminders |
+| `AUTH_ENABLED` | `false` | Enable authentication; required for public production deployments |
+| `ALLOW_UNAUTHENTICATED` | `false` | Explicit local/private-only override for production no-auth startup |
 
 Optional but commonly needed:
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ If the frontend loads but API requests fail, check the backend health endpoint f
 
 Public deployments must enable `AUTH_ENABLED=true` with local username/password login or OIDC SSO. The default Docker Compose stack exposes only the frontend on `4174`; the backend stays internal on the Docker network and is reached through the frontend `/api` proxy.
 
+OpenAPI docs are disabled by default in production. If you explicitly enable `/docs` or `/docs/json` on an authenticated staging or production deployment, keep `DOCS_AUTH_REQUIRED=true` or place the docs behind a private network boundary.
+
 Do not expose the backend directly to the Internet. If you need a temporary direct backend port for local debugging, create a local `docker-compose.override.yml` like this and keep the binding on `127.0.0.1`:
 
 ```yaml

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "NODE_ENV=development tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "migrate": "tsx src/db/migrate.ts",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,11 +9,10 @@ import fastifyMultipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import sensible from "@fastify/sensible";
 import fastifyStatic from "@fastify/static";
-import fastifySwagger from "@fastify/swagger";
-import fastifySwaggerUi from "@fastify/swagger-ui";
 import Fastify, { type FastifyInstance } from "fastify";
 import { migrationsReady } from "./db/client.js";
 import { getDataDir } from "./db/db-utils.js";
+import { registerApiDocs } from "./plugins/api-docs.js";
 import { env } from "./plugins/env.js";
 import { jwtPlugin } from "./plugins/jwt.js";
 import { apiKeyRoutes } from "./routes/api-keys.js";
@@ -94,57 +93,6 @@ function isPublicNotificationActionPath(url: string | undefined): boolean {
 	return /(^|\/)(api\/)?notification-actions(\/|$)/.test(normalizedUrl);
 }
 
-async function registerApiDocs(app: FastifyInstance, enabled: boolean) {
-	if (!enabled) return;
-
-	await app.register(fastifySwagger, {
-		openapi: {
-			openapi: "3.0.3",
-			info: {
-				title: "MedAssist-ng API",
-				description: "MedAssist-ng backend API",
-				version: process.env.npm_package_version ?? "dev",
-			},
-			servers: [{ url: "/", description: "Current server" }],
-			tags: [
-				{ name: "health", description: "Service health endpoints" },
-				{ name: "auth", description: "Authentication and profile endpoints" },
-				{ name: "api-keys", description: "Programmatic API key management" },
-				{ name: "intake-journal", description: "Owner-only intake journal CRUD and history endpoints" },
-				{ name: "medication-enrichment", description: "Medication search and enrichment endpoints" },
-				{ name: "settings", description: "User settings and notification test endpoints" },
-			],
-			components: {
-				securitySchemes: {
-					bearerAuth: {
-						type: "http",
-						scheme: "bearer",
-						bearerFormat: "API key or JWT",
-						description: "Use Authorization: Bearer ma_... (API key) or a JWT token.",
-					},
-					cookieAuth: {
-						type: "apiKey",
-						in: "cookie",
-						name: "access_token",
-						description: "Session cookie set by login.",
-					},
-				},
-			},
-		},
-		hideUntagged: false,
-	});
-
-	await app.register(fastifySwaggerUi, {
-		routePrefix: "/docs",
-		staticCSP: true,
-		transformSpecificationClone: true,
-		uiConfig: {
-			docExpansion: "list",
-			deepLinking: false,
-		},
-	});
-}
-
 /** Create and configure Fastify app (without starting) */
 export async function createApp(options?: {
 	logLevel?: string;
@@ -158,6 +106,7 @@ export async function createApp(options?: {
 	isProduction?: boolean;
 	imagesDir?: string;
 	openApiDocsEnabled?: boolean;
+	docsAuthRequired?: boolean;
 }): Promise<FastifyInstance> {
 	const opts = {
 		logLevel: options?.logLevel ?? "info",
@@ -171,6 +120,7 @@ export async function createApp(options?: {
 		isProduction: options?.isProduction ?? false,
 		imagesDir: options?.imagesDir ?? resolve(getDataDir(), "images"),
 		openApiDocsEnabled: options?.openApiDocsEnabled ?? false,
+		docsAuthRequired: options?.docsAuthRequired ?? options?.authEnabled ?? false,
 	};
 
 	const app = Fastify({
@@ -227,7 +177,10 @@ export async function createApp(options?: {
 	await app.register(jwtPlugin, jwtConfig);
 
 	await app.register(fastifyMultipart, { limits: { fileSize: 10 * 1024 * 1024 } });
-	await registerApiDocs(app, opts.openApiDocsEnabled);
+	await registerApiDocs(app, {
+		enabled: opts.openApiDocsEnabled,
+		authRequired: opts.docsAuthRequired,
+	});
 
 	// Only register static if directory exists
 	if (existsSync(opts.imagesDir)) {
@@ -334,13 +287,15 @@ const jwtConfig = getJwtConfig(env.AUTH_ENABLED, env.JWT_SECRET);
 await app.register(jwtPlugin, jwtConfig);
 
 await app.register(fastifyMultipart, { limits: { fileSize: 10 * 1024 * 1024 } }); // 10MB limit
-await registerApiDocs(app, env.OPENAPI_DOCS_ENABLED);
+await registerApiDocs(app, {
+	enabled: env.OPENAPI_DOCS_ENABLED,
+	authRequired: env.DOCS_AUTH_REQUIRED,
+});
 await app.register(fastifyStatic, {
 	root: imagesDir,
 	prefix: "/images/",
 	decorateReply: false,
 });
-
 await app.register(healthRoutes);
 await app.register(authRoutes);
 await app.register(apiKeyRoutes);

--- a/backend/src/plugins/api-docs.ts
+++ b/backend/src/plugins/api-docs.ts
@@ -1,0 +1,74 @@
+import fastifySwagger from "@fastify/swagger";
+import fastifySwaggerUi from "@fastify/swagger-ui";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { requireAuth } from "./auth.js";
+
+export interface ApiDocsOptions {
+	enabled: boolean;
+	authRequired: boolean;
+}
+
+function isDocsPath(url: string | undefined): boolean {
+	const pathname = url?.split("?")[0] ?? "";
+	return pathname === "/docs" || pathname.startsWith("/docs/");
+}
+
+async function requireDocsAuth(request: FastifyRequest, reply: FastifyReply) {
+	if (!isDocsPath(request.raw.url)) return;
+	await requireAuth(request, reply);
+}
+
+export async function registerApiDocs(app: FastifyInstance, options: ApiDocsOptions) {
+	if (!options.enabled) return;
+
+	if (options.authRequired) {
+		app.addHook("preHandler", requireDocsAuth);
+	}
+
+	await app.register(fastifySwagger, {
+		openapi: {
+			openapi: "3.0.3",
+			info: {
+				title: "MedAssist-ng API",
+				description: "MedAssist-ng backend API",
+				version: process.env.npm_package_version ?? "dev",
+			},
+			servers: [{ url: "/", description: "Current server" }],
+			tags: [
+				{ name: "health", description: "Service health endpoints" },
+				{ name: "auth", description: "Authentication and profile endpoints" },
+				{ name: "api-keys", description: "Programmatic API key management" },
+				{ name: "intake-journal", description: "Owner-only intake journal CRUD and history endpoints" },
+				{ name: "medication-enrichment", description: "Medication search and enrichment endpoints" },
+				{ name: "settings", description: "User settings and notification test endpoints" },
+			],
+			components: {
+				securitySchemes: {
+					bearerAuth: {
+						type: "http",
+						scheme: "bearer",
+						bearerFormat: "API key or JWT",
+						description: "Use Authorization: Bearer ma_... (API key) or a JWT token.",
+					},
+					cookieAuth: {
+						type: "apiKey",
+						in: "cookie",
+						name: "access_token",
+						description: "Session cookie set by login.",
+					},
+				},
+			},
+		},
+		hideUntagged: false,
+	});
+
+	await app.register(fastifySwaggerUi, {
+		routePrefix: "/docs",
+		staticCSP: true,
+		transformSpecificationClone: true,
+		uiConfig: {
+			docExpansion: "list",
+			deepLinking: false,
+		},
+	});
+}

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -19,6 +19,10 @@ const EnvSchema = z.object({
 		.string()
 		.transform((v) => v === "true")
 		.optional(),
+	DOCS_AUTH_REQUIRED: z
+		.string()
+		.transform((v) => v === "true")
+		.optional(),
 
 	// ==========================================================================
 	// Auth Configuration
@@ -82,6 +86,7 @@ const EnvSchema = z.object({
 type ParsedEnv = z.infer<typeof EnvSchema>;
 export type Env = ParsedEnv & {
 	OPENAPI_DOCS_ENABLED: boolean;
+	DOCS_AUTH_REQUIRED: boolean;
 };
 
 // Parse and validate
@@ -189,4 +194,6 @@ export const env: Env = {
 	...parsed,
 	// Docs UI/spec are enabled in non-production by default.
 	OPENAPI_DOCS_ENABLED: parsed.OPENAPI_DOCS_ENABLED ?? parsed.NODE_ENV !== "production",
+	// Authenticated deployments protect docs by default when docs are enabled.
+	DOCS_AUTH_REQUIRED: parsed.DOCS_AUTH_REQUIRED ?? parsed.AUTH_ENABLED,
 };

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -28,6 +28,11 @@ const EnvSchema = z.object({
 		.string()
 		.default("false")
 		.transform((v) => v === "true"),
+	// Explicit production-only escape hatch for private/local no-auth deployments.
+	ALLOW_UNAUTHENTICATED: z
+		.string()
+		.default("false")
+		.transform((v) => v === "true"),
 	// Allow new user registrations (auto-enabled if no users exist)
 	REGISTRATION_ENABLED: z
 		.string()
@@ -89,6 +94,24 @@ try {
 	console.error("=".repeat(60));
 	console.error(err);
 	console.error("\nPlease check your .env file or environment variables.");
+	console.error("=".repeat(60));
+	process.exit(1);
+}
+
+// Prevent accidental public production deployments without authentication.
+if (parsed.NODE_ENV === "production" && !parsed.AUTH_ENABLED && !parsed.ALLOW_UNAUTHENTICATED) {
+	console.error("=".repeat(60));
+	console.error("AUTHENTICATION CONFIGURATION ERROR");
+	console.error("=".repeat(60));
+	console.error("Refusing to start MedAssist-ng in production with AUTH_ENABLED=false.");
+	console.error(
+		"MedAssist-ng handles health-related personal data, so production deployments must enable authentication."
+	);
+	console.error("");
+	console.error("To fix this, either:");
+	console.error("  1. Set AUTH_ENABLED=true and configure JWT_SECRET, REFRESH_SECRET, and COOKIE_SECRET.");
+	console.error("  2. Enable OIDC with AUTH_ENABLED=true and OIDC_ENABLED=true.");
+	console.error("  3. For local/private-only deployments, explicitly set ALLOW_UNAUTHENTICATED=true.");
 	console.error("=".repeat(60));
 	process.exit(1);
 }

--- a/backend/src/test/api-docs.test.ts
+++ b/backend/src/test/api-docs.test.ts
@@ -1,0 +1,179 @@
+import cookie from "@fastify/cookie";
+import type { Client } from "@libsql/client";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { jwtPlugin } from "../plugins/jwt.js";
+import { documentationSchemaAjv } from "../utils/documentation-schema-keywords.js";
+
+const { testClient, testDb } = vi.hoisted(() => {
+	const { createClient } = require("@libsql/client");
+	const { drizzle } = require("drizzle-orm/libsql");
+	const client = createClient({ url: ":memory:" });
+	const db = drizzle(client);
+	return { testClient: client, testDb: db };
+});
+
+vi.mock("../db/client.js", () => ({
+	db: testDb,
+	migrationsReady: Promise.resolve(),
+}));
+
+vi.mock("../plugins/env.js", () => ({
+	env: {
+		AUTH_ENABLED: true,
+		FORM_LOGIN_ENABLED: true,
+		REGISTRATION_ENABLED: true,
+		OIDC_ENABLED: false,
+		NODE_ENV: "test",
+		LOG_LEVEL: "silent",
+		PORT: 3000,
+		CORS_ORIGINS: "*",
+		JWT_SECRET: "test-jwt-secret-12345",
+		REFRESH_SECRET: "test-refresh-secret-12345",
+		COOKIE_SECRET: "test-cookie-secret-12345",
+		ACCESS_TOKEN_TTL_MINUTES: 15,
+		REFRESH_TOKEN_TTL_DAYS: 7,
+		OPENAPI_DOCS_ENABLED: true,
+		DOCS_AUTH_REQUIRED: true,
+	},
+}));
+
+const { registerApiDocs } = await import("../plugins/api-docs.js");
+
+async function createSchema(client: Client) {
+	await client.execute(`
+		CREATE TABLE IF NOT EXISTS users (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			username text NOT NULL UNIQUE,
+			password_hash text,
+			avatar_url text,
+			auth_provider text NOT NULL DEFAULT 'local',
+			oidc_subject text,
+			is_active integer NOT NULL DEFAULT 1,
+			last_login_at integer,
+			created_at integer NOT NULL DEFAULT (strftime('%s','now')),
+			updated_at integer NOT NULL DEFAULT (strftime('%s','now'))
+		)
+	`);
+}
+
+async function clearData(client: Client) {
+	await client.execute("DELETE FROM users");
+	await client.execute("DELETE FROM sqlite_sequence");
+}
+
+async function buildDocsApp(options: { docsEnabled: boolean; docsAuthRequired: boolean }): Promise<FastifyInstance> {
+	const app = Fastify({ logger: false, ajv: documentationSchemaAjv });
+	await app.register(cookie, { secret: "test-cookie-secret-12345" });
+	await app.register(jwtPlugin, {
+		secret: "test-jwt-secret-12345",
+		cookie: { cookieName: "access_token", signed: false },
+	});
+	app.decorate("config", {
+		accessSecret: "test-jwt-secret-12345",
+		refreshSecret: "test-refresh-secret-12345",
+		accessTtl: 15,
+		refreshTtl: 7,
+		cookieOptions: { httpOnly: true, sameSite: "lax", secure: false, path: "/", maxAge: 15 * 60 },
+		refreshCookieOptions: { httpOnly: true, sameSite: "lax", secure: false, path: "/auth", maxAge: 7 * 24 * 60 * 60 },
+	});
+	await registerApiDocs(app, {
+		enabled: options.docsEnabled,
+		authRequired: options.docsAuthRequired,
+	});
+	await app.ready();
+	return app;
+}
+
+async function createActiveUser(client: Client): Promise<{ id: number; username: string }> {
+	const username = "docsuser";
+	await client.execute({
+		sql: "INSERT INTO users (username, password_hash, auth_provider, is_active) VALUES (?, ?, ?, ?)",
+		args: [username, "unused", "local", 1],
+	});
+
+	const result = await client.execute({
+		sql: "SELECT id, username FROM users WHERE username = ?",
+		args: [username],
+	});
+	const row = result.rows[0];
+	return { id: Number(row.id), username: String(row.username) };
+}
+
+describe("OpenAPI docs protection", () => {
+	beforeAll(async () => {
+		await createSchema(testClient);
+	});
+
+	afterAll(() => {
+		testClient.close();
+	});
+
+	it("returns 404 when docs are disabled", async () => {
+		const app = await buildDocsApp({ docsEnabled: false, docsAuthRequired: false });
+
+		try {
+			const response = await app.inject({ method: "GET", url: "/docs/json" });
+
+			expect(response.statusCode).toBe(404);
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("rejects anonymous docs access when docs auth is required", async () => {
+		const app = await buildDocsApp({ docsEnabled: true, docsAuthRequired: true });
+
+		try {
+			const docsResponse = await app.inject({ method: "GET", url: "/docs" });
+			const jsonResponse = await app.inject({ method: "GET", url: "/docs/json" });
+
+			expect(docsResponse.statusCode).toBe(401);
+			expect(docsResponse.json()).toEqual({ error: "Authentication required", code: "AUTH_REQUIRED" });
+			expect(jsonResponse.statusCode).toBe(401);
+			expect(jsonResponse.json()).toEqual({ error: "Authentication required", code: "AUTH_REQUIRED" });
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("allows authenticated docs access when docs auth is required", async () => {
+		await clearData(testClient);
+		const app = await buildDocsApp({ docsEnabled: true, docsAuthRequired: true });
+
+		try {
+			const user = await createActiveUser(testClient);
+			const token = await app.jwt.sign({ sub: user.id, username: user.username }, { expiresIn: "15m" });
+
+			const response = await app.inject({
+				method: "GET",
+				url: "/docs/json",
+				cookies: { access_token: token },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json()).toMatchObject({
+				openapi: "3.0.3",
+				info: { title: "MedAssist-ng API" },
+			});
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("allows anonymous docs access when docs auth is explicitly disabled", async () => {
+		const app = await buildDocsApp({ docsEnabled: true, docsAuthRequired: false });
+
+		try {
+			const response = await app.inject({ method: "GET", url: "/docs/json" });
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json()).toMatchObject({
+				openapi: "3.0.3",
+				info: { title: "MedAssist-ng API" },
+			});
+		} finally {
+			await app.close();
+		}
+	});
+});

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -30,6 +30,10 @@ describe("plugins/env runtime validation", () => {
 		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
 		expect(mod.env.OIDC_ENABLED).toBe(false);
 		expect(mod.env.PORT).toBe(3000);
+		expect(mod.env.SHARE_TOKEN_TTL_DAYS).toBe(90);
+		expect(mod.env.SENSITIVE_LOGGING_ENABLED).toBe(false);
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
 	});
 
 	it("exits when production auth is disabled without explicit unauthenticated override", async () => {
@@ -55,6 +59,36 @@ describe("plugins/env runtime validation", () => {
 		expect(mod.env.NODE_ENV).toBe("production");
 		expect(mod.env.AUTH_ENABLED).toBe(false);
 		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(true);
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(false);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
+	});
+
+	it("requires docs auth by default when auth is enabled", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.OPENAPI_DOCS_ENABLED = "true";
+		delete process.env.DOCS_AUTH_REQUIRED;
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(true);
+	});
+
+	it("allows docs auth to be explicitly disabled", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.OPENAPI_DOCS_ENABLED = "true";
+		process.env.DOCS_AUTH_REQUIRED = "false";
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
 	});
 
 	it("loads when development auth is disabled", async () => {

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -30,8 +30,6 @@ describe("plugins/env runtime validation", () => {
 		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
 		expect(mod.env.OIDC_ENABLED).toBe(false);
 		expect(mod.env.PORT).toBe(3000);
-		expect(mod.env.SHARE_TOKEN_TTL_DAYS).toBe(90);
-		expect(mod.env.SENSITIVE_LOGGING_ENABLED).toBe(false);
 		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
 		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
 	});

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -17,7 +17,9 @@ describe("plugins/env runtime validation", () => {
 	});
 
 	it("loads with defaults when auth and oidc are disabled", async () => {
+		process.env.NODE_ENV = "test";
 		delete process.env.AUTH_ENABLED;
+		delete process.env.ALLOW_UNAUTHENTICATED;
 		delete process.env.OIDC_ENABLED;
 		delete process.env.JWT_SECRET;
 		delete process.env.REFRESH_SECRET;
@@ -25,11 +27,50 @@ describe("plugins/env runtime validation", () => {
 
 		const mod = await import("../plugins/env.js");
 		expect(mod.env.AUTH_ENABLED).toBe(false);
+		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
 		expect(mod.env.OIDC_ENABLED).toBe(false);
 		expect(mod.env.PORT).toBe(3000);
 	});
 
+	it("exits when production auth is disabled without explicit unauthenticated override", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "false";
+		delete process.env.ALLOW_UNAUTHENTICATED;
+		delete process.env.OIDC_ENABLED;
+
+		vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as never);
+
+		await expect(import("../plugins/env.js")).rejects.toThrow("process.exit:1");
+	});
+
+	it("loads when production auth is disabled with explicit unauthenticated override", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "false";
+		process.env.ALLOW_UNAUTHENTICATED = "true";
+		delete process.env.OIDC_ENABLED;
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.NODE_ENV).toBe("production");
+		expect(mod.env.AUTH_ENABLED).toBe(false);
+		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(true);
+	});
+
+	it("loads when development auth is disabled", async () => {
+		process.env.NODE_ENV = "development";
+		process.env.AUTH_ENABLED = "false";
+		delete process.env.ALLOW_UNAUTHENTICATED;
+		delete process.env.OIDC_ENABLED;
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.NODE_ENV).toBe("development");
+		expect(mod.env.AUTH_ENABLED).toBe(false);
+		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
+	});
+
 	it("exits when auth is enabled but secrets are missing", async () => {
+		process.env.NODE_ENV = "production";
 		process.env.AUTH_ENABLED = "true";
 		delete process.env.JWT_SECRET;
 		delete process.env.REFRESH_SECRET;

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -19,6 +19,10 @@ const EnvSchema = z.object({
 		.string()
 		.default("false")
 		.transform((v) => v === "true"),
+	ALLOW_UNAUTHENTICATED: z
+		.string()
+		.default("false")
+		.transform((v) => v === "true"),
 	REGISTRATION_ENABLED: z
 		.string()
 		.default("false")
@@ -84,6 +88,7 @@ describe("EnvSchema", () => {
 			expect(result.LOG_LEVEL).toBe("info");
 			expect(result.PUBLIC_APP_URL).toBeUndefined();
 			expect(result.AUTH_ENABLED).toBe(false);
+			expect(result.ALLOW_UNAUTHENTICATED).toBe(false);
 			expect(result.REGISTRATION_ENABLED).toBe(false);
 			expect(result.ACCESS_TOKEN_TTL_MINUTES).toBe(15);
 			expect(result.REFRESH_TOKEN_TTL_DAYS).toBe(7);
@@ -138,6 +143,16 @@ describe("EnvSchema", () => {
 		it("should transform AUTH_ENABLED=false to boolean false", () => {
 			const result = EnvSchema.parse({ AUTH_ENABLED: "false" });
 			expect(result.AUTH_ENABLED).toBe(false);
+		});
+
+		it("should transform ALLOW_UNAUTHENTICATED=true to boolean true", () => {
+			const result = EnvSchema.parse({ ALLOW_UNAUTHENTICATED: "true" });
+			expect(result.ALLOW_UNAUTHENTICATED).toBe(true);
+		});
+
+		it("should transform ALLOW_UNAUTHENTICATED=false to boolean false", () => {
+			const result = EnvSchema.parse({ ALLOW_UNAUTHENTICATED: "false" });
+			expect(result.ALLOW_UNAUTHENTICATED).toBe(false);
 		});
 
 		it("should treat non-true string as false", () => {

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -15,6 +15,14 @@ const EnvSchema = z.object({
 	CORS_ORIGINS: z.string().default("http://localhost:5173,http://localhost:4173"),
 	LOG_LEVEL: z.string().default("info"),
 	PUBLIC_APP_URL: z.string().url().optional(),
+	OPENAPI_DOCS_ENABLED: z
+		.string()
+		.transform((v) => v === "true")
+		.optional(),
+	DOCS_AUTH_REQUIRED: z
+		.string()
+		.transform((v) => v === "true")
+		.optional(),
 	AUTH_ENABLED: z
 		.string()
 		.default("false")
@@ -87,6 +95,8 @@ describe("EnvSchema", () => {
 			expect(result.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4173");
 			expect(result.LOG_LEVEL).toBe("info");
 			expect(result.PUBLIC_APP_URL).toBeUndefined();
+			expect(result.OPENAPI_DOCS_ENABLED).toBeUndefined();
+			expect(result.DOCS_AUTH_REQUIRED).toBeUndefined();
 			expect(result.AUTH_ENABLED).toBe(false);
 			expect(result.ALLOW_UNAUTHENTICATED).toBe(false);
 			expect(result.REGISTRATION_ENABLED).toBe(false);
@@ -173,6 +183,13 @@ describe("EnvSchema", () => {
 		it("should transform OIDC_AUTO_CREATE_USERS correctly", () => {
 			expect(EnvSchema.parse({ OIDC_AUTO_CREATE_USERS: "true" }).OIDC_AUTO_CREATE_USERS).toBe(true);
 			expect(EnvSchema.parse({ OIDC_AUTO_CREATE_USERS: "false" }).OIDC_AUTO_CREATE_USERS).toBe(false);
+		});
+
+		it("should transform API docs booleans correctly", () => {
+			expect(EnvSchema.parse({ OPENAPI_DOCS_ENABLED: "true" }).OPENAPI_DOCS_ENABLED).toBe(true);
+			expect(EnvSchema.parse({ OPENAPI_DOCS_ENABLED: "false" }).OPENAPI_DOCS_ENABLED).toBe(false);
+			expect(EnvSchema.parse({ DOCS_AUTH_REQUIRED: "true" }).DOCS_AUTH_REQUIRED).toBe(true);
+			expect(EnvSchema.parse({ DOCS_AUTH_REQUIRED: "false" }).DOCS_AUTH_REQUIRED).toBe(false);
 		});
 	});
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - DATA_DIR=/app/data
     volumes:
       - ./data:/app/data
-    ports:
-      - "4000:3000"
+    expose:
+      - "3000"
     networks:
       - medassist-ng-net
     # Security options

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,7 +32,8 @@ API docs behavior:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AUTH_ENABLED` | `false` | Enable user authentication |
+| `AUTH_ENABLED` | `false` | Enable user authentication. Required for public production deployments. |
+| `ALLOW_UNAUTHENTICATED` | `false` | Explicit local/private-only escape hatch that allows production startup with `AUTH_ENABLED=false` |
 | `REGISTRATION_ENABLED` | `false` | Allow new user registrations |
 | `FORM_LOGIN_ENABLED` | `true` | Enable username/password login |
 | `JWT_SECRET` | — | Access token signing key; required when auth is enabled |
@@ -42,6 +43,23 @@ API docs behavior:
 | `REFRESH_TOKEN_TTL_DAYS` | `7` | Refresh token lifetime |
 
 Generate secrets with `openssl rand -hex 32`.
+
+Production startup fails fast when `NODE_ENV=production`, `AUTH_ENABLED=false`, and `ALLOW_UNAUTHENTICATED` is not `true`. This protects health-related personal data from accidental unauthenticated public deployments.
+
+For public deployments, enable `AUTH_ENABLED=true` and configure local form login or OIDC SSO. If you run a private local-only instance without authentication, set `ALLOW_UNAUTHENTICATED=true` deliberately and keep the app off untrusted networks.
+
+## Backend Exposure
+
+The default Docker Compose stack exposes only the frontend. The backend listens on the internal Docker network and is reached through the frontend `/api` proxy.
+
+Do not publish the backend directly to the Internet. For local debugging only, create a local `docker-compose.override.yml` with a loopback-only binding:
+
+```yaml
+services:
+  backend:
+    ports:
+      - "127.0.0.1:4000:3000"
+```
 
 ## API Keys
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,12 +15,15 @@ Configure MedAssist with environment variables in `.env`. Start from `.env.examp
 | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error`, or `silent` |
 | `RATE_LIMIT_MAX` | `100` | Maximum requests per minute per IP |
 | `OPENAPI_DOCS_ENABLED` | `auto` | Explicitly enable or disable `/docs` and `/docs/json` |
+| `DOCS_AUTH_REQUIRED` | `auto` | Require authentication for enabled docs; defaults to `true` when `AUTH_ENABLED=true` |
 
 API docs behavior:
 
 - If `OPENAPI_DOCS_ENABLED` is unset, docs are enabled outside production and disabled in production.
 - `OPENAPI_DOCS_ENABLED=true` enables `/docs` and `/docs/json`.
 - `OPENAPI_DOCS_ENABLED=false` disables the docs only.
+- If `DOCS_AUTH_REQUIRED` is unset, authenticated deployments require login/API authentication for `/docs` and `/docs/json`.
+- Keep production docs disabled unless you specifically need them. If docs are enabled in public staging or production, protect them with authentication or a network boundary.
 
 `CORS_ORIGINS` note:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,6 +12,7 @@ docker compose -p medassist-dev -f docker-compose.dev.yml up
 - Backend: `http://localhost:3000`
 - API docs UI: `http://localhost:3000/docs` when docs are enabled
 - OpenAPI JSON: `http://localhost:3000/docs/json` when docs are enabled
+- Docs are open in no-auth local development; authenticated setups protect docs by default unless `DOCS_AUTH_REQUIRED=false` is set.
 
 ## Frontend Dev Server Behind a Proxy
 


### PR DESCRIPTION
Closes #657

## Summary
- require explicit opt-in for unauthenticated production startup
- protect enabled OpenAPI docs with auth-aware defaults
- document production compose image pinning and deployment expectations