### PR TITLE
refactor: extract side-effect-free env schema module

### DIFF
--- a/backend/src/plugins/env-schema.ts
+++ b/backend/src/plugins/env-schema.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { parseBoolEnv, parseIntEnv, parseStringListEnv } from "../utils/env-parsing.js";
+
+const DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
+
+function boolEnv(defaultValue: boolean) {
+	return z
+		.string()
+		.optional()
+		.transform((value) => parseBoolEnv(value, defaultValue));
+}
+
+function optionalBoolEnv() {
+	return z
+		.string()
+		.optional()
+		.transform((value) => (value === undefined ? undefined : parseBoolEnv(value, false)));
+}
+
+function intEnv(options: { defaultValue: number; min?: number; max?: number }) {
+	return z
+		.string()
+		.optional()
+		.transform((value) => parseIntEnv(value, options));
+}
+
+export const EnvSchema = z.object({
+	NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
+	PORT: intEnv({ defaultValue: 3000, min: 1, max: 65535 }),
+	CORS_ORIGINS: z
+		.string()
+		.optional()
+		.transform((value) => parseStringListEnv(value ?? DEFAULT_CORS_ORIGINS).join(",")),
+	LOG_LEVEL: z.string().default("info"),
+	SENSITIVE_LOGGING_ENABLED: boolEnv(false),
+	PUBLIC_APP_URL: z.string().url().optional(),
+	OPENAPI_DOCS_ENABLED: optionalBoolEnv(),
+	DOCS_AUTH_REQUIRED: optionalBoolEnv(),
+	RATE_LIMIT_MAX: intEnv({ defaultValue: 100, min: 1, max: 100_000 }),
+	AUTH_ENABLED: boolEnv(false),
+	ALLOW_UNAUTHENTICATED: boolEnv(false),
+	REGISTRATION_ENABLED: boolEnv(false),
+	FORM_LOGIN_ENABLED: boolEnv(true),
+	JWT_SECRET: z.string().min(10).optional(),
+	REFRESH_SECRET: z.string().min(10).optional(),
+	COOKIE_SECRET: z.string().min(10).optional(),
+	ACCESS_TOKEN_TTL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 525_600 }),
+	REFRESH_TOKEN_TTL_DAYS: intEnv({ defaultValue: 7, min: 1, max: 3650 }),
+	SHARE_TOKEN_TTL_DAYS: intEnv({ defaultValue: 90, min: 1, max: 3650 }),
+	OIDC_ENABLED: boolEnv(false),
+	OIDC_ISSUER_URL: z.string().url().optional(),
+	OIDC_CLIENT_ID: z.string().optional(),
+	OIDC_CLIENT_SECRET: z.string().optional(),
+	OIDC_REDIRECT_URI: z.string().url().optional(),
+	OIDC_SCOPES: z.string().default("openid profile email"),
+	OIDC_AUTO_CREATE_USERS: boolEnv(true),
+	OIDC_USERNAME_CLAIM: z.string().default("preferred_username"),
+	OIDC_PROVIDER_NAME: z.string().default("SSO"),
+});
+
+export type ParsedEnv = z.infer<typeof EnvSchema>;

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -1,86 +1,11 @@
 import { existsSync } from "node:fs";
 import dotenv from "dotenv";
-import { z } from "zod";
-import { parseBoolEnv, parseIntEnv, parseStringListEnv } from "../utils/env-parsing.js";
+import { EnvSchema, type ParsedEnv } from "./env-schema.js";
 
 // Load .env: try cwd first, then parent dir (for local dev running from backend/)
 const envPath = process.env.DOTENV_PATH || (existsSync(".env") ? ".env" : "../.env");
 dotenv.config({ path: envPath });
 
