### PR TITLE
fix(auth): harden API key pepper and usage tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,8 @@ AUTH_ENABLED=false
 # Token TTL (optional - defaults shown)
 # ACCESS_TOKEN_TTL_MINUTES=15
 # REFRESH_TOKEN_TTL_DAYS=7
+# API_KEY_PEPPER=paste-a-unique-64-character-hex-value-here
+# API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES=15
 # SHARE_TOKEN_TTL_DAYS=90
 
 # =============================================================================

--- a/backend/src/plugins/auth.ts
+++ b/backend/src/plugins/auth.ts
@@ -85,6 +85,7 @@ export interface RequestUser {
 }
 
 const READ_ONLY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const TEST_API_KEY_PEPPER = "medassist-test-api-key-pepper-v1";
 
 export function isReadOnlyApiKeyRequest(request: FastifyRequest): boolean {
 	return request.authContext?.method === "api_key" && request.authContext.scope === "read";
@@ -95,11 +96,22 @@ function isMutationMethod(method: string): boolean {
 }
 
 function getApiKeyPepper(): string {
-	return env.JWT_SECRET || env.REFRESH_SECRET || "medassist-api-key-pepper";
+	if (env.API_KEY_PEPPER) return env.API_KEY_PEPPER;
+	if (env.JWT_SECRET) return env.JWT_SECRET;
+	if (env.REFRESH_SECRET) return env.REFRESH_SECRET;
+	if (env.NODE_ENV === "test") return TEST_API_KEY_PEPPER;
+	throw new Error("API_KEY_PEPPER_REQUIRED");
 }
 
 export function hashApiKeyToken(token: string): string {
 	return pbkdf2Sync(token, getApiKeyPepper(), 120_000, 64, "sha512").toString("hex");
+}
+
+function shouldUpdateApiKeyLastUsedAt(lastUsedAt: Date | null, now: Date): boolean {
+	if (!lastUsedAt) return true;
+	const intervalMinutes = env.API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES ?? 15;
+	const intervalMs = intervalMinutes * 60 * 1000;
+	return now.getTime() - lastUsedAt.getTime() >= intervalMs;
 }
 
 function getBearerToken(request: FastifyRequest): string | null {
@@ -157,10 +169,13 @@ async function tryApiKeyAuth(request: FastifyRequest, reply: FastifyReply): Prom
 		apiKeyId: keyRow.id,
 	};
 
-	await db
-		.update(apiKeys)
-		.set({ lastUsedAt: new Date(), updatedAt: new Date() })
-		.where(and(eq(apiKeys.id, keyRow.id), eq(apiKeys.userId, user.id)));
+	const now = new Date();
+	if (shouldUpdateApiKeyLastUsedAt(keyRow.lastUsedAt, now)) {
+		await db
+			.update(apiKeys)
+			.set({ lastUsedAt: now, updatedAt: now })
+			.where(and(eq(apiKeys.id, keyRow.id), eq(apiKeys.userId, user.id)));
+	}
 
 	return true;
 }

--- a/backend/src/plugins/env-schema.ts
+++ b/backend/src/plugins/env-schema.ts
@@ -45,6 +45,8 @@ export const EnvSchema = z.object({
 	COOKIE_SECRET: z.string().min(10).optional(),
 	ACCESS_TOKEN_TTL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 525_600 }),
 	REFRESH_TOKEN_TTL_DAYS: intEnv({ defaultValue: 7, min: 1, max: 3650 }),
+	API_KEY_PEPPER: z.string().min(32).optional(),
+	API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES: intEnv({ defaultValue: 15, min: 1, max: 1440 }),
 	SHARE_TOKEN_TTL_DAYS: intEnv({ defaultValue: 90, min: 1, max: 3650 }),
 	OIDC_ENABLED: boolEnv(false),
 	OIDC_ISSUER_URL: z.string().url().optional(),

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -66,6 +66,28 @@ if (parsed.AUTH_ENABLED) {
 	}
 }
 
