### PR TITLE
fix(ci): restore CodeQL actions coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,8 @@ on:
       - 'frontend/package.json'
       - 'frontend/package-lock.json'
       - '.github/codeql/**'
-      - '.github/workflows/codeql.yml'
+      - '.github/workflows/**'
+      - '.github/actions/**'
   pull_request:
     branches: [main]
     paths:
@@ -26,6 +27,8 @@ on:
       - 'frontend/package.json'
       - 'frontend/package-lock.json'
       - '.github/codeql/**'
+      - '.github/workflows/**'
+      - '.github/actions/**'
   schedule:
     - cron: "0 6 * * 1" # Weekly on Monday at 6am UTC
   workflow_dispatch: # Allow manual trigger
@@ -42,7 +45,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript-typescript]
+        include:
+          - language: javascript-typescript
+            autobuild: true
+          - language: actions
+            autobuild: false
 
     steps:
       - name: Checkout repository
@@ -55,6 +62,7 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
+        if: matrix.autobuild
         uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,8 +87,9 @@ Use the root-level commands for full-stack validation when a change spans backen
 
 - PR validation is enforced through `.github/workflows/test.yml` and `.github/workflows/e2e.yml`.
 - Workflow syntax validation is enforced through `.github/workflows/workflow-validation.yml` with `actionlint` on PRs that change workflow files under `.github/workflows/**`.
+- CodeQL scans both `javascript-typescript` source code and GitHub Actions workflow changes under `.github/workflows/**` / `.github/actions/**`.
 - Within product-relevant PRs, required product checks still emit their stable names and report a no-op success when a backend/frontend lane is not relevant inside that product scope.
-- Workflow-only edits are validated by `Workflow Validation / Actionlint` and do not trigger backend/frontend/Playwright/container smoke lanes by themselves.
+- Workflow-only edits are validated by `Workflow Validation / Actionlint`; they do not trigger backend/frontend/Playwright/container smoke lanes by themselves, but they still run CodeQL for the `actions` language.
 - Release-relevant PRs also run `.github/workflows/container-smoke.yml` as a dedicated container runtime check.
 - Docker publishing is handled by `.github/workflows/docker-build.yml`.
 - The reusable container smoke workflow is used in two places:


### PR DESCRIPTION
Closes #722

## Summary
- restore CodeQL coverage for GitHub Actions workflow changes
- scan both `javascript-typescript` and `actions`
- keep `autobuild` limited to the JS/TS CodeQL matrix entry
- document that workflow-only edits still run CodeQL for the `actions` language

## Validation
- confirmed by testing-manager before handoff
- workflow YAML structure valid
- trigger paths include workflow and action paths
- `autobuild` gated to JS/TS only