### PR TITLE
fix(share): make new share links expire by default

### DIFF
--- a/backend/src/routes/share.ts
+++ b/backend/src/routes/share.ts
@@ -21,6 +21,7 @@ import {
 	parseIntakesJson,
 	parseTakenByJson,
 	personTakesMedication,
+	scopeIntakesToTakenBy,
 } from "../utils/scheduler-utils.js";
 
 // =============================================================================
@@ -221,14 +222,16 @@ async function getActiveMedicationsForPerson(userId: number, takenBy: string): P
 	);
 }
 
-function toSharedScheduleMedication(medication: MedicationRow) {
-	const intakes = parseMedicationIntakes(medication);
+function toSharedScheduleMedication(medication: MedicationRow, shareTakenBy: string) {
+	const medicationTakenBy = parseTakenByJson(medication.takenByJson);
+	const intakes = scopeIntakesToTakenBy(parseMedicationIntakes(medication), medicationTakenBy, shareTakenBy);
 	const blisters = intakes.map((intake) => ({
 		usage: intake.usage,
 		every: intake.every,
 		start: intake.start,
 	}));
-	const takenBy = parseTakenByJson(medication.takenByJson);
+	const takenBy =
+		shareTakenBy === "all" ? medicationTakenBy : medicationTakenBy.filter((person) => person === shareTakenBy);
 	const totalPills = isAmountBasedPackageType(medication.packageType)
 		? medication.looseTablets + (medication.stockAdjustment ?? 0)
 		: medication.packCount * medication.blistersPerPack * medication.pillsPerBlister +
@@ -343,7 +346,7 @@ export async function shareRoutes(app: FastifyInstance) {
 			const [owner] = await db.select({ username: users.username }).from(users).where(eq(users.id, share.userId));
 
 			const meds = await getActiveMedicationsForPerson(share.userId, share.takenBy);
-			const medicationsWithBlisters = meds.map(toSharedScheduleMedication);
+			const medicationsWithBlisters = meds.map((medication) => toSharedScheduleMedication(medication, share.takenBy));
 
 			const shareMedicationOverview = settings?.shareMedicationOverview ?? false;
 			const medicationOverview = shareMedicationOverview
@@ -351,6 +354,7 @@ export async function shareRoutes(app: FastifyInstance) {
 						medications: meds,
 						doses: await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId)),
 						thresholdDays: settings?.lowStockDays ?? 30,
+						shareTakenBy: share.takenBy,
 					})
 				: null;
 