-const DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
-
-function boolEnv(defaultValue: boolean) {
-	return z
-		.string()
-		.optional()
-		.transform((value) => parseBoolEnv(value, defaultValue));
-}
-
-function optionalBoolEnv() {
-	return z
-		.string()
-		.optional()
-		.transform((value) => (value === undefined ? undefined : parseBoolEnv(value, false)));
-}
-
-function intEnv(options: { defaultValue: number; min?: number; max?: number }) {
-	return z
-		.string()
-		.optional()
-		.transform((value) => parseIntEnv(value, options));
-}
-
-const EnvSchema = z.object({
-	NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
-	PORT: intEnv({ defaultValue: 3000, min: 1, max: 65535 }),
-	CORS_ORIGINS: z
-		.string()
-		.optional()
-		.transform((value) => parseStringListEnv(value ?? DEFAULT_CORS_ORIGINS).join(",")),
-	LOG_LEVEL: z.string().default("info"),
-	SENSITIVE_LOGGING_ENABLED: boolEnv(false),
-	PUBLIC_APP_URL: z.string().url().optional(),
-	OPENAPI_DOCS_ENABLED: optionalBoolEnv(),
-	DOCS_AUTH_REQUIRED: optionalBoolEnv(),
-	RATE_LIMIT_MAX: intEnv({ defaultValue: 100, min: 1, max: 100_000 }),
-
-	// ==========================================================================
-	// Auth Configuration
-	// ==========================================================================
-	// Master switch: Enable/disable authentication (default: disabled for easy setup)
-	AUTH_ENABLED: boolEnv(false),
-	// Explicit production-only escape hatch for private/local no-auth deployments.
-	ALLOW_UNAUTHENTICATED: boolEnv(false),
-	// Allow new user registrations (auto-enabled if no users exist)
-	REGISTRATION_ENABLED: boolEnv(false),
-	// Disable username/password form login (useful for OIDC-only setups)
-	FORM_LOGIN_ENABLED: boolEnv(true),
-
-	// JWT Secrets - only required when AUTH_ENABLED=true
-	JWT_SECRET: z.string().min(10).optional(),
-	REFRESH_SECRET: z.string().min(10).optional(),
-	COOKIE_SECRET: z.string().min(10).optional(),
-
-	// Token TTL settings
-	ACCESS_TOKEN_TTL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 525_600 }),
-	REFRESH_TOKEN_TTL_DAYS: intEnv({ defaultValue: 7, min: 1, max: 3650 }),
-	SHARE_TOKEN_TTL_DAYS: intEnv({ defaultValue: 90, min: 1, max: 3650 }),
-
-	// ==========================================================================
-	// OIDC SSO Configuration (Pocket ID, Authelia, etc.)
-	// ==========================================================================
-	OIDC_ENABLED: boolEnv(false),
-	OIDC_ISSUER_URL: z.string().url().optional(), // e.g., https://auth.example.com
-	OIDC_CLIENT_ID: z.string().optional(),
-	OIDC_CLIENT_SECRET: z.string().optional(),
-	OIDC_REDIRECT_URI: z.string().url().optional(), // e.g., https://medassist.example.com/api/auth/oidc/callback
-	OIDC_SCOPES: z.string().default("openid profile email"),
-	OIDC_AUTO_CREATE_USERS: boolEnv(true),
-	OIDC_USERNAME_CLAIM: z.string().default("preferred_username"), // or 'email', 'sub'
-	OIDC_PROVIDER_NAME: z.string().default("SSO"), // Display name for UI button
-});
-
-type ParsedEnv = z.infer<typeof EnvSchema>;
 export type Env = ParsedEnv & {
 	OPENAPI_DOCS_ENABLED: boolean;
 	DOCS_AUTH_REQUIRED: boolean;

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -1,70 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { z } from "zod";
-import { parseBoolEnv, parseIntEnv, parseStringListEnv } from "../utils/env-parsing.js";
+import { EnvSchema, type ParsedEnv } from "../plugins/env-schema.js";
 
 // Mock process.exit to prevent tests from exiting
 const mockExit = vi.fn();
 vi.spyOn(process, "exit").mockImplementation(mockExit as unknown as (...args: unknown[]) => never);
 
-// Re-create the schema from env.ts for testing
-const DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
-
-function boolEnv(defaultValue: boolean) {
-	return z
-		.string()
-		.optional()
-		.transform((value) => parseBoolEnv(value, defaultValue));
-}
-
-function optionalBoolEnv() {
-	return z
-		.string()
-		.optional()
-		.transform((value) => (value === undefined ? undefined : parseBoolEnv(value, false)));
-}
-
-function intEnv(options: { defaultValue: number; min?: number; max?: number }) {
-	return z
-		.string()
-		.optional()
-		.transform((value) => parseIntEnv(value, options));
-}
-
-const EnvSchema = z.object({
-	NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
-	PORT: intEnv({ defaultValue: 3000, min: 1, max: 65535 }),
-	CORS_ORIGINS: z
-		.string()
-		.optional()
-		.transform((value) => parseStringListEnv(value ?? DEFAULT_CORS_ORIGINS).join(",")),
-	LOG_LEVEL: z.string().default("info"),
-	SENSITIVE_LOGGING_ENABLED: boolEnv(false),
-	PUBLIC_APP_URL: z.string().url().optional(),
-	OPENAPI_DOCS_ENABLED: optionalBoolEnv(),
-	DOCS_AUTH_REQUIRED: optionalBoolEnv(),
-	RATE_LIMIT_MAX: intEnv({ defaultValue: 100, min: 1, max: 100_000 }),
-	AUTH_ENABLED: boolEnv(false),
-	ALLOW_UNAUTHENTICATED: boolEnv(false),
-	REGISTRATION_ENABLED: boolEnv(false),
-	JWT_SECRET: z.string().min(10).optional(),
-	REFRESH_SECRET: z.string().min(10).optional(),
-	COOKIE_SECRET: z.string().min(10).optional(),
-	ACCESS_TOKEN_TTL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 525_600 }),
-	REFRESH_TOKEN_TTL_DAYS: intEnv({ defaultValue: 7, min: 1, max: 3650 }),
-	SHARE_TOKEN_TTL_DAYS: intEnv({ defaultValue: 90, min: 1, max: 3650 }),
-	OIDC_ENABLED: boolEnv(false),
-	OIDC_ISSUER_URL: z.string().url().optional(),
-	OIDC_CLIENT_ID: z.string().optional(),
-	OIDC_CLIENT_SECRET: z.string().optional(),
-	OIDC_REDIRECT_URI: z.string().url().optional(),
-	OIDC_SCOPES: z.string().default("openid profile email"),
-	OIDC_AUTO_CREATE_USERS: boolEnv(true),
-	OIDC_USERNAME_CLAIM: z.string().default("preferred_username"),
-	OIDC_PROVIDER_NAME: z.string().default("SSO"),
-});
-
 // Validation functions from env.ts
-function validateAuthSecrets(parsed: z.infer<typeof EnvSchema>): string[] {
+function validateAuthSecrets(parsed: ParsedEnv): string[] {
 	const missing: string[] = [];
 	if (parsed.AUTH_ENABLED) {
 		if (!parsed.JWT_SECRET) missing.push("JWT_SECRET");
@@ -74,7 +16,7 @@ function validateAuthSecrets(parsed: z.infer<typeof EnvSchema>): string[] {
 	return missing;
 }
 
-function validateOidcConfig(parsed: z.infer<typeof EnvSchema>): string[] {
+function validateOidcConfig(parsed: ParsedEnv): string[] {
 	const missing: string[] = [];
 	if (parsed.OIDC_ENABLED) {
 		if (!parsed.OIDC_ISSUER_URL) missing.push("OIDC_ISSUER_URL");


### PR DESCRIPTION
Closes #701

Part of #694

## Summary
- extract backend env schema logic into a side-effect-free module
- preserve current runtime behavior while improving module boundaries
- keep the change scoped to env schema separation