### PR TITLE
fix(config): harden env parsing and docs drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ PGID=1000
 
 PORT=3000
 # Docker Compose quickstart serves the frontend on http://localhost:4174.
-# Local Vite development usually uses http://localhost:5173 or http://localhost:4173 instead.
+# Local Vite development uses http://localhost:5173 instead.
 CORS_ORIGINS=http://localhost:4174
 
 # Server default timezone for scheduled reminders.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Configure the application with environment variables in `.env`. Keep the basic c
 | `PUID` | `1000` | User ID for container file permissions |
 | `PGID` | `1000` | Group ID for container file permissions |
 | `PORT` | `3000` | Backend API port |
-| `CORS_ORIGINS` | `http://localhost:4174` | Allowed frontend origins |
+| `CORS_ORIGINS` | `http://localhost:4174` in `.env.example` | Allowed frontend origins; backend defaults also include `http://localhost:5173` for local Vite development |
 | `TZ` | `Europe/Berlin` | Default timezone for reminders |
 | `AUTH_ENABLED` | `false` | Enable authentication; required for public production deployments |
 | `ALLOW_UNAUTHENTICATED` | `false` | Explicit local/private-only override for production no-auth startup |

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from "node:fs";
 import { type Client, createClient } from "@libsql/client";
 import dotenv from "dotenv";
 import { drizzle } from "drizzle-orm/libsql";
+import { parseBoolEnv } from "../utils/env-parsing.js";
 import { log } from "../utils/logger.js";
 import { ensureDefaultUser, runAlterMigrations, runDrizzleMigrations } from "./migration-utils.js";
 // Import utilities from focused DB modules (side-effect-free)
@@ -100,7 +101,7 @@ async function runMigrations() {
 	}
 
 	// If auth is disabled, ensure a default user exists (ID=1)
