### PR TITLE
fix(release): always upload pinned compose asset

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -294,6 +294,8 @@ The documented production `docker-compose.yml` must be pinned to the exact relea
 - The `docker-build.yml` workflow automatically builds and pushes Docker images to GHCR with both versioned tags (`1.8.7`, `1.8`) and `latest`.
 - Confirm that the production `docker-compose.yml` image tags in the merged release commit match the pushed release image tag (`X.Y.Z`, without the leading `v`).
 - Confirm the GitHub release includes the generated `docker-compose.pinned.yml` asset with digest-pinned backend and frontend image references.
+- The pinned compose asset must reference the digests produced by the same `docker-build.yml` run for the tagged release images (`X.Y.Z@sha256:...`), not whichever image `latest` points to later.
+- If the GitHub release already exists, the workflow now uploads or replaces `docker-compose.pinned.yml` on that existing release after the build finishes.
 - The `update-test-badges.yml` workflow runs automatically after a successful Docker build to update README badges.
 - Track progress: `https://github.com/DanielVolz/medassist-ng/actions`
 
@@ -411,6 +413,9 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/release-notes-vX.Y.Z
 # If the release was already auto-created (e.g. by pushing a tag), update it:
 gh release edit vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/release-notes-vX.Y.Z.md
 ```
+
+- The release notes may be created or updated manually with `gh`, but `docker-compose.pinned.yml` is attached by the `docker-build.yml` workflow after the tagged image build completes.
+- After publishing or editing a release, wait for the Docker workflow to finish and verify that the release contains `docker-compose.pinned.yml` with `X.Y.Z@sha256:...` image references.
 
 **Present the published release URL to the user for verification.**
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -227,7 +227,6 @@ jobs:
           echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}" >> changelog.md
 
       - name: Download image digest metadata
-        if: steps.check_release.outputs.exists == 'false'
         uses: actions/download-artifact@v7
         with:
           pattern: image-digest-*
@@ -235,7 +234,6 @@ jobs:
           merge-multiple: true
 
       - name: Generate digest-pinned Docker Compose
-        if: steps.check_release.outputs.exists == 'false'
         run: |
           CURRENT_TAG="${{ steps.current_tag.outputs.value }}"
           IMAGE_TAG="${CURRENT_TAG#v}"
@@ -275,9 +273,15 @@ jobs:
           tag_name: ${{ steps.current_tag.outputs.value }}
           target_commitish: ${{ github.sha }}
           body_path: changelog.md
-          files: docker-compose.pinned.yml
           generate_release_notes: false
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload digest-pinned Docker Compose asset
+        run: |
+          CURRENT_TAG="${{ steps.current_tag.outputs.value }}"
+          gh release upload "$CURRENT_TAG" docker-compose.pinned.yml --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #690

## Summary
- always generate `docker-compose.pinned.yml` from the current tagged workflow run digests
- upload or replace the pinned compose asset on the matching GitHub release even when the release already exists
- document in the release-manager instructions that the asset is attached by the workflow after the tagged Docker build completes
