### PR TITLE
fix(observability): improve error correlation logging

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -330,14 +330,26 @@ const start = async () => {
 			info: (msg) => app.log.info(msg),
 			debug: (msg) => app.log.debug(msg),
 			warn: (msg) => app.log.warn(msg),
-			error: (msg) => app.log.error(msg),
+			error: (msg, error) => {
+				if (error === undefined) {
+					app.log.error(msg);
+					return;
+				}
+				app.log.error({ err: error }, msg);
+			},
 		});
 
 		startMedicationEnrichmentCatalogRefresh({
 			info: (msg: string) => app.log.info(msg),
 			debug: (msg: string) => app.log.debug(msg),
 			warn: (msg: string) => app.log.warn(msg),
-			error: (msg: string) => app.log.error(msg),
+			error: (msg: string, error?: unknown) => {
+				if (error === undefined) {
+					app.log.error(msg);
+					return;
+				}
+				app.log.error({ err: error }, msg);
+			},
 		});
 
 		// Start the intake reminder scheduler (checks every minute)
@@ -345,7 +357,13 @@ const start = async () => {
 			info: (msg) => app.log.info(msg),
 			debug: (msg) => app.log.debug(msg),
 			warn: (msg) => app.log.warn(msg),
-			error: (msg) => app.log.error(msg),
+			error: (msg, error) => {
+				if (error === undefined) {
+					app.log.error(msg);
+					return;
+				}
+				app.log.error({ err: error }, msg);
+			},
 		});
 	} catch (err) {
 		app.log.error(err);

--- a/backend/src/services/intake-reminder-scheduler.ts
+++ b/backend/src/services/intake-reminder-scheduler.ts
@@ -1041,11 +1041,11 @@ export function startIntakeReminderScheduler(logger: ServiceLogger): void {
 	logger.info(`[IntakeReminder] Starting intake reminder scheduler (checks every minute)...`);
 
 	// Run immediately on start
-	checkAndSendIntakeReminders(logger).catch((err) => logger.error(`[IntakeReminder] Error: ${err}`));
+	checkAndSendIntakeReminders(logger).catch((err) => logger.error("[IntakeReminder] Startup check failed", err));
 
 	// Then run every minute
 	intakeCheckInterval = setInterval(() => {
-		checkAndSendIntakeReminders(logger).catch((err) => logger.error(`[IntakeReminder] Error: ${err}`));
+		checkAndSendIntakeReminders(logger).catch((err) => logger.error("[IntakeReminder] Scheduled check failed", err));
 	}, CHECK_INTERVAL_MS);
 
 	logger.info(`[IntakeReminder] Scheduler started - checking every minute for upcoming intakes`);

--- a/backend/src/services/reminder-scheduler.ts
+++ b/backend/src/services/reminder-scheduler.ts
@@ -847,7 +847,7 @@ function scheduleNextCheck(logger: ServiceLogger): void {
 	);
 
 	schedulerTimeout = setTimeout(() => {
-		checkAndSendReminder(logger).catch((err) => logger.error(`[Reminder] Error: ${err}`));
+		checkAndSendReminder(logger).catch((err) => logger.error("[Reminder] Scheduled check failed", err));
 		// Schedule the next check after this one completes
 		scheduleNextCheck(logger);
 	}, msUntilNext);
@@ -870,7 +870,7 @@ export function startReminderScheduler(logger: ServiceLogger): void {
 	// This is intentionally a single current-state snapshot (no replay of missed days).
 	if (currentHour >= REMINDER_HOUR && state.lastStockSchedulerCheckDate !== today) {
 		logger.info("[Reminder] Missed today's check, running one catch-up snapshot (no historical replay)...");
-		checkAndSendReminder(logger).catch((err) => logger.error(`[Reminder] Error: ${err}`));
+		checkAndSendReminder(logger).catch((err) => logger.error("[Reminder] Catch-up check failed", err));
 	}
 
 	// Schedule next check at REMINDER_HOUR

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -47,5 +47,5 @@ export type ServiceLogger = {
 	info: (msg: string) => void;
 	debug: (msg: string) => void;
 	warn: (msg: string) => void;
-	error: (msg: string) => void;
+	error: (msg: string, error?: unknown) => void;
 };

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -3,7 +3,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useR
 import { useTranslation } from "react-i18next";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useModalHistory } from "../hooks/useModalHistory";
-import { withCorrelation } from "../utils/correlation";
+import { createCorrelationId, withCorrelation } from "../utils/correlation";
 import { MAX_IMAGE_UPLOAD_BYTES, resolveImageUploadError } from "../utils/image-upload";
 import { log } from "../utils/logger";
 import { ConfirmModal } from "./ConfirmModal";
@@ -49,6 +49,65 @@ interface AuthContextType {
 // Context
 // =============================================================================
 const AuthContext = createContext<AuthContextType | null>(null);
+
+function getRequestUrl(input: RequestInfo | URL): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	if (typeof Request !== "undefined" && input instanceof Request) return input.url;
+	return String(input);
+}
+
+function getRequestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+	if (init?.method) return init.method.toUpperCase();
+	if (typeof Request !== "undefined" && input instanceof Request) return input.method.toUpperCase();
+	return "GET";
+}
+
+function redactApiPath(path: string): string {
+	return path.replace(/(\/api\/share\/)(?:[a-f0-9]{16}|[a-f0-9]{64})(?=\/|$|\?)/gi, "$1[share-token]");
+}
+
+function getRequestLogPath(input: RequestInfo | URL): string {
+	const rawUrl = getRequestUrl(input);
+	try {
+		return redactApiPath(new URL(rawUrl, "http://localhost").pathname);
+	} catch {
+		return redactApiPath(rawUrl.split("?")[0] ?? rawUrl);
+	}
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function isPollingRequest(path: string, method: string): boolean {
+	if (method !== "GET") return false;
+	return path === "/api/doses/taken" || /^\/api\/share\/[^/]+\/doses$/.test(path);
+}
+
+function shouldWarnForResponse(path: string, method: string, response: Response): boolean {
+	if (response.ok || isPollingRequest(path, method)) return false;
+	if (method === "GET" || method === "HEAD") return response.status >= 500;
+	return true;
+}
+
+function withAuthFetchCorrelation(init?: RequestInit): { correlationId: string; init: RequestInit } {
+	const headers = new Headers(init?.headers ?? {});
+	const existingCorrelationId = headers.get("x-correlation-id")?.trim();
+	const correlationId = existingCorrelationId || createCorrelationId("fe-api");
+	if (!existingCorrelationId) {
+		headers.set("x-correlation-id", correlationId);
+	}
+
+	return {
+		correlationId,
+		init: {
+			...init,
+			headers,
+			credentials: "include",
+		},
+	};
+}
 
 export function useAuth() {
 	const context = useContext(AuthContext);
@@ -228,15 +287,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	}
 
 	async function register(username: string, password: string) {
-		const res = await fetch("/api/auth/register", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			credentials: "include",
-			body: JSON.stringify({ username, password }),
-		});
+		const { correlationId, init } = withCorrelation(
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include",
+				body: JSON.stringify({ username, password }),
+			},
+			"fe-auth-register"
+		);
+		const res = await fetch("/api/auth/register", init);
 
 		if (!res.ok) {
 			const data = await res.json();
+			log.warn("[Auth] Registration failed", { status: res.status, code: data.code, correlationId });
 			throw new Error(data.error || "Registration failed");
 		}
 
@@ -264,15 +328,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	}
 
 	async function updateProfile(data: { currentPassword?: string; newPassword?: string }) {
-		const res = await fetch("/api/auth/me", {
-			method: "PUT",
-			headers: { "Content-Type": "application/json" },
-			credentials: "include",
-			body: JSON.stringify(data),
-		});
+		const { correlationId, init } = withCorrelation(
+			{
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include",
+				body: JSON.stringify(data),
+			},
+			"fe-auth-profile"
+		);
+		const res = await fetch("/api/auth/me", init);
 
 		if (!res.ok) {
 			const err = await res.json();
+			log.warn("[Auth] Profile update failed", { status: res.status, code: err.code, correlationId });
 			throw new Error(err.error || "Update failed");
 		}
 
@@ -284,11 +353,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		const formData = new FormData();
 		formData.append("file", file);
 
-		const res = await fetch("/api/auth/avatar", {
-			method: "POST",
-			credentials: "include",
-			body: formData,
-		});
+		const { correlationId, init } = withCorrelation(
+			{
+				method: "POST",
+				credentials: "include",
+				body: formData,
+			},
+			"fe-auth-avatar"
+		);
+		const res = await fetch("/api/auth/avatar", init);
 
 		if (!res.ok) {
 			let code = "UNKNOWN";
@@ -300,6 +373,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			} catch {
 				// No JSON body
 			}
+			log.warn("[Auth] Avatar upload failed", { status: res.status, code, correlationId });
 			throw new Error(code);
 		}
 
