### PR TITLE
fix: harden project automation workflow guards and CI routing

### DIFF
--- a/.github/agents/project-bot.agent.md
+++ b/.github/agents/project-bot.agent.md
@@ -1,0 +1,60 @@
+---
+name: project-bot
+description: Handles GitHub issue, pull request, and Project board mutations for MedAssist-ng without owning product code changes or release actions.
+argument-hint: Describe the project automation task, e.g. "move issue 714 to Ready", "sync project fields for PR 715", or "create a triage issue for the release smoke regression"
+---
+
+# Project Bot Agent
+
+You are the project bot for **MedAssist-ng**. Your job is to manage GitHub Issues, Pull Requests, and Project board metadata without changing product code.
+
+## Core Responsibility
+
+Own GitHub tracking and coordination work only:
+
+- create or update issues
+- create or update PR metadata
+- add or adjust Project board field values
+- verify Project workflow automation outcomes
+- leave traceability comments on issues and PRs
+
+## Hard Boundaries
+
+- **Do not edit repository source files.**
+- **Do not run shell, git, Docker, or local test commands.**
+- **Do not implement product code, workflow code, or release changes.**
+- **Do not create tags or releases.**
+- **Do not merge code changes unless a separate repository rule explicitly delegates that to another specialist.**
+
+If the user request requires code changes, workflow edits, or local validation, hand the work off to the appropriate coding specialist instead of trying to do it here.
+
+## Preferred Surfaces
+
+Use GitHub-native issue, PR, and Project operations whenever available.
+
+Focus on:
+
+1. deterministic Project field updates
+2. issue / PR linkage and traceability
+3. keeping board state aligned with actual delivery status
+
+## MedAssist Project Field Expectations
+
+When the configured Project board exposes them, prefer these fields:
+
+- `Status`
+- `Type`
+- `Priority`
+- `Area`
+- `Risk`
+- `Agent`
+- `Validation`
+
+If a field is missing, fail clearly or warn clearly according to the repository workflow rules. Do not silently invent substitute fields.
+
+## Interaction Style
+
+- Be concise and operational.
+- State exactly what item was changed.
+- When blocked by missing Project configuration or permissions, say so directly.
+- Prefer explicit traceability comments over implicit assumptions.

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -495,6 +495,10 @@ All work is tracked in the [GitHub Project board](https://github.com/users/Danie
 | --- | --- | --- |
 | **Type** | Bug (red), Feature (green), Chore (gray), Documentation (blue) | Categorize the work |
 | **Priority** | High (red), Medium (orange), Low (yellow) | Set urgency |
+| **Area** | backend, frontend, shared, ci, docker, release, security, docs, project-automation | Identify the primary domain |
+| **Risk** | low, medium, high, release-blocking | Track delivery risk |
+| **Agent** | project-bot, implementation-agent, ci-surgeon, security-reviewer, testing-manager, release-manager, frontend-refactor-agent | Track primary specialist ownership |
+| **Validation** | unit, domain, coverage, e2e-smoke, e2e-full, container-smoke, security, release-preflight | Track the expected validation lane |
 | **Size** | XS, S, M, L, XL | Estimate effort |
 
 ### Workflow During PRs
@@ -508,18 +512,7 @@ All work is tracked in the [GitHub Project board](https://github.com/users/Danie
    Also add a direct issue comment with the PR link and a one-line summary for clear issue-thread traceability.
 3. **After merge — verify automation**: The `project-auto-done.yml` workflow automatically moves project items to "Done" when issues close or PRs merge. After merge, verify issue/project status via GitHub MCP.
 
-    **Manual fallback** — if the workflow fails or the item wasn't moved, use GitHub MCP GraphQL/project mutation support with the project/item/field IDs below.
-
-   **Known Project field IDs (Status):**
-   | Status | Option ID |
-   |--------|-----------|
-   | Triage | `826183f5` |
-   | Backlog | `c7cb819e` |
-   | Ready | `13307944` |
-   | In progress | `732e285e` |
-   | Done | `ca45af98` |
-
-   Status field ID: `PVTSSF_lAHOADH82s4BO2OTzg9bdkE`
+    **Manual fallback** — if the workflow fails or the item wasn't moved, use GitHub MCP GraphQL/project mutation support to resolve the current project item, the live `Status` field ID, and the live `Done` option ID dynamically from the configured project. Do not rely on stale hard-coded field IDs.
 
 ### Issue Labels
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,12 @@ Always preserve these parity rules:
 - Project automation lives in `.github/workflows/add-to-project.yml` and related project workflows.
 - CI changes must keep docs and operational guidance in sync.
 
+## Preferred specialist routing
+
+- Use `testing-manager` for test planning, local validation, and CI test triage.
+- Use `release-manager` for PR shipping, merge, release, and workflow monitoring.
+- Use `project-bot` for issue, PR metadata, and GitHub Project board coordination work when no product code change is required.
+
 ## Local-only artifacts
 
 The following are local workspace state and must not be committed unless a user explicitly asks for that exact action:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -24,9 +24,11 @@ jobs:
           fi
 
           if [[ "${PROJECT_URL}" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
-            echo "owner_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-            echo "owner=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
-            echo "project_number=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            {
+              echo "owner_type=${BASH_REMATCH[1]}"
+              echo "owner=${BASH_REMATCH[2]}"
+              echo "project_number=${BASH_REMATCH[3]}"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -110,9 +112,11 @@ jobs:
           fi
 
           if [[ "${PROJECT_URL}" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
-            echo "owner_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-            echo "owner=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
-            echo "project_number=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            {
+              echo "owner_type=${BASH_REMATCH[1]}"
+              echo "owner=${BASH_REMATCH[2]}"
+              echo "project_number=${BASH_REMATCH[3]}"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,10 +12,70 @@ jobs:
     if: contains(fromJson('["opened","reopened","labeled"]'), github.event.action)
     runs-on: ubuntu-latest
     steps:
+      - name: Parse project URL
+        id: project
+        env:
+          PROJECT_URL: ${{ vars.PROJECT_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PROJECT_URL:-}" ]]; then
+            echo "Missing repository variable PROJECT_URL." >&2
+            exit 1
+          fi
+
+          if [[ "${PROJECT_URL}" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
+            echo "owner_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "owner=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            echo "project_number=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "PROJECT_URL has an unsupported format: ${PROJECT_URL}" >&2
+          exit 1
+
+      - name: Create project automation GitHub App token
+        id: app-token
+        if: vars.PROJECT_AUTOMATION_APP_ID != '' && secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PROJECT_AUTOMATION_APP_ID }}
+          owner: ${{ steps.project.outputs.owner }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY }}
+
+      - name: Select project automation token
+        id: project-token
+        env:
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_TOKEN:-}" ]]; then
+            echo "token=${APP_TOKEN}" >> "$GITHUB_OUTPUT"
+            echo "mode=github-app" >> "$GITHUB_OUTPUT"
+            echo "Using GitHub App token for project automation."
+            exit 0
+          fi
+
+          if [[ -n "${FALLBACK_PAT:-}" ]]; then
+            if [[ "${APP_TOKEN_OUTCOME:-}" == "failure" ]]; then
+              echo "::warning title=GitHub App token failed::GitHub App credentials are configured but token creation failed. Falling back to deprecated ADD_TO_PROJECT_PAT for this run."
+            fi
+            echo "::warning title=Project automation fallback::Using deprecated ADD_TO_PROJECT_PAT because PROJECT_AUTOMATION_APP_ID / PROJECT_AUTOMATION_APP_PRIVATE_KEY are not fully configured yet."
+            echo "::add-mask::${FALLBACK_PAT}"
+            echo "token=${FALLBACK_PAT}" >> "$GITHUB_OUTPUT"
+            echo "mode=pat-fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Neither GitHub App credentials nor ADD_TO_PROJECT_PAT are configured for project automation." >&2
+          exit 1
+
       - uses: actions/add-to-project@v2.0.0
         with:
           project-url: ${{ vars.PROJECT_URL }}
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.project-token.outputs.token }}
           labeled: enhancement, bug, triage
           label-operator: OR
 
@@ -25,50 +85,89 @@ jobs:
     needs: add-to-project
     if: always() && !cancelled()
     steps:
+      - name: Parse project URL
+        id: project
+        env:
+          PROJECT_URL: ${{ vars.PROJECT_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PROJECT_URL:-}" ]]; then
+            echo "Missing repository variable PROJECT_URL." >&2
+            exit 1
+          fi
+
+          if [[ "${PROJECT_URL}" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
+            echo "owner_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "owner=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            echo "project_number=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "PROJECT_URL has an unsupported format: ${PROJECT_URL}" >&2
+          exit 1
+
+      - name: Create project automation GitHub App token
+        id: app-token
+        if: vars.PROJECT_AUTOMATION_APP_ID != '' && secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PROJECT_AUTOMATION_APP_ID }}
+          owner: ${{ steps.project.outputs.owner }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY }}
+
+      - name: Select project automation token
+        id: project-token
+        env:
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_TOKEN:-}" ]]; then
+            echo "token=${APP_TOKEN}" >> "$GITHUB_OUTPUT"
+            echo "mode=github-app" >> "$GITHUB_OUTPUT"
+            echo "Using GitHub App token for project automation."
+            exit 0
+          fi
+
+          if [[ -n "${FALLBACK_PAT:-}" ]]; then
+            if [[ "${APP_TOKEN_OUTCOME:-}" == "failure" ]]; then
+              echo "::warning title=GitHub App token failed::GitHub App credentials are configured but token creation failed. Falling back to deprecated ADD_TO_PROJECT_PAT for this run."
+            fi
+            echo "::warning title=Project automation fallback::Using deprecated ADD_TO_PROJECT_PAT because PROJECT_AUTOMATION_APP_ID / PROJECT_AUTOMATION_APP_PRIVATE_KEY are not fully configured yet."
+            echo "::add-mask::${FALLBACK_PAT}"
+            echo "token=${FALLBACK_PAT}" >> "$GITHUB_OUTPUT"
+            echo "mode=pat-fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Neither GitHub App credentials nor ADD_TO_PROJECT_PAT are configured for project automation." >&2
+          exit 1
+
       - name: Sync Type/Priority fields from labels
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.project-token.outputs.token }}
           script: |
