### PR TITLE
refactor(schedule): centralize medication schedule normalization

### DIFF
--- a/backend/src/db/repair-utils.ts
+++ b/backend/src/db/repair-utils.ts
@@ -3,7 +3,7 @@ import {
 	forEachScheduledOccurrenceInRange,
 	getDateOnlyTimestamp,
 	getScheduleMatchWindowMs,
-	parseIntakesJson,
+	normalizeMedicationIntakes,
 	parseLocalDateTime,
 } from "../utils/scheduler-utils.js";
 
@@ -65,15 +65,13 @@ export async function repairOrphanedDoseIds(client: Client): Promise<{ repaired:
 			const medDoses = dosesByMed.get(medId);
 			if (!medDoses || medDoses.length === 0) continue;
 
-			const intakes = parseIntakesJson(
-				med.intakes_json as string | null,
-				{
-					usageJson: (med.usage_json as string) || "[]",
-					everyJson: (med.every_json as string) || "[]",
-					startJson: (med.start_json as string) || "[]",
-				},
-				(med.intake_reminders_enabled as number) === 1
-			);
+			const intakes = normalizeMedicationIntakes({
+				intakesJson: med.intakes_json as string | null,
+				usageJson: med.usage_json as string | null,
+				everyJson: med.every_json as string | null,
+				startJson: med.start_json as string | null,
+				intakeRemindersEnabled: (med.intake_reminders_enabled as number) === 1,
+			});
 
 			if (intakes.length === 0) continue;
 

--- a/backend/src/routes/doses.ts
+++ b/backend/src/routes/doses.ts
@@ -24,9 +24,9 @@ import {
 } from "../utils/openapi-route-standards.js";
 import { tokenFingerprint, valueFingerprint } from "../utils/redaction.js";
 import {
-	parseIntakesJson,
+	normalizeMedicationIntakes,
+	normalizeMedicationSchedule,
 	parseLocalDateTime,
-	parseTakenByJson,
 	personTakesMedication,
 } from "../utils/scheduler-utils.js";
 
@@ -175,13 +175,8 @@ async function loadShareVisibleMedicationMap(
 		.where(and(eq(medications.userId, share.userId), eq(medications.isObsolete, false)));
 
 	const visibleMedications = shareMedications.filter((medication) => {
-		const medTakenBy = parseTakenByJson(medication.takenByJson);
-		const intakes = parseIntakesJson(
-			medication.intakesJson,
-			{ usageJson: medication.usageJson, everyJson: medication.everyJson, startJson: medication.startJson },
-			medication.intakeRemindersEnabled ?? false
-		);
-		return personTakesMedication(share.takenBy, medTakenBy, intakes);
+		const schedule = normalizeMedicationSchedule(medication);
+		return personTakesMedication(share.takenBy, schedule.takenBy, schedule.intakes);
 	});
 
 	return new Map(visibleMedications.map((medication) => [medication.id, medication]));
@@ -206,14 +201,10 @@ function validateShareDoseIdWithMedicationMap(
 		return false;
 	}
 
-	const medTakenBy = parseTakenByJson(medication.takenByJson);
-	const intakes = parseIntakesJson(
-		medication.intakesJson,
-		{ usageJson: medication.usageJson, everyJson: medication.everyJson, startJson: medication.startJson },
-		medication.intakeRemindersEnabled ?? false
-	);
+	const schedule = normalizeMedicationSchedule(medication);
+	const intakes = schedule.intakes;
 
-	if (!personTakesMedication(share.takenBy, medTakenBy, intakes)) {
+	if (!personTakesMedication(share.takenBy, schedule.takenBy, intakes)) {
 		return false;
 	}
 
@@ -222,7 +213,7 @@ function validateShareDoseIdWithMedicationMap(
 		return false;
 	}
 
-	const expectedPersons = intake.takenBy ? [intake.takenBy] : medTakenBy;
+	const expectedPersons = intake.takenBy ? [intake.takenBy] : schedule.takenBy;
 	if (expectedPersons.length === 0) {
 		return parsedDose.personSuffix === null;
 	}
@@ -294,11 +285,7 @@ async function isDoseOutOfStock(options: {
 		return false;
 	}
 
-	const intakes = parseIntakesJson(
-		medication.intakesJson,
-		{ usageJson: medication.usageJson, everyJson: medication.everyJson, startJson: medication.startJson },
-		medication.intakeRemindersEnabled ?? false
-	);
+	const intakes = normalizeMedicationIntakes(medication);
 	const intake = intakes[parsedDose.intakeIndex];
 
 	const scheduledOccurrenceMs = intake

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -27,7 +27,7 @@ import {
 	validationErrorSchema,
 } from "../utils/openapi-route-standards.js";
 import { normalizePackageType, PACKAGE_TYPES } from "../utils/package-profiles.js";
-import { normalizeIntake, parseIntakesJson, parseTakenByJson } from "../utils/scheduler-utils.js";
+import { normalizeIntake, normalizeMedicationIntakes, parseTakenByJson } from "../utils/scheduler-utils.js";
 
 const IMAGES_DIR = resolve(getDataDir(), "images");
 
@@ -357,12 +357,7 @@ function parseIntakesForExport(row: typeof medications.$inferSelect): Array<{
 	remind: boolean;
 	takenBy: string | null;
 }> {
-	// Use the new parseIntakesJson which falls back to legacy format
-	const intakes = parseIntakesJson(
-		row.intakesJson,
-		{ usageJson: row.usageJson, everyJson: row.everyJson, startJson: row.startJson },
-		row.intakeRemindersEnabled ?? false
-	);
+	const intakes = normalizeMedicationIntakes(row);
 
 	return intakes.map((intake) => ({
 		usage: intake.usage,

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -9,7 +9,7 @@ import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
 import { getActiveShareToken } from "../services/share-token-service.js";
 import { getThumbFilename } from "../utils/image-upload.js";
-import { parseIntakesJson, parseTakenByJson, personTakesMedication } from "../utils/scheduler-utils.js";
+import { normalizeMedicationSchedule, personTakesMedication } from "../utils/scheduler-utils.js";
 
 type ImageRoutesOptions = {
 	imagesDir: string;
@@ -130,17 +130,8 @@ async function getAuthorizedSharedMedicationImageFilename(
 			continue;
 		}
 
-		const takenByArray = parseTakenByJson(medication.takenByJson);
-		const intakes = parseIntakesJson(
-			medication.intakesJson,
-			{
-				usageJson: medication.usageJson,
-				everyJson: medication.everyJson,
-				startJson: medication.startJson,
-			},
-			medication.intakeRemindersEnabled ?? false
-		);
-		if (personTakesMedication(share.takenBy, takenByArray, intakes)) {
+		const schedule = normalizeMedicationSchedule(medication);
+		if (personTakesMedication(share.takenBy, schedule.takenBy, schedule.intakes)) {
 			return matchedMedicationFilename;
 		}
 	}

--- a/backend/src/routes/medications.ts
+++ b/backend/src/routes/medications.ts
@@ -516,12 +516,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 				: and(eq(medications.userId, userId), eq(medications.isObsolete, false));
 			const rows = await db.select().from(medications).where(whereClause).orderBy(medications.id);
 			return rows.map((row) => {
-				// Parse intakes from new format, falling back to legacy
-				const intakes = parseIntakesWithUnits(
-					row.intakesJson,
-					{ usageJson: row.usageJson, everyJson: row.everyJson, startJson: row.startJson },
-					row.intakeRemindersEnabled ?? false
-				);
+				const intakes = parseIntakesWithUnits(row);
 
 				return {
 					id: row.id,
@@ -874,12 +869,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 			// ---------------------------------------------------------------
 			// Migrate dose tracking IDs when intake schedule changes
 			// ---------------------------------------------------------------
-			// Parse old intakes from the existing medication row
-			const oldIntakes = parseIntakesWithUnits(
-				existing.intakesJson,
-				{ usageJson: existing.usageJson, everyJson: existing.everyJson, startJson: existing.startJson },
-				existing.intakeRemindersEnabled
-			);
+			const oldIntakes = parseIntakesWithUnits(existing);
 
 			// Get all dose tracking entries for this medication
 			const allDoses = await db

--- a/backend/src/routes/share.ts
+++ b/backend/src/routes/share.ts
@@ -18,8 +18,7 @@ import { isAmountBasedPackageType, normalizePackageType } from "../utils/package
 import { tokenFingerprint } from "../utils/redaction.js";
 import {
 	getAllTakenByForMedication,
-	parseIntakesJson,
-	parseTakenByJson,
+	normalizeMedicationSchedule,
 	personTakesMedication,
 	scopeIntakesToTakenBy,
 } from "../utils/scheduler-utils.js";
@@ -203,35 +202,28 @@ function isShareActive(share: typeof shareTokens.$inferSelect): boolean {
 
 type MedicationRow = typeof medications.$inferSelect;
 
-function parseMedicationIntakes(medication: MedicationRow) {
-	return parseIntakesJson(
-		medication.intakesJson,
-		{ usageJson: medication.usageJson, everyJson: medication.everyJson, startJson: medication.startJson },
-		medication.intakeRemindersEnabled ?? false
-	);
-}
-
 async function getActiveMedicationsForPerson(userId: number, takenBy: string): Promise<MedicationRow[]> {
 	const allMeds = await db
 		.select()
 		.from(medications)
 		.where(and(eq(medications.userId, userId), eq(medications.isObsolete, false)));
 
-	return allMeds.filter((medication) =>
-		personTakesMedication(takenBy, parseTakenByJson(medication.takenByJson), parseMedicationIntakes(medication))
-	);
+	return allMeds.filter((medication) => {
+		const schedule = normalizeMedicationSchedule(medication);
+		return personTakesMedication(takenBy, schedule.takenBy, schedule.intakes);
+	});
 }
 
 function toSharedScheduleMedication(medication: MedicationRow, shareTakenBy: string) {
-	const medicationTakenBy = parseTakenByJson(medication.takenByJson);
-	const intakes = scopeIntakesToTakenBy(parseMedicationIntakes(medication), medicationTakenBy, shareTakenBy);
+	const schedule = normalizeMedicationSchedule(medication);
+	const intakes = scopeIntakesToTakenBy(schedule.intakes, schedule.takenBy, shareTakenBy);
 	const blisters = intakes.map((intake) => ({
 		usage: intake.usage,
 		every: intake.every,
 		start: intake.start,
 	}));
 	const takenBy =
-		shareTakenBy === "all" ? medicationTakenBy : medicationTakenBy.filter((person) => person === shareTakenBy);
+		shareTakenBy === "all" ? schedule.takenBy : schedule.takenBy.filter((person) => person === shareTakenBy);
 	const totalPills = isAmountBasedPackageType(medication.packageType)
 		? medication.looseTablets + (medication.stockAdjustment ?? 0)
 		: medication.packCount * medication.blistersPerPack * medication.pillsPerBlister +
@@ -761,13 +753,8 @@ export async function shareRoutes(app: FastifyInstance) {
 			// Collect all unique person names from medication-level AND intake-level takenBy
 			const allPeople = new Set<string>();
 			for (const med of meds) {
-				const takenByArray = parseTakenByJson(med.takenByJson);
-				const intakes = parseIntakesJson(
-					med.intakesJson,
-					{ usageJson: med.usageJson, everyJson: med.everyJson, startJson: med.startJson },
-					med.intakeRemindersEnabled ?? false
-				);
-				const allForMed = getAllTakenByForMedication(takenByArray, intakes);
+				const schedule = normalizeMedicationSchedule(med);
+				const allForMed = getAllTakenByForMedication(schedule.takenBy, schedule.intakes);
 				for (const person of allForMed) {
 					if (person) allPeople.add(person);
 				}

--- a/backend/src/services/coverage.ts
+++ b/backend/src/services/coverage.ts
@@ -7,8 +7,7 @@ import {
 	getTodayInTimezone,
 	type Intake,
 	normalizeIntakeUsageForStock,
-	parseIntakesJson,
-	parseTakenByJson,
+	normalizeMedicationSchedule,
 	scopeIntakesToTakenBy,
 } from "../utils/scheduler-utils.js";
 
@@ -158,19 +157,9 @@ export function buildSharedMedicationOverview(options: {
 	const todayDate = parseDateOnly(todayDateOnly);
 
 	return medicationRows.map((medication) => {
-		const allIntakes = parseIntakesJson(
-			medication.intakesJson,
-			{
-				usageJson: medication.usageJson,
-				everyJson: medication.everyJson,
-				startJson: medication.startJson,
-			},
-			medication.intakeRemindersEnabled ?? false
-		);
+		const schedule = normalizeMedicationSchedule(medication);
 		const intakes =
-			shareTakenBy == null
-				? allIntakes
-				: scopeIntakesToTakenBy(allIntakes, parseTakenByJson(medication.takenByJson), shareTakenBy);
+			shareTakenBy == null ? schedule.intakes : scopeIntakesToTakenBy(schedule.intakes, schedule.takenBy, shareTakenBy);
 
 		const capacity = computeCapacity(medication);
 		const dailyDoseRate = computeDailyDoseRate(intakes, medication);

--- a/backend/src/services/current-stock.ts
+++ b/backend/src/services/current-stock.ts
@@ -6,9 +6,8 @@ import {
 	getDateOnlyTimestamp,
 	getNextScheduledOccurrenceTime,
 	normalizeIntakeUsageForStock,
-	parseIntakesJson,
+	normalizeMedicationSchedule,
 	parseLocalDateTime,
-	parseTakenByJson,
 } from "../utils/scheduler-utils.js";
 
 type MedicationRow = typeof medications.$inferSelect;
@@ -31,15 +30,8 @@ export function computeMedicationCurrentStock(options: {
 }): number {
 	const { medication, doses, stockCalculationMode, nowMs = Date.now() } = options;
 
-	const intakes = parseIntakesJson(
-		medication.intakesJson,
-		{
-			usageJson: medication.usageJson,
-			everyJson: medication.everyJson,
-			startJson: medication.startJson,
-		},
-		medication.intakeRemindersEnabled ?? false
-	);
+	const schedule = normalizeMedicationSchedule(medication);
+	const intakes = schedule.intakes;
 
 	const baseStock = isAmountBasedPackageType(medication.packageType)
 		? medication.looseTablets + (medication.stockAdjustment ?? 0)
@@ -54,7 +46,7 @@ export function computeMedicationCurrentStock(options: {
 	let consumed = 0;
 
 	if (stockCalculationMode === "automatic") {
-		const medicationTakenBy = parseTakenByJson(medication.takenByJson);
+		const medicationTakenBy = schedule.takenBy;
 
 		intakes.forEach((intake, intakeIndex) => {
 			const usage = normalizeIntakeUsageForStock(intake, medication.medicationForm, medication.packageType);

--- a/backend/src/services/dose-tracking-service.ts
+++ b/backend/src/services/dose-tracking-service.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { parseDoseId } from "../utils/dose-id.js";
-import { parseIntakesJson, parseLocalDateTime } from "../utils/scheduler-utils.js";
+import { normalizeMedicationIntakes, parseLocalDateTime } from "../utils/scheduler-utils.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 
 export type DoseTrackingSource = "manual" | "automatic" | "notification";
@@ -75,11 +75,7 @@ async function isDoseOutOfStock(options: { userId: number; doseId: string }): Pr
 	const [settings] = await db.select().from(userSettings).where(eq(userSettings.userId, options.userId));
 	const stockCalculationMode = (settings?.stockCalculationMode as "automatic" | "manual") ?? "automatic";
 
-	const intakes = parseIntakesJson(
-		medication.intakesJson,
-		{ usageJson: medication.usageJson, everyJson: medication.everyJson, startJson: medication.startJson },
-		medication.intakeRemindersEnabled ?? false
-	);
+	const intakes = normalizeMedicationIntakes(medication);
 	const intake = intakes[parsedDose.intakeIndex];
 
 	const scheduledOccurrenceMs = intake

--- a/backend/src/services/intake-journal-service.ts
+++ b/backend/src/services/intake-journal-service.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, gte, lte } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { doseTracking, intakeJournal, medications } from "../db/schema.js";
 import { type ParsedDoseId, parseDoseId } from "../utils/dose-id.js";
-import { parseIntakesJson, parseLocalDateTime } from "../utils/scheduler-utils.js";
+import { normalizeMedicationIntakes, parseLocalDateTime } from "../utils/scheduler-utils.js";
 import type { DoseTrackingSource } from "./dose-tracking-service.js";
 
 type MedicationTimingRow = {
@@ -67,15 +67,7 @@ function getMedicationDisplayName(medication: Pick<MedicationTimingRow, "id" | "
 }
 
 function resolveScheduledFor(parsedDose: ParsedDoseId, medication: MedicationTimingRow): Date {
-	const intakes = parseIntakesJson(
-		medication.intakesJson,
-		{
-			usageJson: medication.usageJson,
-			everyJson: medication.everyJson,
-			startJson: medication.startJson,
-		},
-		medication.intakeRemindersEnabled
-	);
+	const intakes = normalizeMedicationIntakes(medication);
 	const intake = intakes[parsedDose.intakeIndex];
 	if (!intake) {
 		return new Date(parsedDose.timestampMs);

--- a/backend/src/services/intake-reminder-scheduler.ts
+++ b/backend/src/services/intake-reminder-scheduler.ts
@@ -27,9 +27,8 @@ import {
 	getUpcomingIntakes,
 	type IntakeReminderState,
 	normalizeIntakeUsageForStock,
+	normalizeMedicationSchedule,
 	parseIntakeReminderState,
-	parseIntakesJson,
-	parseTakenByJson,
 	type UpcomingIntake,
 } from "../utils/scheduler-utils.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
@@ -171,16 +170,13 @@ async function autoMarkDueIntakesAsTaken(
 			continue;
 		}
 
-		const intakes = parseIntakesJson(
-			med.intakesJson,
-			{ usageJson: med.usageJson, everyJson: med.everyJson, startJson: med.startJson },
-			med.intakeRemindersEnabled ?? false
-		);
+		const schedule = normalizeMedicationSchedule(med);
+		const intakes = schedule.intakes;
 		if (intakes.length === 0) {
 			continue;
 		}
 
-		const medicationTakenBy = parseTakenByJson(med.takenByJson);
+		const medicationTakenBy = schedule.takenBy;
 		const medDisplayName = getMedicationDisplayName({ id: med.id, name: med.name, genericName: med.genericName });
 		let remainingStock = computeMedicationCurrentStock({
 			medication: med,
@@ -500,13 +496,10 @@ export async function checkAndSendIntakeRemindersForUser(
 	// Intake-level reminders are the single source of truth.
 	const reminderEntries = activeRows
 		.map((med) => {
-			const intakes = parseIntakesJson(
-				med.intakesJson,
-				{ usageJson: med.usageJson, everyJson: med.everyJson, startJson: med.startJson },
-				false
-			);
+			const schedule = normalizeMedicationSchedule({ ...med, intakeRemindersEnabled: false });
+			const intakes = schedule.intakes;
 			const intakesWithReminders = intakes.filter((intake) => intake.intakeRemindersEnabled === true);
-			return { med, intakes, intakesWithReminders };
+			return { med, intakes, intakesWithReminders, medicationTakenBy: schedule.takenBy };
 		})
 		.filter((entry) => entry.intakesWithReminders.length > 0);
 
@@ -560,9 +553,7 @@ export async function checkAndSendIntakeRemindersForUser(
 	todayEnd.setHours(23, 59, 59, 999);
 
 	// Find intakes: upcoming ones in reminder window + past ones for repeat reminders
-	for (const { med, intakes, intakesWithReminders } of reminderEntriesEligible) {
-		// Medication-level takenBy (for fallback/display purposes)
-		const medicationTakenBy = parseTakenByJson(med.takenByJson);
+	for (const { med, intakes, intakesWithReminders, medicationTakenBy } of reminderEntriesEligible) {
 		const medDisplayName = getMedicationDisplayName({ id: med.id, name: med.name, genericName: med.genericName });
 
 		// Process each intake separately to track blisterIndex

--- a/backend/src/services/medications-service.ts
+++ b/backend/src/services/medications-service.ts
@@ -1,4 +1,9 @@
-import { forEachScheduledOccurrenceInRange, type Intake, parseIntakesJson } from "../utils/scheduler-utils.js";
+import {
+	forEachScheduledOccurrenceInRange,
+	type Intake,
+	type MedicationScheduleJsonFields,
+	normalizeMedicationIntakes,
+} from "../utils/scheduler-utils.js";
 
 export { normalizeDateTime } from "../utils/date-time.js";
 
@@ -21,13 +26,9 @@ export function parseRawIntakeUnits(intakesJson: string | null | undefined): Arr
 	}
 }
 
-export function parseIntakesWithUnits(
-	intakesJson: string | null | undefined,
-	legacyRow: { usageJson: string; everyJson: string; startJson: string },
-	medicationIntakeRemindersEnabled?: boolean
-): Intake[] {
-	const intakes = parseIntakesJson(intakesJson, legacyRow, medicationIntakeRemindersEnabled);
-	const rawUnits = parseRawIntakeUnits(intakesJson);
+export function parseIntakesWithUnits(row: MedicationScheduleJsonFields): Intake[] {
+	const intakes = normalizeMedicationIntakes(row);
+	const rawUnits = parseRawIntakeUnits(row.intakesJson);
 	if (rawUnits.length === 0) return intakes;
 
 	return intakes.map((intake, idx) => ({

--- a/backend/src/services/planner-demand.ts
+++ b/backend/src/services/planner-demand.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { isAmountBasedPackageType, isTubePackageType, normalizePackageType } from "../utils/package-profiles.js";
-import { normalizeIntakeUsageForStock, parseTakenByJson } from "../utils/scheduler-utils.js";
+import { normalizeIntakeUsageForStock, normalizeMedicationSchedule } from "../utils/scheduler-utils.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 import { calculateUsageInRange, parseIntakesWithUnits } from "./medications-service.js";
 
@@ -55,13 +55,9 @@ export async function calculatePlannerDemandRows(options: PlannerDemandOptions):
 		.where(and(eq(doseTracking.userId, userId), eq(doseTracking.dismissed, false)));
 
 	return rows.map((row) => {
-		const intakes = parseIntakesWithUnits(
-			row.intakesJson,
-			{ usageJson: row.usageJson, everyJson: row.everyJson, startJson: row.startJson },
-			row.intakeRemindersEnabled ?? false
-		);
+		const intakes = parseIntakesWithUnits(row);
 		const medForm = row.medicationForm ?? "tablet";
-		const medicationTakenBy = parseTakenByJson(row.takenByJson);
+		const medicationTakenBy = normalizeMedicationSchedule(row).takenBy;
 		const blisters = intakes.map((intake) => ({
 			usage: normalizeIntakeUsageForStock(intake, medForm, row.packageType),
 			every: intake.every,

--- a/backend/src/services/reminder-scheduler.ts
+++ b/backend/src/services/reminder-scheduler.ts
@@ -30,9 +30,8 @@ import {
 	getTimezone,
 	getTodayInTimezone,
 	normalizeIntakeUsageForStock,
-	parseIntakesJson,
+	normalizeMedicationSchedule,
 	parseLocalDateTime,
-	parseTakenByJson,
 } from "../utils/scheduler-utils.js";
 import {
 	buildPrescriptionReminderPushNotification,
@@ -178,11 +177,8 @@ async function getMedicationsNeedingReminder(
 		// topical usage in grams cannot be mapped reliably to schedule events.
 		if (isTubePackageType(packageType)) continue;
 
-		const intakes = parseIntakesJson(
-			row.intakesJson,
-			{ usageJson: row.usageJson, everyJson: row.everyJson, startJson: row.startJson },
-			row.intakeRemindersEnabled ?? false
-		);
+		const schedule = normalizeMedicationSchedule(row);
+		const intakes = schedule.intakes;
 		const blisters: Blister[] = intakes.map((i) => ({
 			usage: normalizeIntakeUsageForStock(i, row.medicationForm, row.packageType),
 			every: i.every,
@@ -213,7 +209,7 @@ async function getMedicationsNeedingReminder(
 
 				const intake = intakes[blisterIdx];
 				const intakePerson = intake?.takenBy;
-				const fallbackPeople = parseTakenByJson(row.takenByJson);
+				const fallbackPeople = schedule.takenBy;
 				let peopleForThisIntake: Array<string | null>;
 				if (intakePerson) {
 					peopleForThisIntake = [intakePerson];

--- a/backend/src/test/decomposition-services.test.ts
+++ b/backend/src/test/decomposition-services.test.ts
@@ -16,15 +16,13 @@ describe("medications-service decomposition regression", () => {
 
 		expect(parseRawIntakeUnits(intakesJson)).toEqual(["ml", null]);
 
-		const parsed = parseIntakesWithUnits(
+		const parsed = parseIntakesWithUnits({
 			intakesJson,
-			{
-				usageJson: "[1,2]",
-				everyJson: "[1,1]",
-				startJson: '["2026-01-01T08:00:00.000Z","2026-01-01T20:00:00.000Z"]',
-			},
-			false
-		);
+			usageJson: "[1,2]",
+			everyJson: "[1,1]",
+			startJson: '["2026-01-01T08:00:00.000Z","2026-01-01T20:00:00.000Z"]',
+			intakeRemindersEnabled: false,
+		});
 
 		expect(parsed[0]?.intakeUnit).toBe("ml");
 		expect(parsed[1]?.intakeUnit).toBeNull();

--- a/backend/src/test/intake-reminder-scheduler-actions.test.ts
+++ b/backend/src/test/intake-reminder-scheduler-actions.test.ts
@@ -67,16 +67,18 @@ vi.mock("../utils/scheduler-utils.js", async () => {
 		...actual,
 		getEffectiveTimezone: () => Intl.DateTimeFormat().resolvedOptions().timeZone,
 		getDateLocale: () => "en-US",
-		parseTakenByJson: () => [],
-		parseIntakesJson: () => [
-			{
-				usage: 1,
-				every: 1,
-				start: "2026-01-05T10:45:00.000Z",
-				takenBy: null,
-				intakeRemindersEnabled: true,
-			},
-		],
+		normalizeMedicationSchedule: () => ({
+			intakes: [
+				{
+					usage: 1,
+					every: 1,
+					start: "2026-01-05T10:45:00.000Z",
+					takenBy: null,
+					intakeRemindersEnabled: true,
+				},
+			],
+			takenBy: [],
+		}),
 		getTodaysIntakes: () => [candidate],
 		getUpcomingIntakes: () => [candidate],
 	};

--- a/backend/src/test/routes-real.test.ts
+++ b/backend/src/test/routes-real.test.ts
@@ -58,6 +58,7 @@ const { settingsRoutes, sendShoutrrrNotification, loadUserSettings, getAllUserSe
 	"../routes/settings.js"
 );
 const { exportRoutes } = await import("../routes/export.js");
+const { medicationRoutes } = await import("../routes/medications.js");
 const { reportRoutes } = await import("../routes/report.js");
 
 const __filename = fileURLToPath(import.meta.url);
@@ -119,6 +120,7 @@ describe("Real route coverage: settings/export/report", () => {
 		await runAlterMigrations(testClient);
 		app = Fastify({ logger: false, ajv: documentationSchemaAjv });
 		await app.register(settingsRoutes);
+		await app.register(medicationRoutes);
 		await app.register(exportRoutes);
 		await app.register(reportRoutes);
 		await app.ready();
@@ -217,6 +219,56 @@ describe("Real route coverage: settings/export/report", () => {
 				smtpUser: "mailer@example.com",
 				smtpFrom: "MedAssist <mailer@example.com>",
 				hasSmtpPassword: true,
+			})
+		);
+	});
+
+	it("GET /medications renders legacy-only schedule fields through normalized intakes", async () => {
+		await testClient.execute({
+			sql: `INSERT INTO medications (
+				user_id, name, generic_name, taken_by_json, package_type,
+				pack_count, blisters_per_pack, pills_per_blister, loose_tablets,
+				usage_json, every_json, start_json, intakes_json,
+				stock_adjustment, intake_reminders_enabled
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				1,
+				"Legacy schedule med",
+				null,
+				JSON.stringify(["Daniel"]),
+				"blister",
+				1,
+				1,
+				10,
+				0,
+				JSON.stringify([1.5]),
+				JSON.stringify([2]),
+				JSON.stringify(["2026-04-01T08:45:00"]),
+				"[]",
+				0,
+				1,
+			],
+		});
+
+		const response = await app.inject({ method: "GET", url: "/medications" });
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body).toHaveLength(1);
+		expect(body[0]).toEqual(
+			expect.objectContaining({
+				name: "Legacy schedule med",
+				takenBy: ["Daniel"],
+				blisters: [{ usage: 1.5, every: 2, start: "2026-04-01T08:45:00" }],
+			})
+		);
+		expect(body[0].intakes[0]).toEqual(
+			expect.objectContaining({
+				usage: 1.5,
+				every: 2,
+				start: "2026-04-01T08:45:00",
+				takenBy: null,
+				intakeRemindersEnabled: true,
 			})
 		);
 	});

--- a/backend/src/test/services.test.ts
+++ b/backend/src/test/services.test.ts
@@ -23,6 +23,7 @@ import {
 	getUpcomingIntakes,
 	type Intake,
 	normalizeIntake,
+	normalizeMedicationSchedule,
 	parseBlisters,
 	parseIntakeReminderState,
 	parseIntakesJson,
@@ -342,6 +343,85 @@ describe("Scheduler Utils - Intake Schedule Normalization", () => {
 					intakeRemindersEnabled: true,
 				},
 			]);
+		});
+	});
+
+	describe("normalizeMedicationSchedule", () => {
+		it("normalizes legacy-only medication rows", () => {
+			const schedule = normalizeMedicationSchedule({
+				intakesJson: "[]",
+				usageJson: "[1,2]",
+				everyJson: "[1,3]",
+				startJson: '["2026-01-01T08:00:00","2026-01-02T20:00:00"]',
+				takenByJson: '["Daniel"]',
+				intakeRemindersEnabled: true,
+			});
+
+			expect(schedule.takenBy).toEqual(["Daniel"]);
+			expect(schedule.intakes).toHaveLength(2);
+			expect(schedule.intakes[0]).toEqual(
+				expect.objectContaining({
+					usage: 1,
+					every: 1,
+					start: "2026-01-01T08:00:00",
+					takenBy: null,
+					intakeRemindersEnabled: true,
+				})
+			);
+		});
+
+		it("prefers unified intakes over mixed legacy fields", () => {
+			const schedule = normalizeMedicationSchedule({
+				intakesJson: JSON.stringify([
+					{
+						usage: 0.5,
+						every: 2,
+						start: "2026-02-01T09:30:00",
+						takenBy: "Anna",
+						intakeRemindersEnabled: false,
+					},
+				]),
+				usageJson: "[99]",
+				everyJson: "[99]",
+				startJson: '["2030-01-01T00:00:00"]',
+				takenByJson: '["Daniel"]',
+				intakeRemindersEnabled: true,
+			});
+
+			expect(schedule.takenBy).toEqual(["Daniel"]);
+			expect(schedule.intakes).toHaveLength(1);
+			expect(schedule.intakes[0]).toEqual(
+				expect.objectContaining({
+					usage: 0.5,
+					every: 2,
+					start: "2026-02-01T09:30:00",
+					takenBy: "Anna",
+					intakeRemindersEnabled: false,
+				})
+			);
+		});
+
+		it("normalizes intakes-only rows and keeps them schedulable", () => {
+			const schedule = normalizeMedicationSchedule({
+				intakesJson: JSON.stringify([
+					{
+						usage: 1,
+						every: 1,
+						start: "2026-03-01T07:15:00",
+						takenBy: null,
+						intakeRemindersEnabled: true,
+					},
+				]),
+				takenByJson: '["Daniel"]',
+			});
+
+			const nextOccurrence = getNextScheduledOccurrenceTime(
+				schedule.intakes[0],
+				new Date("2026-03-01T00:00:00").getTime()
+			);
+
+			expect(schedule.intakes).toHaveLength(1);
+			expect(nextOccurrence).toBe(new Date("2026-03-01T07:15:00").getTime());
 		});
 	});
 });

--- a/backend/src/utils/scheduler-utils.ts
+++ b/backend/src/utils/scheduler-utils.ts
@@ -40,6 +40,20 @@ export type Intake = {
 	intakeRemindersEnabled: boolean;
 };
 
+export type MedicationScheduleJsonFields = {
+	intakesJson?: string | null;
+	usageJson?: string | null;
+	everyJson?: string | null;
+	startJson?: string | null;
+	takenByJson?: string | null;
+	intakeRemindersEnabled?: boolean | null;
+};
+
+export type NormalizedMedicationSchedule = {
+	intakes: Intake[];
+	takenBy: string[];
+};
+
 const isValidIntakeUnit = (value: unknown): value is "ml" | "tsp" | "tbsp" =>
 	value === "ml" || value === "tsp" || value === "tbsp";
 
@@ -506,12 +520,16 @@ export function getMsUntilNextCheck(reminderHour: number, tz?: string): number {
 
 export { parseLocalDateTime };
 
-/** Parse blister schedules from JSON columns (DEPRECATED: use parseIntakesJson instead) */
-export function parseBlisters(row: { usageJson: string; everyJson: string; startJson: string }): Blister[] {
+/** Parse blister schedules from JSON columns (DEPRECATED: use normalizeMedicationSchedule instead) */
+export function parseBlisters(row: {
+	usageJson: string | null | undefined;
+	everyJson: string | null | undefined;
+	startJson: string | null | undefined;
+}): Blister[] {
 	try {
-		const usage = JSON.parse(row.usageJson) as number[];
-		const every = JSON.parse(row.everyJson) as number[];
-		const start = JSON.parse(row.startJson) as string[];
+		const usage = JSON.parse(row.usageJson ?? "[]") as number[];
+		const every = JSON.parse(row.everyJson ?? "[]") as number[];
+		const start = JSON.parse(row.startJson ?? "[]") as string[];
 		const len = Math.min(usage.length, every.length, start.length);
 		const blisters: Blister[] = [];
 		for (let i = 0; i < len; i++) {
@@ -532,7 +550,11 @@ export function parseBlisters(row: { usageJson: string; everyJson: string; start
  */
 export function parseIntakesJson(
 	intakesJson: string | null | undefined,
-	legacyRow?: { usageJson: string; everyJson: string; startJson: string },
+	legacyRow?: {
+		usageJson: string | null | undefined;
+		everyJson: string | null | undefined;
+		startJson: string | null | undefined;
+	},
 	medicationIntakeRemindersEnabled?: boolean
 ): Intake[] {
 	// Try new format first
@@ -565,6 +587,32 @@ export function parseIntakesJson(
 	}
 
 	return [];
+}
+
+/**
+ * Canonical medication schedule normalization boundary.
+ *
+ * New code should pass medication rows through this function instead of reading
+ * legacy schedule columns directly. The legacy columns stay in the schema until
+ * a migration policy can safely remove them.
+ */
+export function normalizeMedicationSchedule(row: MedicationScheduleJsonFields): NormalizedMedicationSchedule {
+	return {
+		intakes: parseIntakesJson(
+			row.intakesJson,
+			{
+				usageJson: row.usageJson,
+				everyJson: row.everyJson,
+				startJson: row.startJson,
+			},
+			row.intakeRemindersEnabled ?? false
+		),
+		takenBy: parseTakenByJson(row.takenByJson),
+	};
+}
+
+export function normalizeMedicationIntakes(row: MedicationScheduleJsonFields): Intake[] {
+	return normalizeMedicationSchedule(row).intakes;
 }
 
 /**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -72,6 +72,12 @@ services:
       - "127.0.0.1:4000:3000"
 ```
 
+## Medication Schedule Compatibility
+
+Medication rows still retain legacy schedule columns (`usage_json`, `every_json`, `start_json`) next to the unified `intakes_json` column so existing SQLite files and imports keep working without a migration.
+
+Backend code should consume medication schedules through the canonical normalization helpers in `backend/src/utils/scheduler-utils.ts` (`normalizeMedicationSchedule()` or `normalizeMedicationIntakes()`). Direct legacy parsing should stay inside that utility boundary until a reviewed migration policy can remove the old columns safely.
+
 ## Docker Image Pinning
 
 The default `docker-compose.yml` uses readable versioned image tags. Each GitHub release also attaches `docker-compose.pinned.yml` with the same release tags plus immutable image digests for deployments that need stricter reproducibility.


### PR DESCRIPTION
## Summary
- centralize legacy schedule parsing/normalization in scheduler-utils
- switch routes and services to consume normalized intakes instead of manual legacy field bundles
- add regression coverage for legacy-only, intakes-only, and mixed schedule records
- document schedule normalization behavior in CONFIGURATION.md

## Validation
- cd backend && CI=true npm run test:run -- src/test/services.test.ts src/test/decomposition-services.test.ts src/test/routes-real.test.ts
- cd backend && npm run check
- cd backend && npm run build
- cd backend && npm run test:domain
- git diff --check

Closes #740