### PR TITLE
fix(auth): revoke refresh tokens after password change

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -643,6 +643,35 @@ export async function authRoutes(app: FastifyInstance) {
 				updates.passwordHash = await argon2.hash(newPassword, ARGON2_OPTIONS);
 			}
 
+			if (newPassword) {
+				const newTokenId = randomBytes(32).toString("hex");
+				const refreshExp = new Date(Date.now() + refreshTtlDays * 24 * 60 * 60 * 1000);
+				const newAccessToken = await app.jwt.sign(
+					{ sub: user.id, username: user.username },
+					{ expiresIn: `${accessTtlMinutes}m` }
+				);
+				const newRefreshToken = await app.jwt.sign(
+					{ sub: user.id, jti: newTokenId },
+					{ expiresIn: `${refreshTtlDays}d`, key: app.config.refreshSecret }
+				);
+
+				await db.update(users).set(updates).where(eq(users.id, user.id));
+				await db
+					.update(refreshTokens)
+					.set({ revoked: true, rotatedAt: new Date() })
+					.where(eq(refreshTokens.userId, user.id));
+				await db.insert(refreshTokens).values({
+					userId: user.id,
+					tokenId: newTokenId,
+					expiresAt: refreshExp,
+				});
+
+				return reply
+					.setCookie("access_token", newAccessToken, app.config.cookieOptions)
+					.setCookie("refresh_token", newRefreshToken, app.config.refreshCookieOptions)
+					.send({ ok: true, message: "Profile updated" });
+			}
+
 			await db.update(users).set(updates).where(eq(users.id, user.id));
 
 			return { ok: true, message: "Profile updated" };

--- a/backend/src/test/auth.test.ts
+++ b/backend/src/test/auth.test.ts
@@ -882,6 +882,77 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 			expect(newLogin.statusCode).toBe(200);
 		});
 
+		it("should revoke existing refresh tokens and keep the current session usable after password change", async () => {
+			await app.inject({
+				method: "POST",
+				url: "/auth/register",
+				payload: {
+					username: "rotateprofileuser",
+					password: "TestPassword123",
+				},
+			});
+
+			const currentSession = await app.inject({
+				method: "POST",
+				url: "/auth/login",
+				payload: {
+					username: "rotateprofileuser",
+					password: "TestPassword123",
+				},
+			});
+			const otherSession = await app.inject({
+				method: "POST",
+				url: "/auth/login",
+				payload: {
+					username: "rotateprofileuser",
+					password: "TestPassword123",
+				},
+			});
+			const oldCurrentRefreshToken = getResponseCookieValue(currentSession, "refresh_token");
+			const oldOtherRefreshToken = getResponseCookieValue(otherSession, "refresh_token");
+			const accessToken = getResponseCookieValue(currentSession, "access_token");
+
+			const response = await app.inject({
+				method: "PUT",
+				url: "/auth/me",
+				cookies: {
+					access_token: accessToken,
+				},
+				payload: {
+					currentPassword: "TestPassword123",
+					newPassword: "NewPassword456",
+				},
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json().ok).toBe(true);
+			const newRefreshToken = getResponseCookieValue(response, "refresh_token");
+			expect(newRefreshToken).not.toBe(oldCurrentRefreshToken);
+			expect(newRefreshToken).not.toBe(oldOtherRefreshToken);
+
+			for (const revokedRefreshToken of [oldCurrentRefreshToken, oldOtherRefreshToken]) {
+				const revokedResponse = await app.inject({
+					method: "POST",
+					url: "/auth/refresh",
+					cookies: {
+						refresh_token: revokedRefreshToken,
+					},
+				});
+				expect(revokedResponse.statusCode).toBe(401);
+				expect(revokedResponse.json().code).toBe("INVALID_REFRESH_TOKEN");
+			}
+
+			const usableCurrentSession = await app.inject({
+				method: "POST",
+				url: "/auth/refresh",
+				cookies: {
+					refresh_token: newRefreshToken,
+				},
+			});
+			expect(usableCurrentSession.statusCode).toBe(200);
+			expect(usableCurrentSession.json().ok).toBe(true);
+		});
+
 		it("should reject password change without current password", async () => {
 			await app.inject({
 				method: "POST",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -53,6 +53,8 @@ Production startup fails fast when `NODE_ENV=production`, `AUTH_ENABLED=false`, 
 
 For public deployments, enable `AUTH_ENABLED=true` and configure local form login or OIDC SSO. If you run a private local-only instance without authentication, set `ALLOW_UNAUTHENTICATED=true` deliberately and keep the app off untrusted networks.
 
+When a local user's password is changed, all existing refresh tokens for that user are revoked. The current browser session receives a newly issued access/refresh token pair, while other sessions must sign in again.
+
 ## Backend Exposure
 
 The default Docker Compose stack exposes only the frontend. The backend listens on the internal Docker network and is reached through the frontend `/api` proxy.


### PR DESCRIPTION
## Summary
- revoke old refresh-token chains after password changes
- ensure previously issued refresh tokens can no longer rotate sessions
- preserve expected behavior for the current session flow

## Validation
- `cd backend && CI=true npm run test:run -- src/test/auth.test.ts`
- `cd backend && npm run check`
- `cd backend && npm run build`

Closes #731