-            const projectUrl = process.env.PROJECT_URL;
-            if (!projectUrl) {
-              core.setFailed("Missing repository variable PROJECT_URL.");
+            const ownerType = process.env.PROJECT_OWNER_TYPE;
+            const owner = process.env.PROJECT_OWNER;
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+
+            if (!ownerType || !owner || Number.isNaN(projectNumber)) {
+              core.setFailed("Project URL parsing outputs are missing or invalid.");
               return;
             }
 
-            const match = projectUrl.match(/^https:\/\/github\.com\/(?:users|orgs)\/([^/]+)\/projects\/(\d+)\/?$/);
-            if (!match) {
-              core.setFailed(`PROJECT_URL has an unsupported format: ${projectUrl}`);
-              return;
-            }
-
-            const [, owner, projectNumberRaw] = match;
-            const projectNumber = Number(projectNumberRaw);
             const issueNodeId = context.payload.issue.node_id;
             const issueNumber = context.payload.issue.number;
             const labels = (context.payload.issue.labels || []).map((label) => label.name.toLowerCase());
             const qualifyingLabels = ["enhancement", "bug", "triage"];
+            const ownerRoot = ownerType === "users" ? "user" : "organization";
 
-            const projectQuery = `
+            const projectResult = await github.graphql(`
               query($owner: String!, $number: Int!) {
-                user(login: $owner) {
-                  projectV2(number: $number) {
-                    id
-                    fields(first: 50) {
-                      nodes {
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          name
-                          options {
-                            id
-                            name
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-                organization(login: $owner) {
+                ${ownerRoot}(login: $owner) {
                   projectV2(number: $number) {
                     id
                     fields(first: 50) {
@@ -86,13 +185,11 @@ jobs:
                   }
                 }
               }
-            `;
-
-            const projectResult = await github.graphql(projectQuery, { owner, number: projectNumber });
-            const project = projectResult.user?.projectV2 || projectResult.organization?.projectV2;
+            `, { owner, number: projectNumber });
+            const project = projectResult[ownerRoot]?.projectV2;
 
             if (!project) {
-              core.setFailed(`Project ${projectUrl} was not found or is not accessible to the project automation token.`);
+              core.setFailed(`Project ${ownerType}/${owner}/${projectNumber} was not found or is not accessible to the project automation token.`);
               return;
             }
 
@@ -127,6 +224,10 @@ jobs:
             const fieldsByName = new Map((project.fields?.nodes || []).map((field) => [field.name, field]));
             const typeField = fieldsByName.get("Type");
             const priorityField = fieldsByName.get("Priority");
+            const areaField = fieldsByName.get("Area");
+            const riskField = fieldsByName.get("Risk");
+            const agentField = fieldsByName.get("Agent");
+            const validationField = fieldsByName.get("Validation");
 
             const pickOptionId = (field, optionName) => {
               if (!field || !optionName) return null;
@@ -144,10 +245,65 @@ jobs:
             else if (labels.includes("priority/medium")) priorityName = "Medium";
             else if (labels.includes("triage")) priorityName = "Medium";
 
-            const syncSingleSelectField = async ({ field, fieldName, optionName }) => {
+            const areaLabelMap = new Map([
+              ["area/backend", "backend"],
+              ["area/frontend", "frontend"],
+              ["area/shared", "shared"],
+              ["area/ci", "ci"],
+              ["area/docker", "docker"],
+              ["area/release", "release"],
+              ["area/security", "security"],
+              ["area/docs", "docs"],
+              ["area/project-automation", "project-automation"]
+            ]);
+
+            const riskLabelMap = new Map([
+              ["risk/low", "low"],
+              ["risk/medium", "medium"],
+              ["risk/high", "high"],
+              ["risk/release-blocking", "release-blocking"]
+            ]);
+
+            const agentLabelMap = new Map([
+              ["agent/project-bot", "project-bot"],
+              ["agent/implementation-agent", "implementation-agent"],
+              ["agent/ci-surgeon", "ci-surgeon"],
+              ["agent/security-reviewer", "security-reviewer"],
+              ["agent/testing-manager", "testing-manager"],
+              ["agent/release-manager", "release-manager"],
+              ["agent/frontend-refactor-agent", "frontend-refactor-agent"]
+            ]);
+
+            const validationLabelMap = new Map([
+              ["validation/unit", "unit"],
+              ["validation/domain", "domain"],
+              ["validation/coverage", "coverage"],
+              ["validation/e2e-smoke", "e2e-smoke"],
+              ["validation/e2e-full", "e2e-full"],
+              ["validation/container-smoke", "container-smoke"],
+              ["validation/security", "security"],
+              ["validation/release-preflight", "release-preflight"]
+            ]);
+
+            const pickMappedLabel = (mapping) => {
+              for (const [label, optionName] of mapping.entries()) {
+                if (labels.includes(label)) return optionName;
+              }
+              return null;
+            };
+
+            const areaName = pickMappedLabel(areaLabelMap);
+            const riskName = pickMappedLabel(riskLabelMap);
+            const agentName = pickMappedLabel(agentLabelMap);
+            const validationName = pickMappedLabel(validationLabelMap);
+
+            const syncSingleSelectField = async ({ field, fieldName, optionName, required }) => {
               if (!field) {
                 if (optionName) {
-                  throw new Error(`Configured project is missing the single-select "${fieldName}" field required for label sync.`);
+                  if (required) {
+                    throw new Error(`Configured project is missing the single-select "${fieldName}" field required for label sync.`);
+                  }
+                  core.warning(`Configured project is missing the optional single-select "${fieldName}" field. Skipping label sync for this field.`);
                 }
                 return;
               }
@@ -175,6 +331,10 @@ jobs:
 
               const optionId = pickOptionId(field, optionName);
               if (!optionId) {
+                if (!required) {
+                  core.warning(`Configured project field "${fieldName}" is missing option "${optionName}". Skipping label sync for this field.`);
+                  return;
+                }
                 throw new Error(`Configured project field "${fieldName}" is missing option "${optionName}".`);
               }
 
@@ -199,7 +359,14 @@ jobs:
               console.log(`Issue #${issueNumber}: set ${fieldName} = ${optionName}`);
             };
 
-            await syncSingleSelectField({ field: typeField, fieldName: "Type", optionName: typeName });
-            await syncSingleSelectField({ field: priorityField, fieldName: "Priority", optionName: priorityName });
+            await syncSingleSelectField({ field: typeField, fieldName: "Type", optionName: typeName, required: true });
+            await syncSingleSelectField({ field: priorityField, fieldName: "Priority", optionName: priorityName, required: true });
+            await syncSingleSelectField({ field: areaField, fieldName: "Area", optionName: areaName, required: false });
+            await syncSingleSelectField({ field: riskField, fieldName: "Risk", optionName: riskName, required: false });
+            await syncSingleSelectField({ field: agentField, fieldName: "Agent", optionName: agentName, required: false });
+            await syncSingleSelectField({ field: validationField, fieldName: "Validation", optionName: validationName, required: false });
         env:
           PROJECT_URL: ${{ vars.PROJECT_URL }}
+          PROJECT_OWNER: ${{ steps.project.outputs.owner }}
+          PROJECT_OWNER_TYPE: ${{ steps.project.outputs.owner_type }}
+          PROJECT_NUMBER: ${{ steps.project.outputs.project_number }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -33,9 +33,22 @@ jobs:
           echo "PROJECT_URL has an unsupported format: ${PROJECT_URL}" >&2
           exit 1
 
+      - name: Check project automation GitHub App configuration
+        id: app-config
+        env:
+          APP_ID: ${{ vars.PROJECT_AUTOMATION_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID:-}" && -n "${APP_PRIVATE_KEY:-}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+
       - name: Create project automation GitHub App token
         id: app-token
-        if: vars.PROJECT_AUTOMATION_APP_ID != '' && secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY != ''
+        if: steps.app-config.outputs.enabled == 'true'
         continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
@@ -106,9 +119,22 @@ jobs:
           echo "PROJECT_URL has an unsupported format: ${PROJECT_URL}" >&2
           exit 1
 
+      - name: Check project automation GitHub App configuration
+        id: app-config
+        env:
+          APP_ID: ${{ vars.PROJECT_AUTOMATION_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID:-}" && -n "${APP_PRIVATE_KEY:-}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+
       - name: Create project automation GitHub App token
         id: app-token
-        if: vars.PROJECT_AUTOMATION_APP_ID != '' && secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY != ''
+        if: steps.app-config.outputs.enabled == 'true'
         continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -144,7 +144,7 @@ jobs:
             -e LOG_LEVEL=warn \
             "${{ steps.image_refs.outputs.backend }}"
 
-          for attempt in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             container_status="$(docker inspect --format '{{.State.Status}}' medassist-backend-smoke 2>/dev/null || echo missing)"
             if [ "$container_status" != "running" ]; then
               echo "Backend smoke container stopped before health became ready (status: $container_status)."

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -218,10 +218,10 @@ jobs:
         run: |
           CURRENT_TAG="${{ steps.current_tag.outputs.value }}"
           if gh release view "$CURRENT_TAG" &>/dev/null; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Release $CURRENT_TAG already exists, skipping creation"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
             PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           fi
 
-          echo "tag=${PREV_TAG}" >> $GITHUB_OUTPUT
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog
         if: steps.check_release.outputs.exists == 'false'
@@ -246,39 +246,39 @@ jobs:
         run: |
           CURRENT_TAG="${{ steps.current_tag.outputs.value }}"
           PREV_TAG="${{ steps.prev_tag.outputs.tag }}"
-          
-          echo "## What's New" > changelog.md
-          echo "" >> changelog.md
-          echo "This release includes updates and fixes shipped with ${CURRENT_TAG}." >> changelog.md
-          echo "" >> changelog.md
-          echo "### Highlights" >> changelog.md
-          echo "" >> changelog.md
-          
-          if [ -n "$PREV_TAG" ]; then
-            echo "Changes from ${PREV_TAG} to ${CURRENT_TAG}:" >> changelog.md
-            git log ${PREV_TAG}..${CURRENT_TAG} --pretty=format:"- %s (%h)" --no-merges >> changelog.md
-          else
-            echo "Recent shipped commits:" >> changelog.md
-            git log -20 --pretty=format:"- %s (%h)" --no-merges >> changelog.md
-          fi
-          
-          echo "" >> changelog.md
-          echo "" >> changelog.md
-          echo "## Docker Images" >> changelog.md
-          echo "" >> changelog.md
-          echo '```bash' >> changelog.md
+
           OWNER_LC="$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
-          echo "docker pull ghcr.io/${OWNER_LC}/medassist-ng-backend:${CURRENT_TAG#v}" >> changelog.md
-          echo "docker pull ghcr.io/${OWNER_LC}/medassist-ng-frontend:${CURRENT_TAG#v}" >> changelog.md
-          echo '```' >> changelog.md
-          echo "" >> changelog.md
-          echo "" >> changelog.md
-          echo "A digest-pinned Docker Compose file is attached to this release as \`docker-compose.pinned.yml\`." >> changelog.md
-          echo "Release images now publish OCI provenance and SBOM attestations, and release completion is gated by container smoke tests." >> changelog.md
-          if [ -n "$PREV_TAG" ]; then
-            echo "" >> changelog.md
-            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}" >> changelog.md
-          fi
+          {
+            echo "## What's New"
+            echo ""
+            echo "This release includes updates and fixes shipped with ${CURRENT_TAG}."
+            echo ""
+            echo "### Highlights"
+            echo ""
+            if [ -n "$PREV_TAG" ]; then
+              echo "Changes from ${PREV_TAG} to ${CURRENT_TAG}:"
+              git log "${PREV_TAG}..${CURRENT_TAG}" --pretty=format:"- %s (%h)" --no-merges
+            else
+              echo "Recent shipped commits:"
+              git log -20 --pretty=format:"- %s (%h)" --no-merges
+            fi
+            echo ""
+            echo ""
+            echo "## Docker Images"
+            echo ""
+            echo '```bash'
+            echo "docker pull ghcr.io/${OWNER_LC}/medassist-ng-backend:${CURRENT_TAG#v}"
+            echo "docker pull ghcr.io/${OWNER_LC}/medassist-ng-frontend:${CURRENT_TAG#v}"
+            echo '```'
+            echo ""
+            echo ""
+            echo "A digest-pinned Docker Compose file is attached to this release as \`docker-compose.pinned.yml\`."
+            echo "Release images now publish OCI provenance and SBOM attestations, and release completion is gated by container smoke tests."
+            if [ -n "$PREV_TAG" ]; then
+              echo ""
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}"
+            fi
+          } > changelog.md
 
       - name: Download image digest metadata
         uses: actions/download-artifact@v8

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,10 @@ jobs:
               - 'package.json'
               - 'release-policy.json'
               - 'scripts/**'
-              - '.github/workflows/**'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/e2e.yml'
+              - '.github/workflows/docker-build.yml'
+              - '.github/workflows/container-smoke.yml'
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/project-auto-done.yml
+++ b/.github/workflows/project-auto-done.yml
@@ -37,9 +37,22 @@ jobs:
           echo "PROJECT_URL has an unsupported format: ${PROJECT_URL}" >&2
           exit 1
 
+      - name: Check project automation GitHub App configuration
+        id: app-config
+        env:
+          APP_ID: ${{ vars.PROJECT_AUTOMATION_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID:-}" && -n "${APP_PRIVATE_KEY:-}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+
       - name: Create project automation GitHub App token
         id: app-token
-        if: vars.PROJECT_AUTOMATION_APP_ID != '' && secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY != ''
+        if: steps.app-config.outputs.enabled == 'true'
         continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:

--- a/.github/workflows/project-auto-done.yml
+++ b/.github/workflows/project-auto-done.yml
@@ -28,9 +28,11 @@ jobs:
           fi
 
           if [[ "${PROJECT_URL}" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
-            echo "owner_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-            echo "owner=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
-            echo "project_number=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            {
+              echo "owner_type=${BASH_REMATCH[1]}"
+              echo "owner=${BASH_REMATCH[2]}"
+              echo "project_number=${BASH_REMATCH[3]}"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/project-auto-done.yml
+++ b/.github/workflows/project-auto-done.yml
@@ -16,46 +16,85 @@ jobs:
       (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
+      - name: Parse project URL
+        id: project
+        env:
+          PROJECT_URL: ${{ vars.PROJECT_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PROJECT_URL:-}" ]]; then
+            echo "Missing repository variable PROJECT_URL." >&2
+            exit 1
+          fi
+
+          if [[ "${PROJECT_URL}" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
+            echo "owner_type=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "owner=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            echo "project_number=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "PROJECT_URL has an unsupported format: ${PROJECT_URL}" >&2
+          exit 1
+
+      - name: Create project automation GitHub App token
+        id: app-token
+        if: vars.PROJECT_AUTOMATION_APP_ID != '' && secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PROJECT_AUTOMATION_APP_ID }}
+          owner: ${{ steps.project.outputs.owner }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY }}
+
+      - name: Select project automation token
+        id: project-token
+        env:
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_TOKEN:-}" ]]; then
+            echo "token=${APP_TOKEN}" >> "$GITHUB_OUTPUT"
+            echo "mode=github-app" >> "$GITHUB_OUTPUT"
+            echo "Using GitHub App token for project automation."
+            exit 0
+          fi
+
+          if [[ -n "${FALLBACK_PAT:-}" ]]; then
+            if [[ "${APP_TOKEN_OUTCOME:-}" == "failure" ]]; then
+              echo "::warning title=GitHub App token failed::GitHub App credentials are configured but token creation failed. Falling back to deprecated ADD_TO_PROJECT_PAT for this run."
+            fi
+            echo "::warning title=Project automation fallback::Using deprecated ADD_TO_PROJECT_PAT because PROJECT_AUTOMATION_APP_ID / PROJECT_AUTOMATION_APP_PRIVATE_KEY are not fully configured yet."
+            echo "::add-mask::${FALLBACK_PAT}"
+            echo "token=${FALLBACK_PAT}" >> "$GITHUB_OUTPUT"
+            echo "mode=pat-fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Neither GitHub App credentials nor ADD_TO_PROJECT_PAT are configured for project automation." >&2
+          exit 1
+
       - name: Move project item to Done
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.project-token.outputs.token }}
           script: |
-            const projectUrl = process.env.PROJECT_URL;
-            if (!projectUrl) {
-              core.setFailed("Missing repository variable PROJECT_URL.");
+            const ownerType = process.env.PROJECT_OWNER_TYPE;
+            const owner = process.env.PROJECT_OWNER;
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+
+            if (!ownerType || !owner || Number.isNaN(projectNumber)) {
+              core.setFailed("Project URL parsing outputs are missing or invalid.");
               return;
             }
 
-            const match = projectUrl.match(/^https:\/\/github\.com\/(?:users|orgs)\/([^/]+)\/projects\/(\d+)\/?$/);
-            if (!match) {
-              core.setFailed(`PROJECT_URL has an unsupported format: ${projectUrl}`);
-              return;
-            }
-
-            const [, owner, projectNumberRaw] = match;
-            const projectNumber = Number(projectNumberRaw);
+            const ownerRoot = ownerType === "users" ? "user" : "organization";
 
             const projectResult = await github.graphql(`
               query($owner: String!, $number: Int!) {
-                user(login: $owner) {
-                  projectV2(number: $number) {
-                    id
-                    fields(first: 50) {
-                      nodes {
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          name
-                          options {
-                            id
-                            name
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-                organization(login: $owner) {
+                ${ownerRoot}(login: $owner) {
                   projectV2(number: $number) {
                     id
                     fields(first: 50) {
@@ -75,9 +114,9 @@ jobs:
               }
             `, { owner, number: projectNumber });
 
-            const project = projectResult.user?.projectV2 || projectResult.organization?.projectV2;
+            const project = projectResult[ownerRoot]?.projectV2;
             if (!project) {
-              core.setFailed(`Project ${projectUrl} was not found or is not accessible to the project automation token.`);
+              core.setFailed(`Project ${ownerType}/${owner}/${projectNumber} was not found or is not accessible to the project automation token.`);
               return;
             }
 
@@ -169,3 +208,6 @@ jobs:
             console.log(`Successfully moved ${type} #${number} to "Done".`);
         env:
           PROJECT_URL: ${{ vars.PROJECT_URL }}
+          PROJECT_OWNER: ${{ steps.project.outputs.owner }}
+          PROJECT_OWNER_TYPE: ${{ steps.project.outputs.owner_type }}
+          PROJECT_NUMBER: ${{ steps.project.outputs.project_number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,10 @@ jobs:
               - 'release-policy.json'
               - 'scripts/**'
               - 'biome.json'
-              - '.github/workflows/**'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/e2e.yml'
+              - '.github/workflows/docker-build.yml'
+              - '.github/workflows/container-smoke.yml'
             frontend:
               - 'frontend/**'
               - 'shared/**'
@@ -41,7 +44,10 @@ jobs:
               - 'release-policy.json'
               - 'scripts/**'
               - 'biome.json'
-              - '.github/workflows/**'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/e2e.yml'
+              - '.github/workflows/docker-build.yml'
+              - '.github/workflows/container-smoke.yml'
 
   # =============================================================================
   # Backend Tests (always emits the required check context)

--- a/.github/workflows/update-test-badges.yml
+++ b/.github/workflows/update-test-badges.yml
@@ -53,9 +53,9 @@ jobs:
           OUTPUT=$(npm run test:run 2>&1) || true
           echo "$OUTPUT"
           # Strip ANSI escape codes, then extract "Tests  X passed" from output
-          CLEAN=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+          CLEAN=$(printf '%s\n' "$OUTPUT" | perl -pe 's/\e\[[0-9;]*m//g')
           PASSED=$(echo "$CLEAN" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
-          echo "count=$PASSED" >> $GITHUB_OUTPUT
+          echo "count=$PASSED" >> "$GITHUB_OUTPUT"
 
       - name: Run frontend tests and capture count
         id: frontend-tests
@@ -67,9 +67,9 @@ jobs:
           OUTPUT=$(npm run test:run 2>&1) || true
           echo "$OUTPUT"
           # Strip ANSI escape codes, then extract "Tests  X passed" from output
-          CLEAN=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+          CLEAN=$(printf '%s\n' "$OUTPUT" | perl -pe 's/\e\[[0-9;]*m//g')
           PASSED=$(echo "$CLEAN" | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
-          echo "count=$PASSED" >> $GITHUB_OUTPUT
+          echo "count=$PASSED" >> "$GITHUB_OUTPUT"
 
       - name: Update README badges
         run: |

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Run actionlint
         if: needs.changes.outputs.workflows == 'true'
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.12

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -1,0 +1,44 @@
+name: Workflow Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect workflow changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            workflows:
+              - '.github/workflows/**'
+
+  actionlint:
+    name: Actionlint
+    needs: changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Skip workflow validation when no workflow changes are present
+        if: needs.changes.outputs.workflows != 'true'
+        run: echo "No workflow changes detected; required check passes without running actionlint."
+
+      - name: Checkout repository
+        if: needs.changes.outputs.workflows == 'true'
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        if: needs.changes.outputs.workflows == 'true'
+        uses: rhysd/actionlint@v1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,7 +86,9 @@ Use the root-level commands for full-stack validation when a change spans backen
 ## Release Workflow Safeguards
 
 - PR validation is enforced through `.github/workflows/test.yml` and `.github/workflows/e2e.yml`.
+- Workflow syntax validation is enforced through `.github/workflows/workflow-validation.yml` with `actionlint` on all PR workflow changes.
 - Required PR checks now always emit their stable check names; when a PR is not relevant for a given lane, the workflow reports a no-op success instead of disappearing as a skipped/missing required context.
+- Product test lanes are only triggered by product code or product-facing CI/CD workflow changes (`test.yml`, `e2e.yml`, `docker-build.yml`, `container-smoke.yml`). Project, issue, and PR automation workflow edits still get workflow validation, but no longer trigger backend/frontend/Playwright lanes by themselves.
 - Release-relevant PRs also run `.github/workflows/container-smoke.yml` as a dedicated container runtime check.
 - Docker publishing is handled by `.github/workflows/docker-build.yml`.
 - The reusable container smoke workflow is used in two places:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,6 +108,33 @@ Use the root-level commands for full-stack validation when a change spans backen
 GitHub Project automation expects these repository settings:
 
 - `vars.PROJECT_URL`: GitHub Project v2 URL in the form `https://github.com/users/<owner>/projects/<number>` or `https://github.com/orgs/<owner>/projects/<number>`
-- `secrets.ADD_TO_PROJECT_PAT`: token that can add/update project items for that project
+- `vars.PROJECT_AUTOMATION_APP_ID`: GitHub App ID for Project automation
+- `secrets.PROJECT_AUTOMATION_APP_PRIVATE_KEY`: private key for that GitHub App installation
+- optional transitional fallback: `secrets.ADD_TO_PROJECT_PAT`
 
-The project workflows resolve project and field IDs dynamically from `PROJECT_URL`. If the configured project is inaccessible or missing the expected `Status`, `Type`, or `Priority` fields/options, the workflow now fails clear instead of silently drifting.
+The project workflows now prefer a GitHub App token and only fall back to `ADD_TO_PROJECT_PAT` with an explicit warning while the App rollout is incomplete. They also parse `PROJECT_URL` as either a user-owned or organization-owned project and query the correct GraphQL root explicitly instead of probing both and risking false failures.
+
+The project workflows resolve project and field IDs dynamically from `PROJECT_URL`.
+
+Required fields:
+
+- `Status` with a `Done` option
+- `Type`
+- `Priority`
+
+Recommended deterministic routing fields:
+
+- `Area`: `backend`, `frontend`, `shared`, `ci`, `docker`, `release`, `security`, `docs`, `project-automation`
+- `Risk`: `low`, `medium`, `high`, `release-blocking`
+- `Agent`: `project-bot`, `implementation-agent`, `ci-surgeon`, `security-reviewer`, `testing-manager`, `release-manager`, `frontend-refactor-agent`
+- `Validation`: `unit`, `domain`, `coverage`, `e2e-smoke`, `e2e-full`, `container-smoke`, `security`, `release-preflight`
+
+Label-to-field sync currently supports:
+
+- `priority/high`, `priority/medium`, `priority/low`
+- `area/*`
+- `risk/*`
+- `agent/*`
+- `validation/*`
+
+If the configured project is inaccessible or missing required field/options, the workflows fail clear. Missing optional routing fields currently warn and skip instead of breaking issue intake during project-schema rollout.


### PR DESCRIPTION
## Summary
- prefer the project automation GitHub App when App credentials are configured
- keep the PAT fallback path for repositories without the App configuration
- preserve the user-owned vs org-owned project GraphQL handling
- replace invalid `secrets.*` step guards with an explicit config check before creating App tokens
- add workflow-wide `actionlint` validation for `.github/workflows/**` pull request changes
- narrow backend/frontend/Playwright routing so project, issue, and PR automation workflow edits alone do not trigger product lanes
- keep product lanes triggered for product code and product-facing CI/CD workflow changes only

## Validation
- actionlint clean for `.github/workflows/add-to-project.yml` and `.github/workflows/project-auto-done.yml`
- workflow validation now runs through `.github/workflows/workflow-validation.yml` on PR workflow changes
- backend/frontend/Playwright lanes now stay idle for project automation-only workflow edits while remaining active for product code and product-facing CI/CD workflow changes
- no `secrets.*` references remain in step `if:` expressions
- App token creation only runs when both `PROJECT_AUTOMATION_APP_ID` and `PROJECT_AUTOMATION_APP_PRIVATE_KEY` are present

Closes #718