### PR TITLE
fix: restore backend runtime shared package resolution

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends gosu \
 COPY --from=builder /app/backend/node_modules ./node_modules
 COPY --from=builder /app/backend/dist ./dist
 COPY --from=builder /app/backend/package.json ./
+COPY --from=builder /app/shared/package.json /shared/package.json
+COPY --from=builder /app/shared/dist /shared/dist
 
 # Copy drizzle migrations folder (required for database setup)
 COPY backend/drizzle ./drizzle

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.27.3
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.27.4
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.27.3
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.27.4
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.27.3",
+  "version": "1.27.4",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",


### PR DESCRIPTION
Closes #707

## Summary
- copy the built shared package into the backend runtime image so the symlinked `file:../shared` dependency resolves in production
- bump the app version to 1.27.4 for an emergency patch release
- pin production compose images to the 1.27.4 release tags

## Validation
- `docker build -f backend/Dockerfile -t medassist-ng-backend:1.27.4-hotfix .`
- `docker run --rm --entrypoint node medassist-ng-backend:1.27.4-hotfix -e 'import("@medassist/shared").then(() => console.log("shared-import-ok"))'`\n- `docker run --rm -e PORT=3000 medassist-ng-backend:1.27.4-hotfix` advanced past the previous module-not-found crash and stopped only at the expected production auth safety policy\n