-	const authEnabled = process.env.AUTH_ENABLED === "true";
+	const authEnabled = parseBoolEnv(process.env.AUTH_ENABLED, false);
 	const created = await ensureDefaultUser(client, authEnabled);
 	if (created) {
 		log.info(`[DB] Created default user for auth-disabled mode`);

--- a/backend/src/i18n/translations.ts
+++ b/backend/src/i18n/translations.ts
@@ -1,4 +1,6 @@
 // Backend translations for notifications
+import { parseStringListEnv } from "../utils/env-parsing.js";
+
 export type Language = "en" | "de";
 
 /**
@@ -487,8 +489,7 @@ export function getDateLocale(language: Language): string {
  * Falls back to empty string if not set.
  */
 export function getAppUrl(): string {
-	const origins = process.env.CORS_ORIGINS || "";
-	return origins.split(",")[0]?.trim() || "";
+	return parseStringListEnv(process.env.CORS_ORIGINS)[0] ?? "";
 }
 
 /**

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -289,7 +289,7 @@ await app.register(cors, {
 	},
 });
 await app.register(rateLimit, {
-	max: Number(process.env.RATE_LIMIT_MAX) || 100,
+	max: env.RATE_LIMIT_MAX,
 	timeWindow: "1 minute",
 });
 await app.register(cookie, { secret: env.COOKIE_SECRET ?? "dev-cookie-secret" });

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -1,56 +1,60 @@
 import { existsSync } from "node:fs";
 import dotenv from "dotenv";
 import { z } from "zod";
+import { parseBoolEnv, parseIntEnv, parseStringListEnv } from "../utils/env-parsing.js";
 
 // Load .env: try cwd first, then parent dir (for local dev running from backend/)
 const envPath = process.env.DOTENV_PATH || (existsSync(".env") ? ".env" : "../.env");
 dotenv.config({ path: envPath });
 
+const DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
+
+function boolEnv(defaultValue: boolean) {
+	return z
+		.string()
+		.optional()
+		.transform((value) => parseBoolEnv(value, defaultValue));
+}
+
+function optionalBoolEnv() {
+	return z
+		.string()
+		.optional()
+		.transform((value) => (value === undefined ? undefined : parseBoolEnv(value, false)));
+}
+
+function intEnv(options: { defaultValue: number; min?: number; max?: number }) {
+	return z
+		.string()
+		.optional()
+		.transform((value) => parseIntEnv(value, options));
+}
+
 const EnvSchema = z.object({
 	NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
-	PORT: z
+	PORT: intEnv({ defaultValue: 3000, min: 1, max: 65535 }),
+	CORS_ORIGINS: z
 		.string()
-		.default("3000")
-		.transform((v) => parseInt(v, 10)),
-	CORS_ORIGINS: z.string().default("http://localhost:5173,http://localhost:4173"),
+		.optional()
+		.transform((value) => parseStringListEnv(value ?? DEFAULT_CORS_ORIGINS).join(",")),
 	LOG_LEVEL: z.string().default("info"),
-	SENSITIVE_LOGGING_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	SENSITIVE_LOGGING_ENABLED: boolEnv(false),
 	PUBLIC_APP_URL: z.string().url().optional(),
-	OPENAPI_DOCS_ENABLED: z
-		.string()
-		.transform((v) => v === "true")
-		.optional(),
-	DOCS_AUTH_REQUIRED: z
-		.string()
-		.transform((v) => v === "true")
-		.optional(),
+	OPENAPI_DOCS_ENABLED: optionalBoolEnv(),
+	DOCS_AUTH_REQUIRED: optionalBoolEnv(),
+	RATE_LIMIT_MAX: intEnv({ defaultValue: 100, min: 1, max: 100_000 }),
 
 	// ==========================================================================
 	// Auth Configuration
 	// ==========================================================================
 	// Master switch: Enable/disable authentication (default: disabled for easy setup)
-	AUTH_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	AUTH_ENABLED: boolEnv(false),
 	// Explicit production-only escape hatch for private/local no-auth deployments.
-	ALLOW_UNAUTHENTICATED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	ALLOW_UNAUTHENTICATED: boolEnv(false),
 	// Allow new user registrations (auto-enabled if no users exist)
-	REGISTRATION_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	REGISTRATION_ENABLED: boolEnv(false),
 	// Disable username/password form login (useful for OIDC-only setups)
-	FORM_LOGIN_ENABLED: z
-		.string()
-		.default("true")
-		.transform((v) => v === "true"),
+	FORM_LOGIN_ENABLED: boolEnv(true),
 
 	// JWT Secrets - only required when AUTH_ENABLED=true
 	JWT_SECRET: z.string().min(10).optional(),
@@ -58,36 +62,20 @@ const EnvSchema = z.object({
 	COOKIE_SECRET: z.string().min(10).optional(),
 
 	// Token TTL settings
-	ACCESS_TOKEN_TTL_MINUTES: z
-		.string()
-		.default("15")
-		.transform((v) => parseInt(v, 10)),
-	REFRESH_TOKEN_TTL_DAYS: z
-		.string()
-		.default("7")
-		.transform((v) => parseInt(v, 10)),
-	SHARE_TOKEN_TTL_DAYS: z
-		.string()
-		.default("90")
-		.transform((v) => parseInt(v, 10))
-		.pipe(z.number().int().min(1).max(3650)),
+	ACCESS_TOKEN_TTL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 525_600 }),
+	REFRESH_TOKEN_TTL_DAYS: intEnv({ defaultValue: 7, min: 1, max: 3650 }),
+	SHARE_TOKEN_TTL_DAYS: intEnv({ defaultValue: 90, min: 1, max: 3650 }),
 
 	// ==========================================================================
 	// OIDC SSO Configuration (Pocket ID, Authelia, etc.)
 	// ==========================================================================
-	OIDC_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	OIDC_ENABLED: boolEnv(false),
 	OIDC_ISSUER_URL: z.string().url().optional(), // e.g., https://auth.example.com
 	OIDC_CLIENT_ID: z.string().optional(),
 	OIDC_CLIENT_SECRET: z.string().optional(),
 	OIDC_REDIRECT_URI: z.string().url().optional(), // e.g., https://medassist.example.com/api/auth/oidc/callback
 	OIDC_SCOPES: z.string().default("openid profile email"),
-	OIDC_AUTO_CREATE_USERS: z
-		.string()
-		.default("true")
-		.transform((v) => v === "true"),
+	OIDC_AUTO_CREATE_USERS: boolEnv(true),
 	OIDC_USERNAME_CLAIM: z.string().default("preferred_username"), // or 'email', 'sub'
 	OIDC_PROVIDER_NAME: z.string().default("SSO"), // Display name for UI button
 });

--- a/backend/src/routes/oidc.ts
+++ b/backend/src/routes/oidc.ts
@@ -5,6 +5,7 @@ import * as client from "openid-client";
 import { db } from "../db/client.js";
 import { refreshTokens, users } from "../db/schema.js";
 import { env } from "../plugins/env.js";
+import { parseStringListEnv } from "../utils/env-parsing.js";
 import { applyOpenApiRouteStandards, genericErrorSchema } from "../utils/openapi-route-standards.js";
 
 // =============================================================================
@@ -43,7 +44,7 @@ function generateState(): string {
 // Helpers
 // =============================================================================
 function getFrontendUrl(): string {
-	return env.CORS_ORIGINS.split(",")[0] || "http://localhost:5173";
+	return parseStringListEnv(env.CORS_ORIGINS)[0] ?? "http://localhost:5173";
 }
 
 // =============================================================================
@@ -244,7 +245,7 @@ export async function oidcRoutes(app: FastifyInstance) {
 
 				// Redirect to frontend dashboard
 				// In dev: CORS_ORIGINS contains the frontend URL
-				const frontendUrl = env.CORS_ORIGINS.split(",")[0] || "http://localhost:5173";
+				const frontendUrl = getFrontendUrl();
 				return reply.redirect(`${frontendUrl}/dashboard`);
 			} catch (err: unknown) {
 				request.log.error({ err }, "[OIDC] Callback processing failed");

--- a/backend/src/routes/planner.ts
+++ b/backend/src/routes/planner.ts
@@ -22,6 +22,7 @@ import { getSmtpConfig, sendEmailNotification, sendPushNotification } from "../s
 import { escapeHtml, formatPlannerQuantity, getPlannerUnit, isContainerPackage } from "../services/planner-service.js";
 import { updateReminderSentTime, updateUserReminderSentTime } from "../services/reminder-scheduler.js";
 import type { AuthUser } from "../types/fastify.js";
+import { parseBoolEnv, parseIntEnv } from "../utils/env-parsing.js";
 import {
 	applyOpenApiRouteStandards,
 	genericErrorSchema,
@@ -337,8 +338,8 @@ ${getFooterPlain(language)}`;
 				const smtpHost = process.env.SMTP_HOST;
 				const smtpUser = process.env.SMTP_USER;
 				const smtpPass = process.env.SMTP_TOKEN || process.env.SMTP_PASS; // Token takes precedence
-				const smtpPort = parseInt(process.env.SMTP_PORT ?? "587", 10);
-				const smtpSecure = process.env.SMTP_SECURE === "true";
+				const smtpPort = parseIntEnv(process.env.SMTP_PORT, { defaultValue: 587, min: 1, max: 65_535 });
+				const smtpSecure = parseBoolEnv(process.env.SMTP_SECURE, false);
 				const smtpFrom = process.env.SMTP_FROM ?? smtpUser;
 
 				request.log.info(

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -27,6 +27,7 @@ import {
 	validateNotificationHostname,
 } from "../services/settings-service.js";
 import type { AuthUser } from "../types/fastify.js";
+import { parseBoolEnv, parseIntEnv } from "../utils/env-parsing.js";
 
 export type { UserSettings } from "../services/settings-service.js";
 
@@ -80,10 +81,7 @@ const settingsErrorSchema = {
 };
 
 function envInt(key: string, defaultVal: number): number {
-	const val = process.env[key];
-	if (val === undefined) return defaultVal;
-	const parsed = parseInt(val, 10);
-	return Number.isNaN(parsed) ? defaultVal : parsed;
+	return parseIntEnv(process.env[key], { defaultValue: defaultVal, min: 0, max: 100_000 });
 }
 
 function getLanguage(language: string | null | undefined): Language {
@@ -205,10 +203,10 @@ export async function settingsRoutes(app: FastifyInstance) {
 				swapDashboardMainSections: settings.swapDashboardMainSections ?? false,
 				// SMTP settings (from .env - shared/server-configured)
 				smtpHost: process.env.SMTP_HOST ?? "",
-				smtpPort: parseInt(process.env.SMTP_PORT ?? "587", 10),
+				smtpPort: parseIntEnv(process.env.SMTP_PORT, { defaultValue: 587, min: 1, max: 65_535 }),
 				smtpUser: process.env.SMTP_USER ?? "",
 				smtpFrom: process.env.SMTP_FROM ?? "",
-				smtpSecure: process.env.SMTP_SECURE === "true",
+				smtpSecure: parseBoolEnv(process.env.SMTP_SECURE, false),
 				hasSmtpPassword: !!(process.env.SMTP_TOKEN || process.env.SMTP_PASS),
 				// Reminder state for this user
 				lastAutoEmailSent: settings.lastAutoEmailSent,
@@ -227,7 +225,7 @@ export async function settingsRoutes(app: FastifyInstance) {
 				// Server settings (from .env, read-only)
 				reminderHour,
 				reminderMinutesBefore,
-				expiryWarningDays: parseInt(process.env.EXPIRY_WARNING_DAYS ?? "30", 10),
+				expiryWarningDays: parseIntEnv(process.env.EXPIRY_WARNING_DAYS, { defaultValue: 30, min: 0, max: 3650 }),
 			});
 		}
 	);

--- a/backend/src/services/intake-reminder-scheduler.ts
+++ b/backend/src/services/intake-reminder-scheduler.ts
@@ -15,6 +15,7 @@ import {
 
 import { env } from "../plugins/env.js";
 import { getAllUserSettings, type UserSettings } from "../routes/settings.js";
+import { parseIntEnv } from "../utils/env-parsing.js";
 import type { ServiceLogger } from "../utils/logger.js";
 // Import shared utilities
 import {
@@ -38,7 +39,11 @@ import {
 import { getSmtpConfig, sendEmailNotification, sendPushNotification } from "./notifications/delivery.js";
 import { updateReminderSentTime, updateUserReminderSentTime } from "./notifications/state.js";
 
-const REMINDER_MINUTES_BEFORE = parseInt(process.env.REMINDER_MINUTES_BEFORE ?? "15", 10);
+const REMINDER_MINUTES_BEFORE = parseIntEnv(process.env.REMINDER_MINUTES_BEFORE, {
+	defaultValue: 15,
+	min: 0,
+	max: 1440,
+});
 const CHECK_INTERVAL_MS = 60 * 1000; // Check every 1 minute
 
 const intakeReminderStateFile = resolve(getDataDir(), "intake-reminder-state.json");

--- a/backend/src/services/notification-actions-service.ts
+++ b/backend/src/services/notification-actions-service.ts
@@ -4,6 +4,7 @@ import { db } from "../db/client.js";
 import { notificationActionGroups, notificationActionTokens } from "../db/schema.js";
 import type { Language } from "../i18n/translations.js";
 import { env } from "../plugins/env.js";
+import { parseStringListEnv } from "../utils/env-parsing.js";
 import { getNotificationActionLabels, type PushNotificationAction } from "./notifications/action-renderer.js";
 
 export type NotificationActionKind = "taken" | "skip" | "respond" | "view";
@@ -58,7 +59,7 @@ function resolveNotificationPublicAppUrl(publicAppUrl: string | null | undefined
 		return normalizePublicAppUrl(configuredUrl.toString());
 	}
 
-	const corsOrigins = env.CORS_ORIGINS.split(",")
+	const corsOrigins = parseStringListEnv(env.CORS_ORIGINS)
 		.map((origin) => parseConfiguredUrl(origin))
 		.filter((origin): origin is URL => origin !== null);
 	const reachableCorsOrigin =

--- a/backend/src/services/notifications/delivery.ts
+++ b/backend/src/services/notifications/delivery.ts
@@ -1,5 +1,6 @@
 import nodemailer from "nodemailer";
 import { sendShoutrrrNotification } from "../../routes/settings.js";
+import { parseBoolEnv, parseIntEnv } from "../../utils/env-parsing.js";
 import type { PushNotificationOptions } from "./action-renderer.js";
 
 type MailDeliveryInfo = {
@@ -58,8 +59,8 @@ export function getSmtpConfig(): {
 	const host = process.env.SMTP_HOST;
 	const user = process.env.SMTP_USER;
 	const pass = process.env.SMTP_TOKEN || process.env.SMTP_PASS;
-	const port = parseInt(process.env.SMTP_PORT ?? "587", 10);
-	const secure = process.env.SMTP_SECURE === "true";
+	const port = parseIntEnv(process.env.SMTP_PORT, { defaultValue: 587, min: 1, max: 65_535 });
+	const secure = parseBoolEnv(process.env.SMTP_SECURE, false);
 	const from = process.env.SMTP_FROM ?? user;
 
 	return { host, user, pass, port, secure, from };

--- a/backend/src/services/reminder-scheduler.ts
+++ b/backend/src/services/reminder-scheduler.ts
@@ -6,6 +6,7 @@ import { getDataDir } from "../db/path-utils.js";
 import { doseTracking, medications } from "../db/schema.js";
 import { getFooterHtml, getFooterPlain, getTranslations, type Language, t } from "../i18n/translations.js";
 import { getAllUserSettings, type UserSettings } from "../routes/settings.js";
+import { parseIntEnv } from "../utils/env-parsing.js";
 import type { ServiceLogger } from "../utils/logger.js";
 import {
 	isAmountBasedPackageType,
@@ -53,7 +54,7 @@ function escapeHtml(text: string): string {
 	return text.replace(/[&<>"']/g, (char) => htmlEscapes[char] || char);
 }
 
-const REMINDER_HOUR = parseInt(process.env.REMINDER_HOUR ?? "6", 10); // Default 6:00 AM local time
+const REMINDER_HOUR = parseIntEnv(process.env.REMINDER_HOUR, { defaultValue: 6, min: 0, max: 23 });
 
 const reminderLocksDir = resolve(getDataDir(), "scheduler-locks");
 const LOCK_STALE_MS = 15 * 60 * 1000;

--- a/backend/src/services/settings-service.ts
+++ b/backend/src/services/settings-service.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { userSettings } from "../db/schema.js";
 import type { Language } from "../i18n/translations.js";
+import { parseBoolEnv, parseIntEnv } from "../utils/env-parsing.js";
 import { isNtfyNotificationUrl } from "./notifications/action-renderer.js";
 
 export type UserSettings = {
@@ -93,16 +94,11 @@ export function getNotificationProvider(url: string): string {
 }
 
 function envBool(key: string, defaultVal: boolean): boolean {
-	const val = process.env[key];
-	if (val === undefined) return defaultVal;
-	return val === "true" || val === "1";
+	return parseBoolEnv(process.env[key], defaultVal);
 }
 
 function envInt(key: string, defaultVal: number): number {
-	const val = process.env[key];
-	if (val === undefined) return defaultVal;
-	const parsed = parseInt(val, 10);
-	return Number.isNaN(parsed) ? defaultVal : parsed;
+	return parseIntEnv(process.env[key], { defaultValue: defaultVal, min: 0, max: 100_000 });
 }
 
 export function getDefaultSettings() {

--- a/backend/src/test/env-docs-consistency.test.ts
+++ b/backend/src/test/env-docs-consistency.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const documentedDefaultSettingEnvVars = new Set([
+	"DEFAULT_EMAIL_ENABLED",
+	"DEFAULT_NOTIFICATION_EMAIL",
+	"DEFAULT_EMAIL_STOCK_REMINDERS",
+	"DEFAULT_EMAIL_INTAKE_REMINDERS",
+	"DEFAULT_EMAIL_PRESCRIPTION_REMINDERS",
+	"DEFAULT_SHOUTRRR_ENABLED",
+	"DEFAULT_SHOUTRRR_URL",
+	"DEFAULT_SHOUTRRR_STOCK_REMINDERS",
+	"DEFAULT_SHOUTRRR_INTAKE_REMINDERS",
+	"DEFAULT_SHOUTRRR_PRESCRIPTION_REMINDERS",
+	"DEFAULT_REPEAT_DAILY_REMINDERS",
+	"DEFAULT_SKIP_REMINDERS_FOR_TAKEN_DOSES",
+	"DEFAULT_REPEAT_REMINDERS_ENABLED",
+	"DEFAULT_REMINDER_REPEAT_INTERVAL_MINUTES",
+	"DEFAULT_MAX_NAGGING_REMINDERS",
+	"DEFAULT_LOW_STOCK_DAYS",
+	"DEFAULT_NORMAL_STOCK_DAYS",
+	"DEFAULT_HIGH_STOCK_DAYS",
+	"DEFAULT_LANGUAGE",
+	"DEFAULT_STOCK_CALCULATION_MODE",
+	"DEFAULT_SHARE_MEDICATION_OVERVIEW",
+	"DEFAULT_UPCOMING_TODAY_ONLY",
+	"DEFAULT_SHARE_SCHEDULE_TODAY_ONLY",
+]);
+
+const docsWithDefaultSettings = [
+	".env.example",
+	"docs/DEFAULT_USER_SETTINGS.md",
+	"docs/PUSH_NOTIFICATIONS.md",
+	"docs/CONFIGURATION.md",
+	"README.md",
+];
+const nonEnvDefaultReferences = new Set(["DEFAULT_USER_SETTINGS"]);
+const removedShareStockStatusEnvVar = ["DEFAULT", "SHARE", "STOCK", "STATUS"].join("_");
+
+function readRepoFile(path: string): string {
+	return readFileSync(resolve(process.cwd(), "..", path), "utf-8");
+}
+
+function extractDefaultEnvVars(content: string): Set<string> {
+	return new Set(
+		(content.match(/\bDEFAULT_[A-Z0-9_]+\b/g) ?? []).filter((envVar) => !nonEnvDefaultReferences.has(envVar))
+	);
+}
+
+describe("environment documentation consistency", () => {
+	it("does not mention the removed share stock-status default setting", () => {
+		const content = docsWithDefaultSettings.map(readRepoFile).join("\n");
+
+		expect(content).not.toContain(removedShareStockStatusEnvVar);
+	});
+
+	it("only documents DEFAULT_* variables that are current default-user settings", () => {
+		const documentedVars = new Set<string>();
+		for (const file of docsWithDefaultSettings) {
+			for (const envVar of extractDefaultEnvVars(readRepoFile(file))) {
+				documentedVars.add(envVar);
+			}
+		}
+
+		const staleVars = [...documentedVars].filter((envVar) => !documentedDefaultSettingEnvVars.has(envVar)).sort();
+		expect(staleVars).toEqual([]);
+		expect(documentedVars).toContain("DEFAULT_SHARE_MEDICATION_OVERVIEW");
+	});
+});

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -24,12 +24,16 @@ describe("plugins/env runtime validation", () => {
 		delete process.env.JWT_SECRET;
 		delete process.env.REFRESH_SECRET;
 		delete process.env.COOKIE_SECRET;
+		delete process.env.CORS_ORIGINS;
+		delete process.env.RATE_LIMIT_MAX;
 
 		const mod = await import("../plugins/env.js");
 		expect(mod.env.AUTH_ENABLED).toBe(false);
 		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
 		expect(mod.env.OIDC_ENABLED).toBe(false);
 		expect(mod.env.PORT).toBe(3000);
+		expect(mod.env.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4174");
+		expect(mod.env.RATE_LIMIT_MAX).toBe(100);
 		expect(mod.env.SHARE_TOKEN_TTL_DAYS).toBe(90);
 		expect(mod.env.SENSITIVE_LOGGING_ENABLED).toBe(false);
 		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
@@ -89,6 +93,77 @@ describe("plugins/env runtime validation", () => {
 		const mod = await import("../plugins/env.js");
 		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
 		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
+	});
+
+	it("accepts common boolean variants", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "yes";
+		process.env.ALLOW_UNAUTHENTICATED = "0";
+		process.env.REGISTRATION_ENABLED = "1";
+		process.env.FORM_LOGIN_ENABLED = "TRUE";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.OPENAPI_DOCS_ENABLED = "no";
+		process.env.DOCS_AUTH_REQUIRED = "yes";
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.AUTH_ENABLED).toBe(true);
+		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
+		expect(mod.env.REGISTRATION_ENABLED).toBe(true);
+		expect(mod.env.FORM_LOGIN_ENABLED).toBe(true);
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(false);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(true);
+	});
+
+	it("exits when a boolean env value is invalid", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "maybe";
+
+		vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as never);
+
+		await expect(import("../plugins/env.js")).rejects.toThrow("process.exit:1");
+	});
+
+	it("exits when ACCESS_TOKEN_TTL_MINUTES is invalid", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.ACCESS_TOKEN_TTL_MINUTES = "abc";
+
+		vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as never);
+
+		await expect(import("../plugins/env.js")).rejects.toThrow("process.exit:1");
+	});
+
+	it("exits when RATE_LIMIT_MAX is not positive and bounded", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.RATE_LIMIT_MAX = "100001";
+
+		vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as never);
+
+		await expect(import("../plugins/env.js")).rejects.toThrow("process.exit:1");
+	});
+
+	it("trims CORS_ORIGINS and filters empty entries", async () => {
+		process.env.NODE_ENV = "test";
+		process.env.AUTH_ENABLED = "false";
+		process.env.CORS_ORIGINS = " http://localhost:5173, , http://localhost:4174, ";
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4174");
 	});
 
 	it("loads when development auth is disabled", async () => {

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -1,73 +1,64 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { parseBoolEnv, parseIntEnv, parseStringListEnv } from "../utils/env-parsing.js";
 
 // Mock process.exit to prevent tests from exiting
 const mockExit = vi.fn();
 vi.spyOn(process, "exit").mockImplementation(mockExit as unknown as (...args: unknown[]) => never);
 
 // Re-create the schema from env.ts for testing
+const DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
+
+function boolEnv(defaultValue: boolean) {
+	return z
+		.string()
+		.optional()
+		.transform((value) => parseBoolEnv(value, defaultValue));
+}
+
+function optionalBoolEnv() {
+	return z
+		.string()
+		.optional()
+		.transform((value) => (value === undefined ? undefined : parseBoolEnv(value, false)));
+}
+
+function intEnv(options: { defaultValue: number; min?: number; max?: number }) {
+	return z
+		.string()
+		.optional()
+		.transform((value) => parseIntEnv(value, options));
+}
+
 const EnvSchema = z.object({
 	NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
-	PORT: z
+	PORT: intEnv({ defaultValue: 3000, min: 1, max: 65535 }),
+	CORS_ORIGINS: z
 		.string()
-		.default("3000")
-		.transform((v) => parseInt(v, 10)),
-	CORS_ORIGINS: z.string().default("http://localhost:5173,http://localhost:4173"),
+		.optional()
+		.transform((value) => parseStringListEnv(value ?? DEFAULT_CORS_ORIGINS).join(",")),
 	LOG_LEVEL: z.string().default("info"),
-	SENSITIVE_LOGGING_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	SENSITIVE_LOGGING_ENABLED: boolEnv(false),
 	PUBLIC_APP_URL: z.string().url().optional(),
-	OPENAPI_DOCS_ENABLED: z
-		.string()
-		.transform((v) => v === "true")
-		.optional(),
-	DOCS_AUTH_REQUIRED: z
-		.string()
-		.transform((v) => v === "true")
-		.optional(),
-	AUTH_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
-	ALLOW_UNAUTHENTICATED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
-	REGISTRATION_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	OPENAPI_DOCS_ENABLED: optionalBoolEnv(),
+	DOCS_AUTH_REQUIRED: optionalBoolEnv(),
+	RATE_LIMIT_MAX: intEnv({ defaultValue: 100, min: 1, max: 100_000 }),
+	AUTH_ENABLED: boolEnv(false),
+	ALLOW_UNAUTHENTICATED: boolEnv(false),
+	REGISTRATION_ENABLED: boolEnv(false),
 	JWT_SECRET: z.string().min(10).optional(),
 	REFRESH_SECRET: z.string().min(10).optional(),
 	COOKIE_SECRET: z.string().min(10).optional(),
-	ACCESS_TOKEN_TTL_MINUTES: z
-		.string()
-		.default("15")
-		.transform((v) => parseInt(v, 10)),
-	REFRESH_TOKEN_TTL_DAYS: z
-		.string()
-		.default("7")
-		.transform((v) => parseInt(v, 10)),
-	SHARE_TOKEN_TTL_DAYS: z
-		.string()
-		.default("90")
-		.transform((v) => parseInt(v, 10))
-		.pipe(z.number().int().min(1).max(3650)),
-	OIDC_ENABLED: z
-		.string()
-		.default("false")
-		.transform((v) => v === "true"),
+	ACCESS_TOKEN_TTL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 525_600 }),
+	REFRESH_TOKEN_TTL_DAYS: intEnv({ defaultValue: 7, min: 1, max: 3650 }),
+	SHARE_TOKEN_TTL_DAYS: intEnv({ defaultValue: 90, min: 1, max: 3650 }),
+	OIDC_ENABLED: boolEnv(false),
 	OIDC_ISSUER_URL: z.string().url().optional(),
 	OIDC_CLIENT_ID: z.string().optional(),
 	OIDC_CLIENT_SECRET: z.string().optional(),
 	OIDC_REDIRECT_URI: z.string().url().optional(),
 	OIDC_SCOPES: z.string().default("openid profile email"),
-	OIDC_AUTO_CREATE_USERS: z
-		.string()
-		.default("true")
-		.transform((v) => v === "true"),
+	OIDC_AUTO_CREATE_USERS: boolEnv(true),
 	OIDC_USERNAME_CLAIM: z.string().default("preferred_username"),
 	OIDC_PROVIDER_NAME: z.string().default("SSO"),
 });
@@ -101,7 +92,7 @@ describe("EnvSchema", () => {
 
 			expect(result.NODE_ENV).toBe("production");
 			expect(result.PORT).toBe(3000);
-			expect(result.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4173");
+			expect(result.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4174");
 			expect(result.LOG_LEVEL).toBe("info");
 			expect(result.SENSITIVE_LOGGING_ENABLED).toBe(false);
 			expect(result.PUBLIC_APP_URL).toBeUndefined();
@@ -110,6 +101,7 @@ describe("EnvSchema", () => {
 			expect(result.AUTH_ENABLED).toBe(false);
 			expect(result.ALLOW_UNAUTHENTICATED).toBe(false);
 			expect(result.REGISTRATION_ENABLED).toBe(false);
+			expect(result.RATE_LIMIT_MAX).toBe(100);
 			expect(result.ACCESS_TOKEN_TTL_MINUTES).toBe(15);
 			expect(result.REFRESH_TOKEN_TTL_DAYS).toBe(7);
 			expect(result.SHARE_TOKEN_TTL_DAYS).toBe(90);
@@ -156,14 +148,16 @@ describe("EnvSchema", () => {
 	});
 
 	describe("boolean transformations", () => {
-		it("should transform AUTH_ENABLED=true to boolean true", () => {
-			const result = EnvSchema.parse({ AUTH_ENABLED: "true" });
-			expect(result.AUTH_ENABLED).toBe(true);
+		it("should transform truthy boolean variants to true", () => {
+			for (const value of ["true", "TRUE", "1", "yes", "YeS"]) {
+				expect(EnvSchema.parse({ AUTH_ENABLED: value }).AUTH_ENABLED).toBe(true);
+			}
 		});
 
-		it("should transform AUTH_ENABLED=false to boolean false", () => {
-			const result = EnvSchema.parse({ AUTH_ENABLED: "false" });
-			expect(result.AUTH_ENABLED).toBe(false);
+		it("should transform falsy boolean variants to false", () => {
+			for (const value of ["false", "FALSE", "0", "no", "No"]) {
+				expect(EnvSchema.parse({ AUTH_ENABLED: value }).AUTH_ENABLED).toBe(false);
+			}
 		});
 
 		it("should transform ALLOW_UNAUTHENTICATED=true to boolean true", () => {
@@ -176,9 +170,8 @@ describe("EnvSchema", () => {
 			expect(result.ALLOW_UNAUTHENTICATED).toBe(false);
 		});
 
-		it("should treat non-true string as false", () => {
-			const result = EnvSchema.parse({ AUTH_ENABLED: "yes" });
-			expect(result.AUTH_ENABLED).toBe(false);
+		it("should reject invalid boolean strings", () => {
+			expect(() => EnvSchema.parse({ AUTH_ENABLED: "maybe" })).toThrow();
 		});
 
 		it("should transform REGISTRATION_ENABLED correctly", () => {
@@ -197,10 +190,10 @@ describe("EnvSchema", () => {
 		});
 
 		it("should transform API docs booleans correctly", () => {
-			expect(EnvSchema.parse({ OPENAPI_DOCS_ENABLED: "true" }).OPENAPI_DOCS_ENABLED).toBe(true);
-			expect(EnvSchema.parse({ OPENAPI_DOCS_ENABLED: "false" }).OPENAPI_DOCS_ENABLED).toBe(false);
-			expect(EnvSchema.parse({ DOCS_AUTH_REQUIRED: "true" }).DOCS_AUTH_REQUIRED).toBe(true);
-			expect(EnvSchema.parse({ DOCS_AUTH_REQUIRED: "false" }).DOCS_AUTH_REQUIRED).toBe(false);
+			expect(EnvSchema.parse({ OPENAPI_DOCS_ENABLED: "yes" }).OPENAPI_DOCS_ENABLED).toBe(true);
+			expect(EnvSchema.parse({ OPENAPI_DOCS_ENABLED: "0" }).OPENAPI_DOCS_ENABLED).toBe(false);
+			expect(EnvSchema.parse({ DOCS_AUTH_REQUIRED: "1" }).DOCS_AUTH_REQUIRED).toBe(true);
+			expect(EnvSchema.parse({ DOCS_AUTH_REQUIRED: "no" }).DOCS_AUTH_REQUIRED).toBe(false);
 		});
 	});
 
@@ -226,6 +219,11 @@ describe("EnvSchema", () => {
 			expect(result.ACCESS_TOKEN_TTL_MINUTES).toBe(30);
 		});
 
+		it("should reject invalid ACCESS_TOKEN_TTL_MINUTES", () => {
+			expect(() => EnvSchema.parse({ ACCESS_TOKEN_TTL_MINUTES: "abc" })).toThrow();
+			expect(() => EnvSchema.parse({ ACCESS_TOKEN_TTL_MINUTES: "0" })).toThrow();
+		});
+
 		it("should transform REFRESH_TOKEN_TTL_DAYS to number", () => {
 			const result = EnvSchema.parse({ REFRESH_TOKEN_TTL_DAYS: "14" });
 			expect(result.REFRESH_TOKEN_TTL_DAYS).toBe(14);
@@ -234,6 +232,21 @@ describe("EnvSchema", () => {
 		it("should transform SHARE_TOKEN_TTL_DAYS to number", () => {
 			const result = EnvSchema.parse({ SHARE_TOKEN_TTL_DAYS: "120" });
 			expect(result.SHARE_TOKEN_TTL_DAYS).toBe(120);
+		});
+	});
+
+	describe("RATE_LIMIT_MAX validation", () => {
+		it("should transform valid values to positive bounded numbers", () => {
+			expect(EnvSchema.parse({ RATE_LIMIT_MAX: "1" }).RATE_LIMIT_MAX).toBe(1);
+			expect(EnvSchema.parse({ RATE_LIMIT_MAX: "1000" }).RATE_LIMIT_MAX).toBe(1000);
+			expect(EnvSchema.parse({ RATE_LIMIT_MAX: "100000" }).RATE_LIMIT_MAX).toBe(100_000);
+		});
+
+		it("should reject invalid, zero, negative, and unbounded values", () => {
+			expect(() => EnvSchema.parse({ RATE_LIMIT_MAX: "abc" })).toThrow();
+			expect(() => EnvSchema.parse({ RATE_LIMIT_MAX: "0" })).toThrow();
+			expect(() => EnvSchema.parse({ RATE_LIMIT_MAX: "-1" })).toThrow();
+			expect(() => EnvSchema.parse({ RATE_LIMIT_MAX: "100001" })).toThrow();
 		});
 	});
 
@@ -275,6 +288,11 @@ describe("EnvSchema", () => {
 		it("should accept single origin", () => {
 			const result = EnvSchema.parse({ CORS_ORIGINS: "http://localhost:3000" });
 			expect(result.CORS_ORIGINS).toBe("http://localhost:3000");
+		});
+
+		it("should trim origins and filter empty entries", () => {
+			const result = EnvSchema.parse({ CORS_ORIGINS: " http://a.com, , http://b.com, " });
+			expect(result.CORS_ORIGINS).toBe("http://a.com,http://b.com");
 		});
 	});
 });

--- a/backend/src/test/notification-actions-service.test.ts
+++ b/backend/src/test/notification-actions-service.test.ts
@@ -15,7 +15,7 @@ const { testClient, testDb, mockedEnv } = vi.hoisted(() => {
 		testDb: db,
 		mockedEnv: {
 			PUBLIC_APP_URL: "https://app.example.com",
-			CORS_ORIGINS: "http://localhost:5173,http://localhost:4173",
+			CORS_ORIGINS: "http://localhost:5173,http://localhost:4174",
 		},
 	};
 });
@@ -72,7 +72,7 @@ describe("notification-actions-service", () => {
 	beforeEach(async () => {
 		await clearTables();
 		mockedEnv.PUBLIC_APP_URL = "https://app.example.com";
-		mockedEnv.CORS_ORIGINS = "http://localhost:5173,http://localhost:4173";
+		mockedEnv.CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
 	});
 
 	it("creates a notification action group with hashed tokens and app/view links", async () => {

--- a/backend/src/test/server.test.ts
+++ b/backend/src/test/server.test.ts
@@ -21,10 +21,10 @@ import {
 describe("Index.ts Utility Functions", () => {
 	describe("parseCorsOrigins", () => {
 		it("should parse comma-separated origins", () => {
-			const origins = parseCorsOrigins("http://localhost:5173,http://localhost:4173");
+			const origins = parseCorsOrigins("http://localhost:5173,http://localhost:4174");
 			expect(origins).toHaveLength(2);
 			expect(origins[0]).toBe("http://localhost:5173");
-			expect(origins[1]).toBe("http://localhost:4173");
+			expect(origins[1]).toBe("http://localhost:4174");
 		});
 
 		it("should handle single origin", () => {
@@ -34,13 +34,13 @@ describe("Index.ts Utility Functions", () => {
 		});
 
 		it("should filter out empty strings", () => {
-			const origins = parseCorsOrigins("http://localhost:5173,,http://localhost:4173,");
+			const origins = parseCorsOrigins("http://localhost:5173,,http://localhost:4174,");
 			expect(origins).toHaveLength(2);
 		});
 
 		it("should trim whitespace", () => {
-			const origins = parseCorsOrigins(" http://localhost:5173 , http://localhost:4173 ");
-			expect(origins).toEqual(["http://localhost:5173", "http://localhost:4173"]);
+			const origins = parseCorsOrigins(" http://localhost:5173 , http://localhost:4174 ");
+			expect(origins).toEqual(["http://localhost:5173", "http://localhost:4174"]);
 		});
 
 		it("should return empty array for empty string", () => {
@@ -219,7 +219,7 @@ describe("Server Bootstrap", () => {
 		});
 
 		it("should register cors plugin with multiple origins", async () => {
-			const origins = ["http://localhost:5173", "http://localhost:4173"];
+			const origins = ["http://localhost:5173", "http://localhost:4174"];
 
 			const app = Fastify({ logger: false, ajv: documentationSchemaAjv });
 			await app.register(cors, { origin: origins, credentials: true });
@@ -366,46 +366,34 @@ describe("Server Bootstrap", () => {
 
 	describe("CORS Origins Parsing", () => {
 		it("should parse comma-separated origins", () => {
-			const originsEnv = "http://localhost:5173,http://localhost:4173";
-			const origins = originsEnv
-				.split(",")
-				.map((o) => o.trim())
-				.filter(Boolean);
+			const originsEnv = "http://localhost:5173,http://localhost:4174";
+			const origins = parseCorsOrigins(originsEnv);
 
 			expect(origins).toHaveLength(2);
 			expect(origins[0]).toBe("http://localhost:5173");
-			expect(origins[1]).toBe("http://localhost:4173");
+			expect(origins[1]).toBe("http://localhost:4174");
 		});
 
 		it("should handle single origin", () => {
 			const originsEnv = "https://myapp.example.com";
-			const origins = originsEnv
-				.split(",")
-				.map((o) => o.trim())
-				.filter(Boolean);
+			const origins = parseCorsOrigins(originsEnv);
 
 			expect(origins).toHaveLength(1);
 			expect(origins[0]).toBe("https://myapp.example.com");
 		});
 
 		it("should filter out empty strings", () => {
-			const originsEnv = "http://localhost:5173,,http://localhost:4173,";
-			const origins = originsEnv
-				.split(",")
-				.map((o) => o.trim())
-				.filter(Boolean);
+			const originsEnv = "http://localhost:5173,,http://localhost:4174,";
+			const origins = parseCorsOrigins(originsEnv);
 
 			expect(origins).toHaveLength(2);
 		});
 
 		it("should trim whitespace", () => {
-			const originsEnv = " http://localhost:5173 , http://localhost:4173 ";
-			const origins = originsEnv
-				.split(",")
-				.map((o) => o.trim())
-				.filter(Boolean);
+			const originsEnv = " http://localhost:5173 , http://localhost:4174 ";
+			const origins = parseCorsOrigins(originsEnv);
 
-			expect(origins).toEqual(["http://localhost:5173", "http://localhost:4173"]);
+			expect(origins).toEqual(["http://localhost:5173", "http://localhost:4174"]);
 		});
 	});
 

--- a/backend/src/utils/env-parsing.ts
+++ b/backend/src/utils/env-parsing.ts
@@ -1,0 +1,63 @@
+export interface ParseIntEnvOptions {
+	defaultValue: number;
+	min?: number;
+	max?: number;
+}
+
+function normalizeEnvValue(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export function parseBoolEnv(value: string | null | undefined, defaultValue: boolean): boolean {
+	const normalized = normalizeEnvValue(value);
+	if (normalized === undefined) {
+		return defaultValue;
+	}
+
+	switch (normalized.toLowerCase()) {
+		case "true":
+		case "1":
+		case "yes":
+			return true;
+		case "false":
+		case "0":
+		case "no":
+			return false;
+		default:
+			throw new Error(`Invalid boolean environment value: ${value}`);
+	}
+}
+
+export function parseIntEnv(value: string | null | undefined, options: ParseIntEnvOptions): number {
+	const normalized = normalizeEnvValue(value);
+	if (normalized === undefined) {
+		return options.defaultValue;
+	}
+
+	if (!/^-?\d+$/.test(normalized)) {
+		throw new Error(`Invalid integer environment value: ${value}`);
+	}
+
+	const parsed = Number.parseInt(normalized, 10);
+	if (!Number.isSafeInteger(parsed)) {
+		throw new Error(`Invalid integer environment value: ${value}`);
+	}
+
+	if (options.min !== undefined && parsed < options.min) {
+		throw new Error(`Environment integer value ${parsed} is below minimum ${options.min}`);
+	}
+
+	if (options.max !== undefined && parsed > options.max) {
+		throw new Error(`Environment integer value ${parsed} is above maximum ${options.max}`);
+	}
+
+	return parsed;
+}
+
+export function parseStringListEnv(value: string | null | undefined): string[] {
+	return (value ?? "")
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+}

--- a/backend/src/utils/server-config.ts
+++ b/backend/src/utils/server-config.ts
@@ -7,15 +7,13 @@ import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import type { CookieSerializeOptions } from "@fastify/cookie";
 import { getDataDir } from "../db/path-utils.js";
+import { parseStringListEnv } from "./env-parsing.js";
 
 /**
  * Parse comma-separated CORS origins string
  */
 export function parseCorsOrigins(originsStr: string): string[] {
-	return originsStr
-		.split(",")
-		.map((o) => o.trim())
-		.filter((o) => o.length > 0);
+	return parseStringListEnv(originsStr);
 }
 
 /**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,7 +9,7 @@ Configure MedAssist with environment variables in `.env`. Start from `.env.examp
 | `PUID` | `1000` | User ID for container file permissions |
 | `PGID` | `1000` | Group ID for container file permissions |
 | `PORT` | `3000` | Backend API port |
-| `CORS_ORIGINS` | `http://localhost:4174` | Allowed origins for CORS in the Docker Compose quickstart; local Vite development commonly uses `http://localhost:5173` or `http://localhost:4173` |
+| `CORS_ORIGINS` | `http://localhost:5173,http://localhost:4174` | Allowed origins for CORS. The backend schema default covers local Vite development and the Docker Compose quickstart; `.env.example` sets only the Docker quickstart origin. |
 | `TZ` | `Europe/Berlin` | Server default timezone for scheduled reminders |
 | `PUBLIC_APP_URL` | — | Public base URL for notification action and share links. Strongly recommended for any deployment used from another device; do not point this to `localhost` or an internal Docker hostname. Local Vite development also allows this hostname automatically. |
 | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error`, or `silent` |
@@ -29,7 +29,7 @@ API docs behavior:
 `CORS_ORIGINS` note:
 
 - The `.env.example` file is optimized for the Docker Compose quickstart, where the frontend runs on `http://localhost:4174`.
-- Local frontend development uses the Vite dev server instead, so the backend schema defaults cover `http://localhost:5173` and `http://localhost:4173`.
+- Local frontend development uses the Vite dev server instead, so the backend schema defaults cover `http://localhost:5173` and `http://localhost:4174`.
 - If you use a custom hostname or reverse proxy, include that origin in `CORS_ORIGINS`.
 
 ## Authentication


### PR DESCRIPTION
Closes #669

## Summary
- extract shared env parsing helpers and standardize config coercion
- align runtime defaults and configuration docs
- add regression coverage for env parsing, runtime behavior, and docs consistency

## Validation
- targeted backend tests: `env-docs-consistency`, `env-runtime`, `env`, `notification-actions-service`, `server`
- `cd backend && npm run check && npm run build` in isolated shipping worktree
