### PR TITLE
fix(ci): scope PR workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,16 @@ on:
       - '.github/workflows/codeql.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**.js'
+      - '**.ts'
+      - '**.tsx'
+      - '**.jsx'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - '.github/codeql/**'
   schedule:
     - cron: "0 6 * * 1" # Weekly on Monday at 6am UTC
   workflow_dispatch: # Allow manual trigger

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -12,8 +12,6 @@ on:
       - 'frontend/package*.json'
       - 'shared/package*.json'
       - 'docker-compose*.yml'
-      - '.github/workflows/docker-build.yml'
-      - '.github/workflows/container-smoke.yml'
   workflow_call:
     inputs:
       image_source:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,13 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'shared/**'
+      - 'package.json'
+      - 'release-policy.json'
+      - 'scripts/**'
 
 # Minimal permissions for security
 permissions:
@@ -29,10 +36,6 @@ jobs:
               - 'package.json'
               - 'release-policy.json'
               - 'scripts/**'
-              - '.github/workflows/test.yml'
-              - '.github/workflows/e2e.yml'
-              - '.github/workflows/docker-build.yml'
-              - '.github/workflows/container-smoke.yml'
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,14 @@ name: Test
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'shared/**'
+      - 'package.json'
+      - 'release-policy.json'
+      - 'scripts/**'
+      - 'biome.json'
 
 # Minimal permissions for security
 permissions:
@@ -33,10 +41,6 @@ jobs:
               - 'release-policy.json'
               - 'scripts/**'
               - 'biome.json'
-              - '.github/workflows/test.yml'
-              - '.github/workflows/e2e.yml'
-              - '.github/workflows/docker-build.yml'
-              - '.github/workflows/container-smoke.yml'
             frontend:
               - 'frontend/**'
               - 'shared/**'
@@ -44,10 +48,6 @@ jobs:
               - 'release-policy.json'
               - 'scripts/**'
               - 'biome.json'
-              - '.github/workflows/test.yml'
-              - '.github/workflows/e2e.yml'
-              - '.github/workflows/docker-build.yml'
-              - '.github/workflows/container-smoke.yml'
 
   # =============================================================================
   # Backend Tests (always emits the required check context)

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -3,6 +3,8 @@ name: Workflow Validation
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
 
 permissions:
   contents: read

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,9 +86,9 @@ Use the root-level commands for full-stack validation when a change spans backen
 ## Release Workflow Safeguards
 
 - PR validation is enforced through `.github/workflows/test.yml` and `.github/workflows/e2e.yml`.
-- Workflow syntax validation is enforced through `.github/workflows/workflow-validation.yml` with `actionlint` on all PR workflow changes.
-- Required PR checks now always emit their stable check names; when a PR is not relevant for a given lane, the workflow reports a no-op success instead of disappearing as a skipped/missing required context.
-- Product test lanes are only triggered by product code or product-facing CI/CD workflow changes (`test.yml`, `e2e.yml`, `docker-build.yml`, `container-smoke.yml`). Project, issue, and PR automation workflow edits still get workflow validation, but no longer trigger backend/frontend/Playwright lanes by themselves.
+- Workflow syntax validation is enforced through `.github/workflows/workflow-validation.yml` with `actionlint` on PRs that change workflow files under `.github/workflows/**`.
+- Within product-relevant PRs, required product checks still emit their stable names and report a no-op success when a backend/frontend lane is not relevant inside that product scope.
+- Workflow-only edits are validated by `Workflow Validation / Actionlint` and do not trigger backend/frontend/Playwright/container smoke lanes by themselves.
 - Release-relevant PRs also run `.github/workflows/container-smoke.yml` as a dedicated container runtime check.
 - Docker publishing is handled by `.github/workflows/docker-build.yml`.
 - The reusable container smoke workflow is used in two places:


### PR DESCRIPTION
Closes #720

## Summary
- scope PR workflow triggers to the files they actually validate
- keep the follow-up change limited to the intended CI workflow files and docs update
- reduce unrelated workflow fan-out for workflow-only pull requests

## Validation
- prepared local state on commit `eea4a73`
- scope limited to the intended follow-up files only