### PR TITLE
chore: release 1.26.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.26.1
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.26.2
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.26.1
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.26.2
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.26.1",
+  "version": "1.26.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Prepare patch release v1.26.2.

- bump backend and frontend app versions to 1.26.2
- pin production docker images to 1.26.2