### PR TITLE
fix: protect image serving

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
 import type { IncomingHttpHeaders } from "node:http";
 import { resolve } from "node:path";
 import cookie from "@fastify/cookie";
@@ -8,7 +7,6 @@ import helmet from "@fastify/helmet";
 import fastifyMultipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import sensible from "@fastify/sensible";
-import fastifyStatic from "@fastify/static";
 import Fastify, { type FastifyInstance } from "fastify";
 import { migrationsReady } from "./db/client.js";
 import { getDataDir } from "./db/db-utils.js";
@@ -20,6 +18,7 @@ import { authRoutes } from "./routes/auth.js";
 import { doseRoutes } from "./routes/doses.js";
 import { exportRoutes } from "./routes/export.js";
 import { healthRoutes } from "./routes/health.js";
+import { imageRoutes } from "./routes/images.js";
 import { intakeJournalRoutes } from "./routes/intake-journal.js";
 import { medicationEnrichmentRoutes } from "./routes/medication-enrichment.js";
 import { medicationRoutes } from "./routes/medications.js";
@@ -203,16 +202,8 @@ export async function createApp(options?: {
 		authRequired: opts.docsAuthRequired,
 	});
 
-	// Only register static if directory exists
-	if (existsSync(opts.imagesDir)) {
-		await app.register(fastifyStatic, {
-			root: opts.imagesDir,
-			prefix: "/images/",
-			decorateReply: false,
-		});
-	}
-
 	// Register routes
+	await app.register(imageRoutes, { imagesDir: opts.imagesDir });
 	await app.register(healthRoutes);
 	await app.register(authRoutes);
 	await app.register(apiKeyRoutes);
@@ -312,11 +303,7 @@ await registerApiDocs(app, {
 	enabled: env.OPENAPI_DOCS_ENABLED,
 	authRequired: env.DOCS_AUTH_REQUIRED,
 });
-await app.register(fastifyStatic, {
-	root: imagesDir,
-	prefix: "/images/",
-	decorateReply: false,
-});
+await app.register(imageRoutes, { imagesDir });
 await app.register(healthRoutes);
 await app.register(authRoutes);
 await app.register(apiKeyRoutes);

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -47,10 +47,20 @@ function getStoredFilenameCandidates(requestedFilename: string): Set<string> {
 	return candidates;
 }
 
