### PR TITLE
chore: release 1.27.3

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.27.2",
+      "version": "1.27.3",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.27.2
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.27.3
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.27.2
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.27.3
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.27.2",
+      "version": "1.27.3",
       "dependencies": {
         "@medassist/shared": "file:../shared",
         "i18next": "^26.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.27.2",
+  "version": "1.27.3",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",


### PR DESCRIPTION
Closes #704

## Summary
- bump backend and frontend app versions to 1.27.3
- update production docker-compose image tags to 1.27.3
- prepare GitHub release publication for the already-merged patch fixes on main
