### PR TITLE
fix(csrf): document and test cookie security contract

### DIFF
--- a/backend/src/test/app-factory.test.ts
+++ b/backend/src/test/app-factory.test.ts
@@ -67,6 +67,17 @@ async function expectCorsDefaultAllowsSecondaryDevOrigin(app: FastifyInstance): 
 	expect(response.headers["access-control-allow-credentials"]).toBe("true");
 }
 
+async function expectCorsWithholdsAllowOriginForUnconfiguredBrowserOrigin(app: FastifyInstance): Promise<void> {
+	const response = await app.inject({
+		method: "GET",
+		url: "/bootstrap-test/probe",
+		headers: { origin: "https://evil.example" },
+	});
+
+	expect(response.statusCode).toBe(200);
+	expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+}
+
 async function expectDefaultRateLimit(app: FastifyInstance): Promise<void> {
 	for (let index = 0; index < DEFAULT_RATE_LIMIT_MAX; index += 1) {
 		const response = await app.inject({ method: "GET", url: "/bootstrap-test/probe" });
@@ -116,6 +127,40 @@ describe("createApp bootstrap defaults", () => {
 		} finally {
 			await defaultApp.close();
 			await runtimeApp.close();
+		}
+	});
+
+	it("withholds CORS allow-origin from unconfigured browser origins", async () => {
+		const app = await buildProbeApp();
+
+		try {
+			await expectCorsWithholdsAllowOriginForUnconfiguredBrowserOrigin(app);
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("keeps public notification action CORS credential-free for arbitrary browser origins", async () => {
+		const app = await buildProbeApp({
+			corsOrigins: ["https://medassist.example"],
+		});
+
+		try {
+			const preflight = await app.inject({
+				method: "OPTIONS",
+				url: "/notification-actions/demo-token",
+				headers: {
+					origin: "https://ntfy.example",
+					"access-control-request-method": "POST",
+					"access-control-request-headers": "content-type",
+				},
+			});
+
+			expect(preflight.statusCode).toBe(204);
+			expect(preflight.headers["access-control-allow-origin"]).toBe("https://ntfy.example");
+			expect(preflight.headers["access-control-allow-credentials"]).toBeUndefined();
+		} finally {
+			await app.close();
 		}
 	});
 

--- a/backend/src/test/server.test.ts
+++ b/backend/src/test/server.test.ts
@@ -50,6 +50,17 @@ describe("Index.ts Utility Functions", () => {
 	});
 
 	describe("buildBaseCookieOptions", () => {
+		it("should make development access cookies httpOnly SameSite=Lax without Secure", () => {
+			const options = buildBaseCookieOptions(15, false);
+			expect(options).toMatchObject({
+				httpOnly: true,
+				secure: false,
+				sameSite: "lax",
+				path: "/",
+				maxAge: 15 * 60,
+			});
+		});
+
 		it("should set secure=true in production", () => {
 			const options = buildBaseCookieOptions(15, true);
 			expect(options.secure).toBe(true);
@@ -75,6 +86,18 @@ describe("Index.ts Utility Functions", () => {
 	});
 
 	describe("buildRefreshCookieOptions", () => {
+		it("should make production refresh cookies secure, httpOnly and SameSite=Lax", () => {
+			const base = buildBaseCookieOptions(15, true);
+			const refresh = buildRefreshCookieOptions(base, 7);
+			expect(refresh).toMatchObject({
+				httpOnly: true,
+				secure: true,
+				sameSite: "lax",
+				path: "/",
+				maxAge: 7 * 24 * 60 * 60,
+			});
+		});
+
 		it("should extend base options with longer maxAge", () => {
 			const base = buildBaseCookieOptions(15, false);
 			const refresh = buildRefreshCookieOptions(base, 7);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,6 +34,8 @@ API docs behavior:
 
 ## Authentication
 
+Browser cookie, CORS, CSRF, Bearer token, and API-key security behavior is documented in [SECURITY.md](SECURITY.md).
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUTH_ENABLED` | `false` | Enable user authentication. Required for public production deployments. |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Notes
+
+## Browser Session And CSRF Contract
+
+MedAssist uses HTTP-only cookies for browser sessions and also accepts `Authorization: Bearer ...` for JWT and API-key clients on authenticated API routes.
+
+Session cookies are configured as:
+
+- `httpOnly=true`, so browser JavaScript cannot read token values.
+- `sameSite=lax`, so cross-site subresource and form-style POST requests do not include session cookies in modern browsers.
+- `secure=true` in production and `secure=false` only for local development/test.
+
+Authenticated state-changing routes are protected server-side by `requireAuth`. When authentication is enabled, these routes accept either a same-site session cookie, a valid Bearer JWT, or a write-scoped API key unless the route adds a stricter local check. Read-scoped API keys are rejected for mutation methods.
+
+Cookie-auth state-changing route groups:
+
+- Auth/session: `POST /auth/logout`, `PUT /auth/me`, `POST /auth/avatar`, `DELETE /auth/avatar`, `DELETE /auth/me`
+- API keys: `POST /auth/api-keys`, `DELETE /auth/api-keys/:id`
+- Medication data: medication create/update/delete, stock/refill/package actions, dose tracking, intake journal, refill history
+- Settings and reminder tests: `PUT /settings`, `PUT /settings/language`, test email/push endpoints, planner send/reminder endpoints
+- Export/import/report/share management: export request/import, report generation, share create/revoke/regenerate
+- Medication enrichment: authenticated enrichment requests
+
+Public token routes are not cookie-auth endpoints. Share links, share dose actions, and notification action tokens are authorized by their own opaque token values and must stay scoped to the token target.
+
+## CORS Expectations
+
+Credentialed browser CORS is allowed only for configured `CORS_ORIGINS`. An unconfigured browser origin does not receive `Access-Control-Allow-Origin`, so the browser cannot grant credentialed cross-origin API access. Requests from unconfigured origins may still reach the backend outside browser CORS enforcement, so server-side authentication and authorization remain mandatory.
+
+Public notification action routes allow arbitrary browser origins without credentials. This is intentional so external notification providers can send token-based actions without receiving browser session cookies.
+
+## CSRF Decision
+
+No additional CSRF token is required for the current browser contract because state-changing session requests rely on `SameSite=Lax`, credentialed CORS allowlists, JSON/fetch-based clients, server-side auth, and current-password checks for sensitive account changes.
+
+Add explicit CSRF-token protection before allowing any of these changes:
+
+- `SameSite=None` cookies or third-party embedding.
+- Simple cross-site form submissions for state-changing routes.
+- New high-risk cookie-auth mutations that do not require JSON/fetch preflight or a separate confirmation factor.
+- Broadening credentialed CORS beyond trusted application origins.


### PR DESCRIPTION
## Summary
- document the cookie-auth CSRF security contract and threat model
- add regression coverage for CSRF-related cookie/session behavior
- keep API-key/Bearer behavior distinctions explicit in tests/docs

## Validation
- `cd backend && CI=true npm run test:run -- src/test/app-factory.test.ts src/test/server.test.ts`
- `cd backend && npm run check`
- `cd backend && npm run build`

Closes #732