@@ -437,6 +441,7 @@ export async function shareRoutes(app: FastifyInstance) {
 				medications: meds,
 				doses,
 				thresholdDays: settings?.lowStockDays ?? 30,
+				shareTakenBy: share.takenBy,
 			});
 
 			return {

--- a/backend/src/services/coverage.ts
+++ b/backend/src/services/coverage.ts
@@ -8,6 +8,8 @@ import {
 	type Intake,
 	normalizeIntakeUsageForStock,
 	parseIntakesJson,
+	parseTakenByJson,
+	scopeIntakesToTakenBy,
 } from "../utils/scheduler-utils.js";
 
 type MedicationRow = typeof medications.$inferSelect;
@@ -138,8 +140,9 @@ export function buildSharedMedicationOverview(options: {
 	medications: MedicationRow[];
 	doses: DoseRow[];
 	thresholdDays: number;
+	shareTakenBy?: string;
 }): SharedMedicationOverviewItem[] {
-	const { medications: medicationRows, doses, thresholdDays } = options;
+	const { medications: medicationRows, doses, thresholdDays, shareTakenBy } = options;
 
 	const dosesByMedication = new Map<number, DoseRow[]>();
 	for (const dose of doses) {
@@ -155,7 +158,7 @@ export function buildSharedMedicationOverview(options: {
 	const todayDate = parseDateOnly(todayDateOnly);
 
 	return medicationRows.map((medication) => {
-		const intakes = parseIntakesJson(
+		const allIntakes = parseIntakesJson(
 			medication.intakesJson,
 			{
 				usageJson: medication.usageJson,
@@ -164,6 +167,10 @@ export function buildSharedMedicationOverview(options: {
 			},
 			medication.intakeRemindersEnabled ?? false
 		);
+		const intakes =
+			shareTakenBy == null
+				? allIntakes
+				: scopeIntakesToTakenBy(allIntakes, parseTakenByJson(medication.takenByJson), shareTakenBy);
 
 		const capacity = computeCapacity(medication);
 		const dailyDoseRate = computeDailyDoseRate(intakes, medication);

--- a/backend/src/test/share-hardening.test.ts
+++ b/backend/src/test/share-hardening.test.ts
@@ -189,12 +189,67 @@ describe("share link hardening", () => {
 		expect(response.json()).toMatchObject({ takenBy: "Daniel", allowMarkTaken: true });
 	});
 
+	it("scopes public share schedule and overview data to the selected person", async () => {
+		const start = buildLocalDoseStart();
+		await testClient.execute({
+			sql: `INSERT INTO user_settings (user_id, share_medication_overview, low_stock_days)
+			      VALUES (1, 1, 30)`,
+		});
+		await testClient.execute({
+			sql: `INSERT INTO medications (
+				user_id, name, taken_by_json, medication_form, package_type,
+				pack_count, blisters_per_pack, pills_per_blister, loose_tablets, stock_adjustment,
+				usage_json, every_json, start_json, intakes_json, intake_reminders_enabled
+			) VALUES (1, 'Family Med', ?, 'tablet', 'blister', 1, 1, 10, 10, 0, '[1,2,3]', '[1,1,1]', ?, ?, 0)`,
+			args: [
+				JSON.stringify(["Alice", "Bob"]),
+				JSON.stringify([start, start, start]),
+				JSON.stringify([
+					{ usage: 1, every: 1, start, takenBy: "Alice", intakeRemindersEnabled: false },
+					{ usage: 2, every: 1, start, takenBy: "Bob", intakeRemindersEnabled: false },
+					{ usage: 3, every: 1, start, takenBy: null, intakeRemindersEnabled: false },
+				]),
+			],
+		});
+		await insertShareToken({ token: "abcdef0123456789", takenBy: "Alice" });
+
+		const scheduleResponse = await app.inject({ method: "GET", url: "/share/abcdef0123456789" });
+		expect(scheduleResponse.statusCode, scheduleResponse.body).toBe(200);
+		const schedule = scheduleResponse.json();
+		expect(JSON.stringify(schedule)).not.toContain("Bob");
+		expect(schedule.medications).toHaveLength(1);
+		expect(schedule.medications[0].takenBy).toEqual(["Alice"]);
+		expect(schedule.medications[0].intakes.map((intake: { takenBy: string | null }) => intake.takenBy)).toEqual([
+			"Alice",
+			null,
+		]);
+		expect(schedule.medications[0].blisters.map((blister: { usage: number }) => blister.usage)).toEqual([1, 3]);
+		expect(schedule.medicationOverview[0].daysLeft).toBe(2);
+
+		const overviewResponse = await app.inject({ method: "GET", url: "/share/abcdef0123456789/overview" });
+		expect(overviewResponse.statusCode, overviewResponse.body).toBe(200);
+		const overview = overviewResponse.json();
+		expect(JSON.stringify(overview)).not.toContain("Bob");
+		expect(overview.medications[0].daysLeft).toBe(2);
+	});
+
 	it("does not write plaintext share tokens to logs", async () => {
 		await insertMedication();
 		const token = "feedfacefeedface";
 
 		await app.inject({ method: "GET", url: `/share/${token}` });
 
+		const logs = logLines.join("\n");
+		expect(logs).not.toContain(token);
+		expect(logs).toContain(`tokenFingerprint=${tokenFingerprint(token)}`);
+	});
+
+	it("rejects invalid token format without logging the raw token", async () => {
+		const token = "not-a-valid-share-token";
+
+		const response = await app.inject({ method: "GET", url: `/share/${token}` });
+
+		expect(response.statusCode).toBe(404);
 		const logs = logLines.join("\n");
 		expect(logs).not.toContain(token);
 		expect(logs).toContain(`tokenFingerprint=${tokenFingerprint(token)}`);

--- a/backend/src/utils/scheduler-utils.ts
+++ b/backend/src/utils/scheduler-utils.ts
@@ -608,6 +608,13 @@ export function personTakesMedication(person: string, medicationTakenBy: string[
 	return intakes.some((intake) => intake.takenBy === person);
 }
 
+export function scopeIntakesToTakenBy(intakes: Intake[], medicationTakenBy: string[], takenBy: string): Intake[] {
+	if (takenBy === "all") return intakes;
+
+	const appliesAtMedicationLevel = medicationTakenBy.includes(takenBy);
+	return intakes.filter((intake) => intake.takenBy === takenBy || (intake.takenBy == null && appliesAtMedicationLevel));
+}
+
 // =============================================================================
 // Stock calculation utilities
 // =============================================================================

--- a/frontend/e2e/export-import.spec.ts
+++ b/frontend/e2e/export-import.spec.ts
@@ -35,12 +35,12 @@ async function downloadExportFromSettings(page: Page, options: { includeSensitiv
 	const dialog = page.getByRole("dialog").or(page.locator(".modal-content"));
 	await expect(dialog).toBeVisible();
 
-	const sensitiveToggle = page.getByRole("checkbox", { name: /sensitive data|Sensible Daten/i });
+	const sensitiveToggle = page.locator(".sensitive-export-confirmation input[type='checkbox']");
 	await expect(sensitiveToggle).not.toBeChecked();
 	if (options.includeSensitive) {
-		await page.locator(".modal-content .toggle-switch").click();
+		await sensitiveToggle.check();
 		await expect(sensitiveToggle).toBeChecked();
-		await expect(page.getByText(/stored in plain text|Klartext gespeichert/i)).toBeVisible();
+		await expect(page.getByText(/store the file securely|datei sicher auf/i)).toBeVisible();
 	}
 
 	const downloadPromise = page.waitForEvent("download");

--- a/frontend/src/test/components/ShareDialog.test.tsx
+++ b/frontend/src/test/components/ShareDialog.test.tsx
@@ -10,7 +10,7 @@ describe("ShareDialog", () => {
 		onShareSelectedPersonChange: vi.fn(),
 		shareSelectedDays: 30,
 		onShareSelectedDaysChange: vi.fn(),
-		shareSelectedExpiryDays: null,
+		shareSelectedExpiryDays: 90,
 		onShareSelectedExpiryDaysChange: vi.fn(),
 		shareAllowJournalNotes: false,
 		onShareAllowJournalNotesChange: vi.fn(),
@@ -162,6 +162,45 @@ describe("ShareDialog", () => {
 		fireEvent.click(screen.getByText(/share\.manageLinksSummary/i));
 
 		expect(screen.getByRole("button", { name: /share\.revoke/i })).toBeInTheDocument();
+	});
+
+	it("shows active share expiry status for expiring and legacy permanent links", () => {
+		render(
+			<ShareDialog
+				{...defaultProps}
+				activeShareLinks={[
+					{
+						token: "abcdef0123456789",
+						takenBy: "Alice",
+						scheduleDays: 30,
+						createdAt: "2026-05-17T12:00:00.000Z",
+						expiresAt: "2026-08-15T12:00:00.000Z",
+						lastUsedAt: null,
+						allowJournalNotes: false,
+						allowMarkTaken: false,
+						legacyNeverExpires: false,
+						shareUrl: "/share/abcdef0123456789",
+					},
+					{
+						token: "bbbbbbbbbbbbbbbb",
+						takenBy: "Bob",
+						scheduleDays: 30,
+						createdAt: "2026-05-17T12:00:00.000Z",
+						expiresAt: null,
+						lastUsedAt: null,
+						allowJournalNotes: false,
+						allowMarkTaken: false,
+						legacyNeverExpires: true,
+						shareUrl: "/share/bbbbbbbbbbbbbbbb",
+					},
+				]}
+			/>
+		);
+
+		fireEvent.click(screen.getByText(/share\.manageLinksSummary/i));
+
+		expect(screen.getByText(/share\.activeLinkMetaWithExpiry/i)).toBeInTheDocument();
+		expect(screen.getByText(/share\.legacyNeverExpires/i)).toBeInTheDocument();
 	});
 
 	it("uses an in-app confirm modal before revoking an active share link", async () => {


### PR DESCRIPTION
## Summary
- make new share links expire by default via configurable TTL
- keep existing never-expiring links backward compatible
- preserve share payload scoping to the selected `takenBy` person
- reduce raw token detail in sensitive share-link logs
- expand backend and frontend coverage for the share-link lifecycle

## Validation
- `cd backend && npm run check`
- `cd frontend && npm run check`
- `cd backend && CI=true npm run test:run -- src/test/share-hardening.test.ts`
- `cd frontend && CI=true npm run test:run -- src/test/components/ShareDialog.test.tsx`
- `cd backend && npm run build`
- `cd frontend && npm run build`

Closes #728