### PR TITLE
fix(auth): make login failures enumeration-resistant

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -94,6 +94,14 @@ const authErrorSchema = {
 	},
 };
 
+const invalidCredentialsResponse = { error: "Invalid username or password", code: "INVALID_CREDENTIALS" } as const;
+
+type LoginFailureReason = "missing_user" | "wrong_password" | "inactive_account" | "sso_only_account";
+
+async function performDummyCredentialWork() {
+	await argon2.hash("dummy", ARGON2_OPTIONS);
+}
+
 function normalizeDateTime(value: unknown): string | null {
 	if (value == null) {
 		return null;
@@ -329,28 +337,35 @@ export async function authRoutes(app: FastifyInstance) {
 			const [user] = await db.select().from(users).where(sql`lower(${users.username}) = lower(${username})`);
 
 			// Generic error to prevent user enumeration
-			const invalidCredentialsError = () =>
-				reply.status(401).send({ error: "Invalid username or password", code: "INVALID_CREDENTIALS" });
+			const invalidCredentialsError = (reason: LoginFailureReason, rejectedUser?: typeof users.$inferSelect) => {
+				app.log.warn(
+					{ reason, username, userId: rejectedUser?.id },
+					"[Auth] Login rejected with invalid credentials response"
+				);
+				return reply.status(401).send(invalidCredentialsResponse);
+			};
 
 			if (!user) {
 				// Perform dummy hash to prevent timing attacks
-				await argon2.hash("dummy", ARGON2_OPTIONS);
-				return invalidCredentialsError();
+				await performDummyCredentialWork();
+				return invalidCredentialsError("missing_user");
 			}
 
 			if (!user.isActive) {
-				return reply.status(401).send({ error: "Account disabled", code: "ACCOUNT_DISABLED" });
+				await performDummyCredentialWork();
+				return invalidCredentialsError("inactive_account", user);
 			}
 
 			if (!user.passwordHash) {
 				// SSO-only user trying local login
-				return reply.status(401).send({ error: "Please use SSO to login", code: "SSO_ONLY" });
+				await performDummyCredentialWork();
+				return invalidCredentialsError("sso_only_account", user);
 			}
 
 			// Verify password
 			const valid = await argon2.verify(user.passwordHash, password, ARGON2_OPTIONS);
 			if (!valid) {
-				return invalidCredentialsError();
+				return invalidCredentialsError("wrong_password", user);
 			}
 
 			// Update last login

--- a/backend/src/test/auth.test.ts
+++ b/backend/src/test/auth.test.ts
@@ -5,6 +5,7 @@
 import cookie from "@fastify/cookie";
 import sensible from "@fastify/sensible";
 import type { Client } from "@libsql/client";
+import argon2 from "argon2";
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { jwtPlugin } from "../plugins/jwt.js";
@@ -87,6 +88,8 @@ async function clearData(client: Client) {
 	await client.execute("DELETE FROM users");
 	await client.execute("DELETE FROM sqlite_sequence");
 }
+
+const invalidCredentialsResponse = { error: "Invalid username or password", code: "INVALID_CREDENTIALS" } as const;
 
 // =============================================================================
 // Tests
@@ -376,7 +379,7 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 			});
 
 			expect(response.statusCode).toBe(401);
-			expect(response.json().code).toBe("INVALID_CREDENTIALS");
+			expect(response.json()).toEqual(invalidCredentialsResponse);
 		});
 
 		it("should reject non-existent user", async () => {
@@ -390,7 +393,75 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 			});
 
 			expect(response.statusCode).toBe(401);
-			expect(response.json().code).toBe("INVALID_CREDENTIALS");
+			expect(response.json()).toEqual(invalidCredentialsResponse);
+		});
+
+		it("should perform dummy hash work for non-existent users", async () => {
+			const hashSpy = vi.spyOn(argon2, "hash");
+
+			const response = await app.inject({
+				method: "POST",
+				url: "/auth/login",
+				payload: {
+					username: "nonexistent",
+					password: "TestPassword123",
+				},
+			});
+
+			expect(response.statusCode).toBe(401);
+			expect(response.json()).toEqual(invalidCredentialsResponse);
+			expect(hashSpy).toHaveBeenCalledWith(
+				"dummy",
+				expect.objectContaining({
+					memoryCost: 65536,
+					timeCost: 3,
+					parallelism: 4,
+				})
+			);
+
+			hashSpy.mockRestore();
+		});
+
+		it("should return identical login failure responses for missing, wrong-password, inactive, and SSO-only users", async () => {
+			await app.inject({
+				method: "POST",
+				url: "/auth/register",
+				payload: {
+					username: "inactiveuser",
+					password: "TestPassword123",
+				},
+			});
+
+			await testClient.execute({
+				sql: "UPDATE users SET is_active = 0 WHERE username = ?",
+				args: ["inactiveuser"],
+			});
+
+			await testClient.execute({
+				sql: `
+					INSERT INTO users (username, password_hash, auth_provider, oidc_subject, is_active)
+					VALUES (?, ?, ?, ?, ?)
+				`,
+				args: ["ssouser", null, "oidc", "oidc-subject-1", 1],
+			});
+
+			const loginAttempts = [
+				{ username: "nonexistent", password: "TestPassword123" },
+				{ username: "loginuser", password: "WrongPassword" },
+				{ username: "inactiveuser", password: "TestPassword123" },
+				{ username: "ssouser", password: "TestPassword123" },
+			];
+
+			for (const payload of loginAttempts) {
+				const response = await app.inject({
+					method: "POST",
+					url: "/auth/login",
+					payload,
+				});
+
+				expect(response.statusCode).toBe(401);
+				expect(response.json()).toEqual(invalidCredentialsResponse);
+			}
 		});
 
 		it("should login successfully when username has leading/trailing whitespace", async () => {
@@ -656,7 +727,7 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 			});
 
 			expect(response.statusCode).toBe(401);
-			expect(response.json().code).toBe("ACCOUNT_DISABLED");
+			expect(response.json()).toEqual(invalidCredentialsResponse);
 		});
 	});
 


### PR DESCRIPTION
Closes #654

## Summary
- return a uniform login failure response for invalid, inactive, and SSO-only accounts
- keep internal failure reasons in server logs only
- add focused auth regression coverage