+function isStrongApiKeyPepperSource(value: string | undefined): boolean {
+	return (value?.trim().length ?? 0) >= 32;
+}
+
+if (
+	parsed.NODE_ENV === "production" &&
+	parsed.AUTH_ENABLED &&
+	!isStrongApiKeyPepperSource(parsed.API_KEY_PEPPER) &&
+	!isStrongApiKeyPepperSource(parsed.JWT_SECRET) &&
+	!isStrongApiKeyPepperSource(parsed.REFRESH_SECRET)
+) {
+	console.error("=".repeat(60));
+	console.error("API KEY CONFIGURATION ERROR");
+	console.error("=".repeat(60));
+	console.error("Production API key hashing requires API_KEY_PEPPER or a strong JWT_SECRET/REFRESH_SECRET.");
+	console.error("");
+	console.error("To fix this, set API_KEY_PEPPER to a unique random value:");
+	console.error("  openssl rand -hex 32");
+	console.error("=".repeat(60));
+	process.exit(1);
+}
+
 // Validate OIDC configuration when enabled
 if (parsed.OIDC_ENABLED) {
 	const missing: string[] = [];

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -73,6 +73,7 @@ describe("plugins/env runtime validation", () => {
 		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
 		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
 		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.API_KEY_PEPPER = "a".repeat(64);
 		process.env.OPENAPI_DOCS_ENABLED = "true";
 		delete process.env.DOCS_AUTH_REQUIRED;
 
@@ -87,6 +88,7 @@ describe("plugins/env runtime validation", () => {
 		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
 		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
 		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.API_KEY_PEPPER = "a".repeat(64);
 		process.env.OPENAPI_DOCS_ENABLED = "true";
 		process.env.DOCS_AUTH_REQUIRED = "false";
 
@@ -104,6 +106,7 @@ describe("plugins/env runtime validation", () => {
 		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
 		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
 		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.API_KEY_PEPPER = "a".repeat(64);
 		process.env.OPENAPI_DOCS_ENABLED = "no";
 		process.env.DOCS_AUTH_REQUIRED = "yes";
 
@@ -192,6 +195,45 @@ describe("plugins/env runtime validation", () => {
 		await expect(import("../plugins/env.js")).rejects.toThrow("process.exit:1");
 	});
 
+	it("exits in production auth when API key pepper and auth secrets are too weak for API key hashing", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		delete process.env.API_KEY_PEPPER;
+
+		vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as never);
+
+		await expect(import("../plugins/env.js")).rejects.toThrow("process.exit:1");
+	});
+
+	it("loads in production auth when API_KEY_PEPPER is strong", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.API_KEY_PEPPER = "b".repeat(64);
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.API_KEY_PEPPER).toBe("b".repeat(64));
+	});
+
+	it("loads in production auth without API_KEY_PEPPER when an auth secret is strong", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "c".repeat(64);
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		delete process.env.API_KEY_PEPPER;
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.JWT_SECRET).toBe("c".repeat(64));
+	});
+
 	it("exits when oidc is enabled but required settings are missing", async () => {
 		process.env.AUTH_ENABLED = "false";
 		process.env.OIDC_ENABLED = "true";
@@ -212,6 +254,7 @@ describe("plugins/env runtime validation", () => {
 		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
 		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
 		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.API_KEY_PEPPER = "a".repeat(64);
 		process.env.OIDC_ENABLED = "true";
 		process.env.OIDC_ISSUER_URL = "https://auth.example.com";
 		process.env.OIDC_CLIENT_ID = "medassist";

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -46,6 +46,8 @@ describe("EnvSchema", () => {
 			expect(result.RATE_LIMIT_MAX).toBe(100);
 			expect(result.ACCESS_TOKEN_TTL_MINUTES).toBe(15);
 			expect(result.REFRESH_TOKEN_TTL_DAYS).toBe(7);
+			expect(result.API_KEY_PEPPER).toBeUndefined();
+			expect(result.API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES).toBe(15);
 			expect(result.SHARE_TOKEN_TTL_DAYS).toBe(90);
 			expect(result.OIDC_ENABLED).toBe(false);
 			expect(result.OIDC_SCOPES).toBe("openid profile email");
@@ -174,6 +176,28 @@ describe("EnvSchema", () => {
 		it("should transform SHARE_TOKEN_TTL_DAYS to number", () => {
 			const result = EnvSchema.parse({ SHARE_TOKEN_TTL_DAYS: "120" });
 			expect(result.SHARE_TOKEN_TTL_DAYS).toBe(120);
+		});
+
+		it("should transform API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES to number", () => {
+			const result = EnvSchema.parse({ API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES: "30" });
+			expect(result.API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES).toBe(30);
+		});
+
+		it("should reject invalid API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES", () => {
+			expect(() => EnvSchema.parse({ API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES: "abc" })).toThrow();
+			expect(() => EnvSchema.parse({ API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES: "0" })).toThrow();
+		});
+	});
+
+	describe("API key pepper validation", () => {
+		it("should accept strong API_KEY_PEPPER values", () => {
+			const pepper = "a".repeat(32);
+			const result = EnvSchema.parse({ API_KEY_PEPPER: pepper });
+			expect(result.API_KEY_PEPPER).toBe(pepper);
+		});
+
+		it("should reject short API_KEY_PEPPER values", () => {
+			expect(() => EnvSchema.parse({ API_KEY_PEPPER: "short-api-key-pepper" })).toThrow();
 		});
 	});
 

--- a/backend/src/test/settings-auth-security.test.ts
+++ b/backend/src/test/settings-auth-security.test.ts
@@ -33,6 +33,7 @@ const { testClient, testDb, mockedEnv, nodemailerSendMail } = vi.hoisted(() => {
 			["COOKIE_SECRET", "test-cookie-secret"],
 			["ACCESS_TOKEN_TTL_MINUTES", 15],
 			["REFRESH_TOKEN_TTL_DAYS", 7],
+			["API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES", 15],
 			["OPENAPI_DOCS_ENABLED", false],
 		]),
 		nodemailerSendMail: vi.fn(),
@@ -75,12 +76,14 @@ async function insertApiKey(options: {
 	scope?: "read" | "write";
 	isActive?: boolean;
 	expiresAt?: Date | null;
+	lastUsedAt?: Date | null;
 }) {
 	const expiresAtValue = options.expiresAt ? Math.floor(options.expiresAt.getTime() / 1000) : null;
+	const lastUsedAtValue = options.lastUsedAt ? Math.floor(options.lastUsedAt.getTime() / 1000) : null;
 
 	const result = await testClient.execute({
-		sql: `INSERT INTO api_keys (user_id, name, key_hash, token_prefix, scope, is_active, expires_at)
-		      VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+		sql: `INSERT INTO api_keys (user_id, name, key_hash, token_prefix, scope, is_active, expires_at, last_used_at)
+		      VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
 		args: [
 			options.userId,
 			"Seeded Key",
@@ -89,6 +92,7 @@ async function insertApiKey(options: {
 			options.scope ?? "write",
 			options.isActive === false ? 0 : 1,
 			expiresAtValue,
+			lastUsedAtValue,
 		],
 	});
 
@@ -187,6 +191,73 @@ describe("Settings and API key security contracts", () => {
 			args: [userId],
 		});
 		expect(Number(settingsRows.rows[0].count)).toBe(0);
+	});
+
+	it("hashes API keys deterministically with the configured pepper", () => {
+		const originalPepper = mockedEnv.API_KEY_PEPPER;
+		try {
+			mockedEnv.API_KEY_PEPPER = "a".repeat(64);
+			const firstHash = hashApiKeyToken("ma_deterministic_hash_token_123");
+			const secondHash = hashApiKeyToken("ma_deterministic_hash_token_123");
+
+			mockedEnv.API_KEY_PEPPER = "b".repeat(64);
+			const differentPepperHash = hashApiKeyToken("ma_deterministic_hash_token_123");
+
+			expect(firstHash).toBe(secondHash);
+			expect(firstHash).not.toBe(differentPepperHash);
+		} finally {
+			mockedEnv.API_KEY_PEPPER = originalPepper;
+		}
+	});
+
+	it("throttles API key lastUsedAt writes", async () => {
+		const userId = await createTestUser(testClient, { username: "settings-api-key-last-used-user" });
+		const apiToken = "ma_last_used_throttle_token_123456789";
+		const recentLastUsedSeconds = Math.floor(Date.now() / 1000) - 60;
+		const keyId = await insertApiKey({
+			userId,
+			token: apiToken,
+			scope: "read",
+			lastUsedAt: new Date(recentLastUsedSeconds * 1000),
+		});
+
+		const firstResponse = await app.inject({
+			method: "GET",
+			url: "/settings",
+			headers: { authorization: `Bearer ${apiToken}` },
+		});
+		const secondResponse = await app.inject({
+			method: "GET",
+			url: "/settings",
+			headers: { authorization: `Bearer ${apiToken}` },
+		});
+		expect(firstResponse.statusCode).toBe(200);
+		expect(secondResponse.statusCode).toBe(200);
+
+		const throttledRow = await testClient.execute({
+			sql: "SELECT last_used_at FROM api_keys WHERE id = ?",
+			args: [keyId],
+		});
+		expect(Number(throttledRow.rows[0].last_used_at)).toBe(recentLastUsedSeconds);
+
+		const staleLastUsedSeconds = Math.floor(Date.now() / 1000) - 20 * 60;
+		await testClient.execute({
+			sql: "UPDATE api_keys SET last_used_at = ? WHERE id = ?",
+			args: [staleLastUsedSeconds, keyId],
+		});
+
+		const refreshResponse = await app.inject({
+			method: "GET",
+			url: "/settings",
+			headers: { authorization: `Bearer ${apiToken}` },
+		});
+		expect(refreshResponse.statusCode).toBe(200);
+
+		const refreshedRow = await testClient.execute({
+			sql: "SELECT last_used_at FROM api_keys WHERE id = ?",
+			args: [keyId],
+		});
+		expect(Number(refreshedRow.rows[0].last_used_at)).toBeGreaterThan(staleLastUsedSeconds);
 	});
 
 	it("rejects PUT /settings with a read-only API key", async () => {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -45,6 +45,8 @@ API docs behavior:
 | `COOKIE_SECRET` | — | Cookie signing key; required when auth is enabled |
 | `ACCESS_TOKEN_TTL_MINUTES` | `15` | Access token lifetime |
 | `REFRESH_TOKEN_TTL_DAYS` | `7` | Refresh token lifetime |
+| `API_KEY_PEPPER` | — | Optional dedicated pepper for API key hashes. Strongly recommended for production; if omitted, production requires a strong `JWT_SECRET` or `REFRESH_SECRET` for API key hashing. Generate with `openssl rand -hex 32`. |
+| `API_KEY_LAST_USED_WRITE_INTERVAL_MINUTES` | `15` | Minimum interval between API key `lastUsedAt` database writes per key |
 | `SHARE_TOKEN_TTL_DAYS` | `90` | Default lifetime for newly generated public share links |
 
 Generate secrets with `openssl rand -hex 32`.


### PR DESCRIPTION
## Summary
- require a secure pepper source for API key hashing in production
- remove unsafe static fallback behavior for API key peppering
- add startup validation around API key hashing configuration
- throttle API key `lastUsedAt` writes on hot paths

## Validation
- `cd backend && CI=true npm run test:run -- src/test/env.test.ts src/test/env-runtime.test.ts src/test/settings-auth-security.test.ts src/test/business-authz-real.test.ts`
- `cd backend && npm run check`
- `cd backend && npm run build`

Closes #730