@@ -308,13 +382,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 	// Delete avatar
 	async function deleteAvatar() {
-		const res = await fetch("/api/auth/avatar", {
-			method: "DELETE",
-			credentials: "include",
-		});
+		const { correlationId, init } = withCorrelation(
+			{
+				method: "DELETE",
+				credentials: "include",
+			},
+			"fe-auth-avatar-delete"
+		);
+		const res = await fetch("/api/auth/avatar", init);
 
 		if (!res.ok) {
 			const err = await res.json().catch(() => ({ error: "Delete failed" }));
+			log.warn("[Auth] Avatar delete failed", { status: res.status, code: err.code, correlationId });
 			throw new Error(err.error || "Delete failed");
 		}
 
@@ -323,13 +402,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 	// Delete account
 	async function deleteAccount() {
-		const res = await fetch("/api/auth/me", {
-			method: "DELETE",
-			credentials: "include",
-		});
+		const { correlationId, init } = withCorrelation(
+			{
+				method: "DELETE",
+				credentials: "include",
+			},
+			"fe-auth-account-delete"
+		);
+		const res = await fetch("/api/auth/me", init);
 
 		if (!res.ok) {
 			const err = await res.json().catch(() => ({ error: "Delete failed" }));
+			log.warn("[Auth] Account delete failed", { status: res.status, code: err.code, correlationId });
 			throw new Error(err.error || "Delete failed");
 		}
 
@@ -339,19 +423,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	// Fetch wrapper that automatically refreshes token on 401
 	const authFetch = useCallback(
 		async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-			const options: RequestInit = {
-				...init,
-				credentials: "include",
-			};
+			const method = getRequestMethod(input, init);
+			const path = getRequestLogPath(input);
+			const correlated = withAuthFetchCorrelation(init);
+			const options = correlated.init;
+			const { correlationId } = correlated;
 
-			let res = await fetch(input, options);
+			let res: Response;
+			try {
+				res = await fetch(input, options);
+			} catch (error) {
+				const details = { method, path, correlationId, error: getErrorMessage(error) };
+				if (isPollingRequest(path, method)) {
+					log.debug("[Auth] API polling request failed", details);
+				} else {
+					log.error("[Auth] API request failed", details);
+				}
+				throw error;
+			}
 
 			// If 401 and not already a refresh/login request, try to refresh token
-			if (res.status === 401 && !String(input).includes("/auth/")) {
+			let retried = false;
+			if (res.status === 401 && !path.startsWith("/api/auth/")) {
 				const refreshed = await tryRefreshToken();
 				if (refreshed) {
 					// Retry the original request with new token
-					res = await fetch(input, options);
+					retried = true;
+					try {
+						res = await fetch(input, options);
+					} catch (error) {
+						log.error("[Auth] API retry request failed", {
+							method,
+							path,
+							correlationId,
+							error: getErrorMessage(error),
+						});
+						throw error;
+					}
 					if (res.ok) {
 						setSessionExpired(false);
 					}
@@ -360,6 +468,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 					setUser(null);
 					setSessionExpired(true);
 				}
+			}
+
+			if (shouldWarnForResponse(path, method, res)) {
+				log.warn("[Auth] API request completed with failure status", {
+					method,
+					path,
+					status: res.status,
+					correlationId,
+					retried,
+				});
 			}
 
 			return res;

--- a/frontend/src/hooks/useDoses.ts
+++ b/frontend/src/hooks/useDoses.ts
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
 import { useFeedback } from "../context/FeedbackContext";
+import { log } from "../utils/logger";
 
 export interface UseDosesReturn {
 	takenDoses: Set<string>;
@@ -23,6 +24,10 @@ export interface UseDosesReturn {
 	undoDoseTaken: (doseId: string) => Promise<void>;
 	undoDoseSkipped: (doseId: string) => Promise<void>;
 	loadTakenDoses: () => Promise<void>;
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 export function useDoses(): UseDosesReturn {
@@ -78,9 +83,12 @@ export function useDoses(): UseDosesReturn {
 			} else if (res.status === 401 || res.status === 403) {
 				// Prevent showing previous user's dose state after auth/session changes.
 				clearDosesState();
+			} else {
+				log.debug("[useDoses] dose polling failed", { status: res.status });
 			}
 			// Don't reset on error - keep current state
-		} catch {
+		} catch (error) {
+			log.debug("[useDoses] dose polling request failed", { error: getErrorMessage(error) });
 			// Don't reset on error - keep current state
 		}
 	}, [authFetch, clearDosesState]);
@@ -167,6 +175,8 @@ export function useDoses(): UseDosesReturn {
 			});
 
 			// Send to server
+			let failureStatus: number | null = null;
+			let failureCode: string | null = null;
 			try {
 				const response = await authFetch("/api/doses/taken", {
 					method: "POST",
@@ -174,12 +184,19 @@ export function useDoses(): UseDosesReturn {
 					body: JSON.stringify({ doseId }),
 				});
 				if (!response.ok) {
-					if ((await getErrorCode(response)) === "OUT_OF_STOCK") {
+					failureStatus = response.status;
+					failureCode = await getErrorCode(response);
+					if (failureCode === "OUT_OF_STOCK") {
 						showFeedback({ message: t("common.outOfStockTakeBlocked"), tone: "error" });
 					}
-					throw new Error("Failed to mark dose as taken");
+					throw new Error(`HTTP ${response.status}`);
 				}
-			} catch {
+			} catch (error) {
+				log.warn("[useDoses] mark dose taken failed", {
+					status: failureStatus,
+					code: failureCode,
+					error: getErrorMessage(error),
+				});
 				// Revert on error
 				setTakenDoses((prev) => {
 					const next = new Set(prev);
@@ -269,6 +286,7 @@ export function useDoses(): UseDosesReturn {
 				return next;
 			});
 
+			let failureStatus: number | null = null;
 			try {
 				const response = await authFetch("/api/doses/skip", {
 					method: "POST",
@@ -276,9 +294,14 @@ export function useDoses(): UseDosesReturn {
 					body: JSON.stringify({ doseId }),
 				});
 				if (!response.ok) {
-					throw new Error("Failed to mark dose as skipped");
+					failureStatus = response.status;
+					throw new Error(`HTTP ${response.status}`);
 				}
-			} catch {
+			} catch (error) {
+				log.warn("[useDoses] mark dose skipped failed", {
+					status: failureStatus,
+					error: getErrorMessage(error),
+				});
 				setDismissedDoses((prev) => {
 					const next = new Set(prev);
 					if (wasSkipped) {
@@ -341,11 +364,20 @@ export function useDoses(): UseDosesReturn {
 			});
 
 			// Send to server
+			let failureStatus: number | null = null;
 			try {
-				await authFetch(`/api/doses/taken/${encodeURIComponent(doseId)}`, {
+				const response = await authFetch(`/api/doses/taken/${encodeURIComponent(doseId)}`, {
 					method: "DELETE",
 				});
-			} catch {
+				if (!response.ok) {
+					failureStatus = response.status;
+					throw new Error(`HTTP ${response.status}`);
+				}
+			} catch (error) {
+				log.warn("[useDoses] undo dose taken failed", {
+					status: failureStatus,
+					error: getErrorMessage(error),
+				});
 				// Revert on error
 				setTakenDoses((prev) => {
 					const next = new Set(prev);
@@ -386,11 +418,20 @@ export function useDoses(): UseDosesReturn {
 				return next;
 			});
 
+			let failureStatus: number | null = null;
 			try {
-				await authFetch(`/api/doses/skip/${encodeURIComponent(doseId)}`, {
+				const response = await authFetch(`/api/doses/skip/${encodeURIComponent(doseId)}`, {
 					method: "DELETE",
 				});
-			} catch {
+				if (!response.ok) {
+					failureStatus = response.status;
+					throw new Error(`HTTP ${response.status}`);
+				}
+			} catch (error) {
+				log.warn("[useDoses] undo dose skipped failed", {
+					status: failureStatus,
+					error: getErrorMessage(error),
+				});
 				setDismissedDoses((prev) => {
 					const next = new Set(prev);
 					if (wasSkipped) {

--- a/frontend/src/hooks/useMedications.ts
+++ b/frontend/src/hooks/useMedications.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useAuth } from "../components/Auth";
 import type { Medication } from "../types";
+import { log } from "../utils/logger";
 
 export interface UseMedicationsReturn {
 	meds: Medication[];
@@ -14,6 +15,10 @@ export interface UseMedicationsReturn {
 	deleteMed: (id: number, editingId: number | null, resetForm: () => void) => Promise<void>;
 	uploadMedImage: (medId: number, file: File) => Promise<void>;
 	deleteMedImage: (medId: number) => Promise<void>;
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 export function useMedications(): UseMedicationsReturn {
@@ -33,15 +38,30 @@ export function useMedications(): UseMedicationsReturn {
 	const loadMeds = useCallback(() => {
 		setLoading(true);
 		authFetch("/api/medications?includeObsolete=true")
-			.then((res) => res.json())
+			.then((res) => {
+				if (!res.ok) {
+					throw new Error(`HTTP ${res.status}`);
+				}
+				return res.json();
+			})
 			.then((data) => setMeds(Array.isArray(data) ? data : []))
-			.catch(() => setMeds([]))
+			.catch((error: unknown) => {
+				log.warn("[useMedications] load medications failed", { error: getErrorMessage(error) });
+				setMeds([]);
+			})
 			.finally(() => setLoading(false));
 	}, [authFetch]);
 
 	const deleteMed = useCallback(
 		async (id: number, editingId: number | null, resetForm: () => void) => {
-			await authFetch(`/api/medications/${id}`, { method: "DELETE" }).catch(() => null);
+			try {
+				const response = await authFetch(`/api/medications/${id}`, { method: "DELETE" });
+				if (!response.ok) {
+					throw new Error(`HTTP ${response.status}`);
+				}
+			} catch (error) {
+				log.warn("[useMedications] delete medication failed", { medicationId: id, error: getErrorMessage(error) });
+			}
 			if (editingId === id) resetForm();
 			loadMeds();
 		},
@@ -92,7 +112,17 @@ export function useMedications(): UseMedicationsReturn {
 
 	const deleteMedImage = useCallback(
 		async (medId: number) => {
-			await authFetch(`/api/medications/${medId}/image`, { method: "DELETE" }).catch(() => null);
+			try {
+				const response = await authFetch(`/api/medications/${medId}/image`, { method: "DELETE" });
+				if (!response.ok) {
+					throw new Error(`HTTP ${response.status}`);
+				}
+			} catch (error) {
+				log.warn("[useMedications] delete medication image failed", {
+					medicationId: medId,
+					error: getErrorMessage(error),
+				});
+			}
 			loadMeds();
 		},
 		[authFetch, loadMeds]

--- a/frontend/src/test/components/Auth.test.tsx
+++ b/frontend/src/test/components/Auth.test.tsx
@@ -111,6 +111,27 @@ describe("AuthProvider", () => {
 		);
 	});
 
+	it("authFetch adds a correlation id to authenticated API requests", async () => {
+		vi.clearAllMocks();
+		(global.fetch as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ authEnabled: false, formLoginEnabled: true }),
+			})
+			.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ data: true }) });
+
+		const { result } = renderHook(() => useAuth(), { wrapper });
+
+		await waitFor(() => {
+			expect(result.current.loading).toBe(false);
+		});
+
+		await result.current.authFetch("/api/medications", { method: "GET" });
+
+		const requestInit = (fetch as ReturnType<typeof vi.fn>).mock.calls[1]?.[1] as RequestInit;
+		expect(new Headers(requestInit.headers).get("x-correlation-id")).toMatch(/^fe-api-/);
+	});
+
 	it("authFetch logs user out when refresh fails", async () => {
 		vi.clearAllMocks();
 		(global.fetch as ReturnType<typeof vi.fn>)

--- a/frontend/src/test/hooks/useDoses.test.ts
+++ b/frontend/src/test/hooks/useDoses.test.ts
@@ -3,6 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useDoses } from "../../hooks/useDoses";
 
 const feedbackMock = vi.hoisted(() => ({ showFeedback: vi.fn() }));
+const loggerMock = vi.hoisted(() => ({
+	debug: vi.fn(),
+	error: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+}));
 const authFetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init));
 
 vi.mock("../../components/Auth", () => ({
@@ -17,6 +23,10 @@ vi.mock("../../context/FeedbackContext", () => ({
 		dismissFeedback: vi.fn(),
 		clearFeedback: vi.fn(),
 	}),
+}));
+
+vi.mock("../../utils/logger", () => ({
+	log: loggerMock,
 }));
 
 describe("useDoses", () => {
@@ -186,6 +196,28 @@ describe("useDoses", () => {
 		await waitFor(() => {
 			expect(result.current.takenDoses.has("new-dose")).toBe(false);
 		});
+	});
+
+	it("logs a warning when marking a dose as taken fails", async () => {
+		(global.fetch as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ doses: [] }) })
+			.mockRejectedValueOnce(new Error("Network error"))
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ doses: [] }) });
+
+		const { result } = renderHook(() => useDoses());
+
+		await waitFor(() => {
+			expect(result.current.takenDoses.size).toBe(0);
+		});
+
+		await act(async () => {
+			await result.current.markDoseTaken("new-dose");
+		});
+
+		expect(loggerMock.warn).toHaveBeenCalledWith(
+			"[useDoses] mark dose taken failed",
+			expect.objectContaining({ error: "Network error" })
+		);
 	});
 
 	it("undoes dose taken optimistically", async () => {

--- a/frontend/src/test/hooks/useMedications.test.ts
+++ b/frontend/src/test/hooks/useMedications.test.ts
@@ -3,12 +3,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useMedications } from "../../hooks/useMedications";
 import type { Medication } from "../../types";
 
+const loggerMock = vi.hoisted(() => ({
+	debug: vi.fn(),
+	error: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+}));
 const authFetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init));
 
 vi.mock("../../components/Auth", () => ({
 	useAuth: () => ({
 		authFetch: authFetchMock,
 	}),
+}));
+
+vi.mock("../../utils/logger", () => ({
+	log: loggerMock,
 }));
 
 describe("useMedications", () => {
@@ -88,6 +98,10 @@ describe("useMedications", () => {
 		});
 
 		expect(result.current.meds).toEqual([]);
+		expect(loggerMock.warn).toHaveBeenCalledWith(
+			"[useMedications] load medications failed",
+			expect.objectContaining({ error: "Network error" })
+		);
 	});
 
 	it("handles non-array response", async () => {


### PR DESCRIPTION
Closes #686

## Summary
- preserve original backend scheduler/startup error objects in ServiceLogger error calls
- improve frontend auth and data-hook logging around failing API responses and correlation IDs
- update the matching frontend tests for the new logging and correlation behavior

## Validation
- backend: npm run check
- frontend: npm run check
- targeted frontend tests: 75 passed, 0 failed