-function matchesStoredImage(storedFilename: string | null | undefined, requestedCandidates: Set<string>): boolean {
-	if (!storedFilename) return false;
-	if (requestedCandidates.has(storedFilename)) return true;
-	return requestedCandidates.has(getThumbFilename(storedFilename));
+function getMatchedStoredFilename(
+	storedFilename: string | null | undefined,
+	requestedCandidates: Set<string>
+): string | null {
+	if (!storedFilename) return null;
+
+	const thumbFilename = getThumbFilename(storedFilename);
+	if (requestedCandidates.has(thumbFilename)) {
+		return thumbFilename;
+	}
+
+	if (requestedCandidates.has(storedFilename)) return storedFilename;
+
+	return null;
 }
 
 async function getAuthenticatedUserId(request: FastifyRequest, reply: FastifyReply): Promise<number> {
@@ -67,10 +77,11 @@ async function getAuthenticatedUserId(request: FastifyRequest, reply: FastifyRep
 	return userId;
 }
 
-async function isAuthorizedOwnerImage(userId: number, requestedCandidates: Set<string>): Promise<boolean> {
+async function getAuthorizedOwnerImageFilename(userId: number, requestedCandidates: Set<string>): Promise<string | null> {
 	const [user] = await db.select({ avatarUrl: users.avatarUrl }).from(users).where(eq(users.id, userId));
-	if (matchesStoredImage(user?.avatarUrl, requestedCandidates)) {
-		return true;
+	const matchedAvatarFilename = getMatchedStoredFilename(user?.avatarUrl, requestedCandidates);
+	if (matchedAvatarFilename) {
+		return matchedAvatarFilename;
 	}
 
 	const ownerMedications = await db
@@ -78,16 +89,23 @@ async function isAuthorizedOwnerImage(userId: number, requestedCandidates: Set<s
 		.from(medications)
 		.where(eq(medications.userId, userId));
 
-	return ownerMedications.some((medication) => matchesStoredImage(medication.imageUrl, requestedCandidates));
+	for (const medication of ownerMedications) {
+		const matchedMedicationFilename = getMatchedStoredFilename(medication.imageUrl, requestedCandidates);
+		if (matchedMedicationFilename) {
+			return matchedMedicationFilename;
+		}
+	}
+
+	return null;
 }
 
-async function isAuthorizedSharedMedicationImage(
+async function getAuthorizedSharedMedicationImageFilename(
 	shareToken: string,
 	requestedCandidates: Set<string>
-): Promise<boolean> {
+): Promise<string | null> {
 	const { share, reason } = await getActiveShareToken(shareToken, { touchLastUsed: false });
 	if (!share || reason !== "ok") {
-		return false;
+		return null;
 	}
 
 	const sharedMedications = await db
@@ -103,9 +121,10 @@ async function isAuthorizedSharedMedicationImage(
 		.from(medications)
 		.where(and(eq(medications.userId, share.userId), eq(medications.isObsolete, false)));
 
-	return sharedMedications.some((medication) => {
-		if (!matchesStoredImage(medication.imageUrl, requestedCandidates)) {
-			return false;
+	for (const medication of sharedMedications) {
+		const matchedMedicationFilename = getMatchedStoredFilename(medication.imageUrl, requestedCandidates);
+		if (!matchedMedicationFilename) {
+			continue;
 		}
 
 		const takenByArray = parseTakenByJson(medication.takenByJson);
@@ -118,8 +137,12 @@ async function isAuthorizedSharedMedicationImage(
 			},
 			medication.intakeRemindersEnabled ?? false
 		);
-		return personTakesMedication(share.takenBy, takenByArray, intakes);
-	});
+		if (personTakesMedication(share.takenBy, takenByArray, intakes)) {
+			return matchedMedicationFilename;
+		}
+	}
+
+	return null;
 }
 
 export async function imageRoutes(app: FastifyInstance, options: ImageRoutesOptions) {
@@ -131,17 +154,18 @@ export async function imageRoutes(app: FastifyInstance, options: ImageRoutesOpti
 			return reply.status(400).send({ error: "Invalid image filename", code: "INVALID_IMAGE_FILENAME" });
 		}
 
-		const filePath = resolve(options.imagesDir, filename);
 		const requestedCandidates = getStoredFilenameCandidates(filename);
 		const shareToken = typeof request.query.shareToken === "string" ? request.query.shareToken.trim() : "";
 
-		const authorized = shareToken
-			? await isAuthorizedSharedMedicationImage(shareToken, requestedCandidates)
-			: await isAuthorizedOwnerImage(await getAuthenticatedUserId(request, reply), requestedCandidates);
+		const authorizedFilename = shareToken
+			? await getAuthorizedSharedMedicationImageFilename(shareToken, requestedCandidates)
+			: await getAuthorizedOwnerImageFilename(await getAuthenticatedUserId(request, reply), requestedCandidates);
 
-		if (!authorized) {
+		if (!authorizedFilename) {
 			return reply.status(404).send({ error: "Image not found", code: "IMAGE_NOT_FOUND" });
 		}
+
+		const filePath = resolve(options.imagesDir, authorizedFilename);
 
 		if (!existsSync(filePath)) {
 			return reply.status(404).send({ error: "Image not found", code: "IMAGE_NOT_FOUND" });

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -4,9 +4,10 @@ import { extname, resolve } from "node:path";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db } from "../db/client.js";
-import { medications, shareTokens, users } from "../db/schema.js";
+import { medications, users } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import { getActiveShareToken } from "../services/share-token-service.js";
 import { getThumbFilename } from "../utils/image-upload.js";
 import { parseIntakesJson, parseTakenByJson, personTakesMedication } from "../utils/scheduler-utils.js";
 
@@ -19,7 +20,6 @@ type ImageQuery = {
 };
 
 const imageFilenamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/;
-const shareTokenPattern = /^[a-f0-9]{16}$/;
 
 function isValidImageFilename(filename: string): boolean {
 	return (
@@ -51,12 +51,6 @@ function matchesStoredImage(storedFilename: string | null | undefined, requested
 	if (!storedFilename) return false;
 	if (requestedCandidates.has(storedFilename)) return true;
 	return requestedCandidates.has(getThumbFilename(storedFilename));
-}
-
-function isExpired(value: Date | string | number | null | undefined): boolean {
-	if (value == null) return false;
-	const timestamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
-	return Number.isFinite(timestamp) && timestamp <= Date.now();
 }
 
 async function getAuthenticatedUserId(request: FastifyRequest, reply: FastifyReply): Promise<number> {
@@ -91,12 +85,8 @@ async function isAuthorizedSharedMedicationImage(
 	shareToken: string,
 	requestedCandidates: Set<string>
 ): Promise<boolean> {
-	if (!shareTokenPattern.test(shareToken)) {
-		return false;
-	}
-
-	const [share] = await db.select().from(shareTokens).where(eq(shareTokens.token, shareToken));
-	if (!share || isExpired(share.expiresAt)) {
+	const { share, reason } = await getActiveShareToken(shareToken, { touchLastUsed: false });
+	if (!share || reason !== "ok") {
 		return false;
 	}
 

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -77,7 +77,10 @@ async function getAuthenticatedUserId(request: FastifyRequest, reply: FastifyRep
 	return userId;
 }
 
-async function getAuthorizedOwnerImageFilename(userId: number, requestedCandidates: Set<string>): Promise<string | null> {
+async function getAuthorizedOwnerImageFilename(
+	userId: number,
+	requestedCandidates: Set<string>
+): Promise<string | null> {
 	const [user] = await db.select({ avatarUrl: users.avatarUrl }).from(users).where(eq(users.id, userId));
 	const matchedAvatarFilename = getMatchedStoredFilename(user?.avatarUrl, requestedCandidates);
 	if (matchedAvatarFilename) {

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -1,0 +1,165 @@
+import { createReadStream, existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { extname, resolve } from "node:path";
+import { and, eq } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { db } from "../db/client.js";
+import { medications, shareTokens, users } from "../db/schema.js";
+import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
+import { env } from "../plugins/env.js";
+import { getThumbFilename } from "../utils/image-upload.js";
+import { parseIntakesJson, parseTakenByJson, personTakesMedication } from "../utils/scheduler-utils.js";
+
+type ImageRoutesOptions = {
+	imagesDir: string;
+};
+
+type ImageQuery = {
+	shareToken?: string;
+};
+
+const imageFilenamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/;
+const shareTokenPattern = /^[a-f0-9]{16}$/;
+
+function isValidImageFilename(filename: string): boolean {
+	return (
+		imageFilenamePattern.test(filename) &&
+		!filename.includes("/") &&
+		!filename.includes("\\") &&
+		!filename.includes("..")
+	);
+}
+
+function getImageContentType(filename: string): string | null {
+	const ext = extname(filename).toLowerCase();
+	if (ext === ".webp") return "image/webp";
+	if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+	if (ext === ".png") return "image/png";
+	if (ext === ".gif") return "image/gif";
+	return null;
+}
+
+function getStoredFilenameCandidates(requestedFilename: string): Set<string> {
+	const candidates = new Set([requestedFilename]);
+	if (requestedFilename.endsWith("-thumb.webp")) {
+		candidates.add(requestedFilename.replace(/-thumb\.webp$/, ".webp"));
+	}
+	return candidates;
+}
+
+function matchesStoredImage(storedFilename: string | null | undefined, requestedCandidates: Set<string>): boolean {
+	if (!storedFilename) return false;
+	if (requestedCandidates.has(storedFilename)) return true;
+	return requestedCandidates.has(getThumbFilename(storedFilename));
+}
+
+function isExpired(value: Date | string | number | null | undefined): boolean {
+	if (value == null) return false;
+	const timestamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
+	return Number.isFinite(timestamp) && timestamp <= Date.now();
+}
+
+async function getAuthenticatedUserId(request: FastifyRequest, reply: FastifyReply): Promise<number> {
+	if (!env.AUTH_ENABLED) {
+		return getAnonymousUserId();
+	}
+
+	await requireAuth(request, reply);
+	const userId = request.user?.id;
+	if (typeof userId !== "number") {
+		reply.status(401).send({ error: "Authentication required", code: "AUTH_REQUIRED" });
+		throw new Error("AUTH_REQUIRED");
+	}
+	return userId;
+}
+
+async function isAuthorizedOwnerImage(userId: number, requestedCandidates: Set<string>): Promise<boolean> {
+	const [user] = await db.select({ avatarUrl: users.avatarUrl }).from(users).where(eq(users.id, userId));
+	if (matchesStoredImage(user?.avatarUrl, requestedCandidates)) {
+		return true;
+	}
+
+	const ownerMedications = await db
+		.select({ imageUrl: medications.imageUrl })
+		.from(medications)
+		.where(eq(medications.userId, userId));
+
+	return ownerMedications.some((medication) => matchesStoredImage(medication.imageUrl, requestedCandidates));
+}
+
+async function isAuthorizedSharedMedicationImage(
+	shareToken: string,
+	requestedCandidates: Set<string>
+): Promise<boolean> {
+	if (!shareTokenPattern.test(shareToken)) {
+		return false;
+	}
+
+	const [share] = await db.select().from(shareTokens).where(eq(shareTokens.token, shareToken));
+	if (!share || isExpired(share.expiresAt)) {
+		return false;
+	}
+
+	const sharedMedications = await db
+		.select({
+			imageUrl: medications.imageUrl,
+			takenByJson: medications.takenByJson,
+			intakesJson: medications.intakesJson,
+			usageJson: medications.usageJson,
+			everyJson: medications.everyJson,
+			startJson: medications.startJson,
+			intakeRemindersEnabled: medications.intakeRemindersEnabled,
+		})
+		.from(medications)
+		.where(and(eq(medications.userId, share.userId), eq(medications.isObsolete, false)));
+
+	return sharedMedications.some((medication) => {
+		if (!matchesStoredImage(medication.imageUrl, requestedCandidates)) {
+			return false;
+		}
+
+		const takenByArray = parseTakenByJson(medication.takenByJson);
+		const intakes = parseIntakesJson(
+			medication.intakesJson,
+			{
+				usageJson: medication.usageJson,
+				everyJson: medication.everyJson,
+				startJson: medication.startJson,
+			},
+			medication.intakeRemindersEnabled ?? false
+		);
+		return personTakesMedication(share.takenBy, takenByArray, intakes);
+	});
+}
+
+export async function imageRoutes(app: FastifyInstance, options: ImageRoutesOptions) {
+	app.get<{ Params: { filename: string }; Querystring: ImageQuery }>("/images/:filename", async (request, reply) => {
+		const { filename } = request.params;
+		const contentType = getImageContentType(filename);
+
+		if (!isValidImageFilename(filename) || !contentType) {
+			return reply.status(400).send({ error: "Invalid image filename", code: "INVALID_IMAGE_FILENAME" });
+		}
+
+		const filePath = resolve(options.imagesDir, filename);
+		const requestedCandidates = getStoredFilenameCandidates(filename);
+		const shareToken = typeof request.query.shareToken === "string" ? request.query.shareToken.trim() : "";
+
+		const authorized = shareToken
+			? await isAuthorizedSharedMedicationImage(shareToken, requestedCandidates)
+			: await isAuthorizedOwnerImage(await getAuthenticatedUserId(request, reply), requestedCandidates);
+
+		if (!authorized) {
+			return reply.status(404).send({ error: "Image not found", code: "IMAGE_NOT_FOUND" });
+		}
+
+		if (!existsSync(filePath)) {
+			return reply.status(404).send({ error: "Image not found", code: "IMAGE_NOT_FOUND" });
+		}
+
+		const fileStat = await stat(filePath);
+		reply.header("Cache-Control", "private, no-store");
+		reply.header("Content-Length", fileStat.size);
+		return reply.type(contentType).send(createReadStream(filePath));
+	});
+}

--- a/backend/src/test/image-routes.test.ts
+++ b/backend/src/test/image-routes.test.ts
@@ -73,8 +73,11 @@ async function createSchema(client: Client) {
 			taken_by text NOT NULL,
 			schedule_days integer NOT NULL DEFAULT 30,
 			allow_journal_notes integer NOT NULL DEFAULT 0,
+			allow_mark_taken integer NOT NULL DEFAULT 1,
 			created_at integer NOT NULL DEFAULT (strftime('%s','now')),
-			expires_at integer
+			expires_at integer,
+			last_used_at integer,
+			revoked_at integer
 		)`,
 	];
 

--- a/backend/src/test/image-routes.test.ts
+++ b/backend/src/test/image-routes.test.ts
@@ -1,0 +1,267 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import cookie from "@fastify/cookie";
+import sensible from "@fastify/sensible";
+import type { Client } from "@libsql/client";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { jwtPlugin } from "../plugins/jwt.js";
+import { documentationSchemaAjv } from "../utils/documentation-schema-keywords.js";
+
+const { testClient, testDb } = vi.hoisted(() => {
+	const { createClient } = require("@libsql/client");
+	const { drizzle } = require("drizzle-orm/libsql");
+	const client = createClient({ url: ":memory:" });
+	const db = drizzle(client);
+	return { testClient: client, testDb: db };
+});
+
+vi.mock("../db/client.js", () => ({
+	db: testDb,
+	migrationsReady: Promise.resolve(),
+}));
+
+vi.mock("../plugins/env.js", () => ({
+	env: {
+		AUTH_ENABLED: true,
+		NODE_ENV: "test",
+		LOG_LEVEL: "silent",
+		PORT: 3000,
+		CORS_ORIGINS: "*",
+		JWT_SECRET: "test-jwt-secret-12345",
+		REFRESH_SECRET: "test-refresh-secret-12345",
+		COOKIE_SECRET: "test-cookie-secret-12345",
+		ACCESS_TOKEN_TTL_MINUTES: 15,
+		REFRESH_TOKEN_TTL_DAYS: 7,
+	},
+}));
+
+const { imageRoutes } = await import("../routes/images.js");
+
+async function createSchema(client: Client) {
+	const tableCreations = [
+		`CREATE TABLE IF NOT EXISTS users (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			username text NOT NULL UNIQUE,
+			password_hash text,
+			avatar_url text,
+			auth_provider text NOT NULL DEFAULT 'local',
+			oidc_subject text,
+			is_active integer NOT NULL DEFAULT 1,
+			last_login_at integer,
+			created_at integer NOT NULL DEFAULT (strftime('%s','now')),
+			updated_at integer NOT NULL DEFAULT (strftime('%s','now'))
+		)`,
+		`CREATE TABLE IF NOT EXISTS medications (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			user_id integer NOT NULL,
+			name text NOT NULL,
+			taken_by_json text NOT NULL DEFAULT '[]',
+			usage_json text NOT NULL DEFAULT '[]',
+			every_json text NOT NULL DEFAULT '[]',
+			start_json text NOT NULL DEFAULT '[]',
+			intakes_json text NOT NULL DEFAULT '[]',
+			image_url text,
+			intake_reminders_enabled integer NOT NULL DEFAULT 0,
+			is_obsolete integer NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE IF NOT EXISTS share_tokens (
+			id integer PRIMARY KEY AUTOINCREMENT,
+			user_id integer NOT NULL,
+			token text NOT NULL UNIQUE,
+			taken_by text NOT NULL,
+			schedule_days integer NOT NULL DEFAULT 30,
+			allow_journal_notes integer NOT NULL DEFAULT 0,
+			created_at integer NOT NULL DEFAULT (strftime('%s','now')),
+			expires_at integer
+		)`,
+	];
+
+	for (const sql of tableCreations) {
+		await client.execute(sql);
+	}
+}
+
+async function clearData(client: Client) {
+	await client.execute("DELETE FROM share_tokens");
+	await client.execute("DELETE FROM medications");
+	await client.execute("DELETE FROM users");
+	await client.execute("DELETE FROM sqlite_sequence");
+}
+
+async function seedUser(id: number, username: string, avatarUrl: string | null = null) {
+	await testClient.execute({
+		sql: "INSERT INTO users (id, username, avatar_url) VALUES (?, ?, ?)",
+		args: [id, username, avatarUrl],
+	});
+}
+
+async function seedMedication(userId: number, imageUrl: string, takenBy: string[] = ["Daniel"]) {
+	await testClient.execute({
+		sql: "INSERT INTO medications (user_id, name, taken_by_json, image_url) VALUES (?, ?, ?, ?)",
+		args: [userId, "Private Med", JSON.stringify(takenBy), imageUrl],
+	});
+}
+
+async function seedShareToken(userId: number, token: string, takenBy: string) {
+	await testClient.execute({
+		sql: "INSERT INTO share_tokens (user_id, token, taken_by) VALUES (?, ?, ?)",
+		args: [userId, token, takenBy],
+	});
+}
+
+describe("Image routes", () => {
+	let app: FastifyInstance;
+	let imagesDir: string;
+
+	beforeAll(async () => {
+		await createSchema(testClient);
+		imagesDir = mkdtempSync(join(tmpdir(), "medassist-image-routes-"));
+
+		app = Fastify({ logger: false, ajv: documentationSchemaAjv });
+		await app.register(sensible);
+		await app.register(cookie, { secret: "test-cookie-secret-12345" });
+		await app.register(jwtPlugin, {
+			secret: "test-jwt-secret-12345",
+			cookie: { cookieName: "access_token", signed: false },
+		});
+		await app.register(imageRoutes, { imagesDir });
+		await app.ready();
+	});
+
+	afterAll(async () => {
+		await app.close();
+		testClient.close();
+		rmSync(imagesDir, { recursive: true, force: true });
+	});
+
+	beforeEach(async () => {
+		await clearData(testClient);
+		rmSync(imagesDir, { recursive: true, force: true });
+		mkdirSync(imagesDir, { recursive: true });
+	});
+
+	async function authCookie(userId: number, username: string): Promise<string> {
+		const token = await app.jwt.sign({ sub: userId, username }, { expiresIn: "15m" });
+		return `access_token=${token}`;
+	}
+
+	function writeImage(filename: string, content = "private image") {
+		writeFileSync(join(imagesDir, filename), content);
+	}
+
+	it("blocks unauthenticated direct image requests", async () => {
+		await seedUser(1, "owner");
+		await seedMedication(1, "med-1-123.webp");
+		writeImage("med-1-123.webp");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/med-1-123.webp",
+		});
+
+		expect(response.statusCode).toBe(401);
+		expect(response.body).not.toBe("private image");
+	});
+
+	it("serves owned medication images to authenticated owners", async () => {
+		await seedUser(1, "owner");
+		await seedMedication(1, "med-1-123.webp");
+		writeImage("med-1-123.webp");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/med-1-123.webp",
+			headers: { cookie: await authCookie(1, "owner") },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["content-type"]).toBe("image/webp");
+		expect(response.body).toBe("private image");
+	});
+
+	it("serves owned avatar images to authenticated owners", async () => {
+		await seedUser(1, "owner", "avatar_1-123.webp");
+		writeImage("avatar_1-123.webp", "private avatar");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/avatar_1-123.webp",
+			headers: { cookie: await authCookie(1, "owner") },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toBe("private avatar");
+	});
+
+	it("does not serve another user's medication image to an authenticated user", async () => {
+		await seedUser(1, "owner");
+		await seedUser(2, "other");
+		await seedMedication(1, "med-1-123.webp");
+		writeImage("med-1-123.webp");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/med-1-123.webp",
+			headers: { cookie: await authCookie(2, "other") },
+		});
+
+		expect(response.statusCode).toBe(404);
+		expect(response.body).not.toBe("private image");
+	});
+
+	it("serves thumbnail files when the stored full-size image is authorized", async () => {
+		await seedUser(1, "owner");
+		await seedMedication(1, "med-1-123.webp");
+		writeImage("med-1-123-thumb.webp", "private thumb");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/med-1-123-thumb.webp",
+			headers: { cookie: await authCookie(1, "owner") },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toBe("private thumb");
+	});
+
+	it("serves medication images through valid share tokens only for shared people", async () => {
+		await seedUser(1, "owner");
+		await seedMedication(1, "med-1-123.webp", ["Daniel"]);
+		await seedShareToken(1, "feedfacecafebeef", "Daniel");
+		writeImage("med-1-123.webp");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/med-1-123.webp?shareToken=feedfacecafebeef",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toBe("private image");
+	});
+
+	it("rejects share tokens that do not include the medication person", async () => {
+		await seedUser(1, "owner");
+		await seedMedication(1, "med-1-123.webp", ["Daniel"]);
+		await seedShareToken(1, "feedfacecafebeef", "Anna");
+		writeImage("med-1-123.webp");
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/med-1-123.webp?shareToken=feedfacecafebeef",
+		});
+
+		expect(response.statusCode).toBe(404);
+		expect(response.body).not.toBe("private image");
+	});
+
+	it("rejects traversal-style image filenames", async () => {
+		const response = await app.inject({
+			method: "GET",
+			url: "/images/%2e%2e.webp",
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+});

--- a/frontend/src/components/MedicationAvatar.tsx
+++ b/frontend/src/components/MedicationAvatar.tsx
@@ -8,9 +8,10 @@ export type MedicationAvatarProps = {
 	name: string;
 	imageUrl?: string | null;
 	size?: "sm" | "md" | "lg";
+	imageSrcResolver?: (filename: string) => string;
 };
 
-export function MedicationAvatar({ name, imageUrl, size = "sm" }: MedicationAvatarProps) {
+export function MedicationAvatar({ name, imageUrl, size = "sm", imageSrcResolver }: MedicationAvatarProps) {
 	const [thumbFailed, setThumbFailed] = useState(false);
 	const previousImageUrlRef = useRef(imageUrl);
 
@@ -34,8 +35,9 @@ export function MedicationAvatar({ name, imageUrl, size = "sm" }: MedicationAvat
 		const shouldUseThumbFirst = normalizedImageUrl.endsWith(".webp");
 		const extIndex = imageUrl.lastIndexOf(".");
 		const baseName = extIndex > 0 ? imageUrl.slice(0, extIndex) : imageUrl;
-		const thumbSrc = `/api/images/${baseName}-thumb.webp`;
-		const fullSrc = `/api/images/${imageUrl}`;
+		const resolveImageSrc = imageSrcResolver ?? ((filename: string) => `/api/images/${encodeURIComponent(filename)}`);
+		const thumbSrc = resolveImageSrc(`${baseName}-thumb.webp`);
+		const fullSrc = resolveImageSrc(imageUrl);
 		const resolvedSrc = shouldUseThumbFirst && !thumbFailed ? thumbSrc : fullSrc;
 
 		return (

--- a/frontend/src/components/SharedMedicationOverviewSection.tsx
+++ b/frontend/src/components/SharedMedicationOverviewSection.tsx
@@ -66,6 +66,7 @@ export interface SharedMedicationOverviewSectionProps {
 	medications: SharedMedicationOverviewItem[];
 	showTitle?: boolean;
 	onMedicationImageClick?: (imageUrl: string, name: string) => void;
+	imageSrcResolver?: (filename: string) => string;
 }
 
 export function SharedMedicationOverviewSection({
@@ -73,6 +74,7 @@ export function SharedMedicationOverviewSection({
 	medications,
 	showTitle = true,
 	onMedicationImageClick,
+	imageSrcResolver,
 }: SharedMedicationOverviewSectionProps) {
 	const { t } = useTranslation();
 	const renderMedicationAvatar = (name: string, imageUrl: string | null) => {
@@ -90,7 +92,7 @@ export function SharedMedicationOverviewSection({
 					}
 				}}
 			>
-				<MedicationAvatar name={name} imageUrl={imageUrl} size="sm" />
+				<MedicationAvatar name={name} imageUrl={imageUrl} size="sm" imageSrcResolver={imageSrcResolver} />
 			</div>
 		);
 	};

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -71,6 +71,13 @@ export function SharedSchedule() {
 	const [sharedJournalError, setSharedJournalError] = useState<string | null>(null);
 	const [showPastDays, setShowPastDays] = useState(false);
 	const [showFutureDays, setShowFutureDays] = useState(false);
+	const sharedImageSrc = useCallback(
+		(filename: string) => {
+			const imagePath = `/api/images/${encodeURIComponent(filename)}`;
+			return token ? `${imagePath}?shareToken=${encodeURIComponent(token)}` : imagePath;
+		},
+		[token]
+	);
 
 	const isLiquidContainerMed = (med: SharedScheduleData["medications"][number] | undefined) =>
 		isLiquidContainerPackageType(med?.packageType);
@@ -1164,6 +1171,7 @@ export function SharedSchedule() {
 						medications={data.medicationOverview ?? []}
 						showTitle={false}
 						onMedicationImageClick={openLightbox}
+						imageSrcResolver={sharedImageSrc}
 					/>
 				) : null}
 
@@ -1287,7 +1295,12 @@ export function SharedSchedule() {
 																				}
 																			}}
 																		>
-																			<MedicationAvatar name={item.medName} imageUrl={med?.imageUrl} size="sm" />
+																			<MedicationAvatar
+																				name={item.medName}
+																				imageUrl={med?.imageUrl}
+																				size="sm"
+																				imageSrcResolver={sharedImageSrc}
+																			/>
 																		</div>
 																		<div className="med-name-stack">
 																			<span className="med-name-text">{item.medName}</span>
@@ -1483,7 +1496,12 @@ export function SharedSchedule() {
 																				}
 																			}}
 																		>
-																			<MedicationAvatar name={item.medName} imageUrl={med?.imageUrl} size="sm" />
+																			<MedicationAvatar
+																				name={item.medName}
+																				imageUrl={med?.imageUrl}
+																				size="sm"
+																				imageSrcResolver={sharedImageSrc}
+																			/>
 																		</div>
 																		<div className="med-name-stack">
 																			<span className="med-name-text">{item.medName}</span>
@@ -1664,7 +1682,12 @@ export function SharedSchedule() {
 																				}
 																			}}
 																		>
-																			<MedicationAvatar name={item.medName} imageUrl={med?.imageUrl} size="sm" />
+																			<MedicationAvatar
+																				name={item.medName}
+																				imageUrl={med?.imageUrl}
+																				size="sm"
+																				imageSrcResolver={sharedImageSrc}
+																			/>
 																		</div>
 																		<div className="med-name-stack">
 																			<span className="med-name-text">{item.medName}</span>
@@ -1754,7 +1777,7 @@ export function SharedSchedule() {
 						×
 					</button>
 					<img
-						src={`/api/images/${lightboxImage.url}`}
+						src={sharedImageSrc(lightboxImage.url)}
 						alt={lightboxImage.name}
 						className="lightbox-image"
 						onClick={(e) => e.stopPropagation()}

--- a/frontend/src/test/components/MedicationAvatar.test.tsx
+++ b/frontend/src/test/components/MedicationAvatar.test.tsx
@@ -29,6 +29,19 @@ describe("MedicationAvatar", () => {
 		expect(img).toHaveAttribute("src", "/api/images/test-image.jpg");
 	});
 
+	it("uses a custom image source resolver when provided", () => {
+		render(
+			<MedicationAvatar
+				name="Shared Med"
+				imageUrl="shared-image.webp"
+				imageSrcResolver={(filename) => `/api/images/${filename}?shareToken=token-123`}
+			/>
+		);
+
+		const img = screen.getByAltText("Shared Med");
+		expect(img).toHaveAttribute("src", "/api/images/shared-image-thumb.webp?shareToken=token-123");
+	});
+
 	it("applies small size class by default", () => {
 		const { container } = render(<MedicationAvatar name="Test" />);
 

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -31,7 +31,7 @@ function createSharedDataWithEmbeddedOverview() {
 			{
 				name: "Aspirin",
 				genericName: "Acetylsalicylic Acid",
-				imageUrl: null,
+				imageUrl: null as string | null,
 				packageType: "blister",
 				packCount: 1,
 				packageAmountValue: null,
@@ -54,7 +54,7 @@ function createSharedDataWithEmbeddedOverview() {
 			{
 				name: "Vitamin D",
 				genericName: null,
-				imageUrl: null,
+				imageUrl: null as string | null,
 				packageType: "bottle",
 				packCount: 0,
 				packageAmountValue: null,
@@ -148,6 +148,7 @@ function createSharedDataWithTodayDose(referenceNow: Date) {
 				id: 1,
 				name: "Ibuprofen",
 				genericName: null,
+				imageUrl: null as string | null,
 				takenBy: [],
 				packageType: "blister",
 				packCount: 2,
@@ -411,6 +412,23 @@ describe("SharedSchedule", () => {
 			const journalButton = document.querySelector(".dose-btn.journal") as HTMLButtonElement;
 			expect(journalButton).not.toBeDisabled();
 			expect(journalButton).toHaveClass("has-note");
+		});
+	});
+
+	it("adds the share token to public shared medication image URLs", async () => {
+		const referenceNow = new Date();
+		referenceNow.setHours(12, 0, 0, 0);
+		vi.spyOn(Date, "now").mockReturnValue(referenceNow.getTime());
+		const sharedData = createSharedDataWithTodayDose(referenceNow);
+		sharedData.medications[0].imageUrl = "med-1-123.webp";
+		const { fetchMock } = createSharedDoseFetchMock({ sharedData });
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		renderSharedSchedule("/share/token-123");
+
+		await waitFor(() => {
+			const image = screen.getByAltText("Ibuprofen");
+			expect(image).toHaveAttribute("src", "/api/images/med-1-123-thumb.webp?shareToken=token-123");
 		});
 	});
 


### PR DESCRIPTION
Closes #659

## Summary
- harden image import/export data handling
- serve medication images only through protected backend checks
- align shared image token validation with the hardened share-token model