### PR TITLE
chore: release 1.27.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.27.1
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.27.2
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.27.1
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.27.2
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.27.1",
+  "version": "1.27.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #688

## Summary
- bump backend and frontend versions to `1.27.2`
- pin production Docker images in `docker-compose.yml` to `1.27.2`
- prepare the patch release for the observability logging cleanup shipped after `v1.27.1`
