### PR TITLE
refactor(appcontext): split import/export state into dedicated hook

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -20,11 +20,12 @@ import {
 	type StockThresholds,
 } from "../types";
 import { getSystemLocale, setDefaultFormattingTimezone } from "../utils/formatters";
-import { log } from "../utils/logger";
 import { mergePersonTags } from "../utils/person-tags";
 import { buildSchedulePreview, calculateCoverage, computeMissedPastDoseIds, getStockStatus } from "../utils/schedule";
-import { useFeedback } from "./FeedbackContext";
 import { ShareContextProvider } from "./ShareContext";
+import { type ImportPreview, useImportExport } from "./useImportExport";
+
+export type { ImportPreview } from "./useImportExport";
 
 // =============================================================================
 // Types
@@ -52,34 +53,6 @@ export type GroupedDay = {
 	date: Date;
 	isPast: boolean;
 	meds: DayMedEntry[];
-};
-
-export type ImportPreview = {
-	version: string;
-	exportedAt: string;
-	includeSensitiveData: boolean;
-	incoming: {
-		medications: number;
-		doseHistory: number;
-		refillHistory: number;
-		shareLinks: number;
-		journalEntries: number;
-		imageCount: number;
-		hasSettings: boolean;
-	};
-	current: {
-		medications: number;
-		doseHistory: number;
-		refillHistory: number;
-		shareLinks: number;
-		hasSettings: boolean;
-	};
-	warnings: {
-		replacesExistingData: boolean;
-		regeneratesShareLinks: boolean;
-		containsImages: boolean;
-		containsSensitiveData: boolean;
-	};
 };
 
 export interface AppContextValue {
@@ -320,8 +293,7 @@ function userStorageKey(userId: number | undefined, key: string): string {
 
 export function AppProvider({ children }: { children: React.ReactNode }) {
 	const { i18n } = useTranslation();
-	const { user, authFetch } = useAuth();
-	const { showFeedback } = useFeedback();
+	const { user } = useAuth();
 
 	// Compose hooks
 	const medications = useMedications();
@@ -331,6 +303,12 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 	const collapsed = useCollapsedDays(user?.id);
 	const share = useShare();
 	const refill = useRefill();
+	const handleImportComplete = useCallback(() => {
+		medications.loadMeds();
+		settingsHook.loadSettings();
+		doses.loadTakenDoses();
+	}, [medications.loadMeds, settingsHook.loadSettings, doses.loadTakenDoses]);
+	const importExport = useImportExport({ onImportComplete: handleImportComplete });
 
 	// Schedule UI state
 	const [scheduleDays, setScheduleDays] = useState<number>(30);
@@ -366,20 +344,6 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		}
 	}, [scheduleLightboxImage]);
 
-	// Export/Import state
-	const [exporting, setExporting] = useState(false);
-	const [importing, setImporting] = useState(false);
-	const [showExportModal, setShowExportModal] = useState(false);
-	const [showImportConfirm, setShowImportConfirm] = useState(false);
-	const [pendingImportData, setPendingImportData] = useState<unknown>(null);
-	const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
-	const [importResult, setImportResult] = useState<{
-		medications: number;
-		doses: number;
-		refills: number;
-		shares: number;
-	} | null>(null);
-
 	useEffect(() => {
 		setDefaultFormattingTimezone(settingsHook.settings.timezone || settingsHook.settings.serverTimezone || null);
 	}, [settingsHook.settings.timezone, settingsHook.settings.serverTimezone]);
@@ -414,10 +378,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		setSelectedUser(null);
 		setShowPastDays(false);
 		setShowFutureDays(false);
-		setShowExportModal(false);
-		setShowImportConfirm(false);
-		setPendingImportData(null);
-		setImportResult(null);
+		importExport.resetImportExportState();
 
 		medications.loadMeds();
 		settingsHook.loadSettings();
@@ -433,6 +394,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		intakeJournal.resetJournalState,
 		refill.clearRefillState,
 		share.resetShareDialogState,
+		importExport.resetImportExportState,
 	]);
 
 	// Update selectedMed when meds change (e.g., after refill)
@@ -729,175 +691,6 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		share.openShareDialog(activeMeds);
 	}, [share, activeMeds]);
 
-	// Get t function for translations
-	const { t } = useTranslation();
-
-	// Export data to JSON file
-	const handleExport = useCallback(
-		async (includeImages: boolean = true, includeSensitive: boolean = false) => {
-			setExporting(true);
-			try {
-				const res = await authFetch(`/api/export?includeSensitive=${includeSensitive}&includeImages=${includeImages}`);
-				if (!res.ok) throw new Error("Export failed");
-				const data = await res.json();
-
-				// Create download
-				const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-				const url = URL.createObjectURL(blob);
-				const a = document.createElement("a");
-				const now = new Date();
-				const dateStr = now.toISOString().replace(/[-:]/g, "").replace(/T/, "-").slice(0, 13);
-				const userPart = user?.username ? `-${user.username}` : "";
-				a.href = url;
-				a.download = `${t("exportImport.downloadFilename")}${userPart}-${dateStr}.json`;
-				document.body.appendChild(a);
-				a.click();
-				document.body.removeChild(a);
-				URL.revokeObjectURL(url);
-			} catch (err) {
-				log.error("Export error:", err);
-			}
-			setExporting(false);
-		},
-		[authFetch, t, user?.username]
-	);
-
-	// Handle file selection for import
-	const handleImportFileSelect = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
-			const file = e.target.files?.[0];
-			if (!file) return;
-
-			const reader = new FileReader();
-			reader.onload = async (event) => {
-				try {
-					const data = JSON.parse(event.target?.result as string);
-					if (!data.version || !data.exportedAt) {
-						setPendingImportData(null);
-						setImportPreview(null);
-						showFeedback({ message: t("exportImport.invalidFile"), tone: "error" });
-						return;
-					}
-
-					const res = await authFetch("/api/import/preview", {
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify(data),
-					});
-
-					const text = await res.text();
-					let previewResponse: { error?: string; preview?: ImportPreview } = {};
-					try {
-						previewResponse = text ? JSON.parse(text) : {};
-					} catch {
-						log.error("Import preview response parse error:", text);
-						showFeedback({
-							message: `${t("exportImport.importError")}: Server returned invalid response`,
-							tone: "error",
-						});
-						return;
-					}
-
-					if (!res.ok || !previewResponse.preview) {
-						setPendingImportData(null);
-						setImportPreview(null);
-						if (previewResponse.error === "Invalid import data format") {
-							showFeedback({ message: t("exportImport.invalidFile"), tone: "error" });
-							return;
-						}
-						showFeedback({
-							message: `${t("exportImport.importError")}: ${previewResponse.error || `HTTP ${res.status}`}`,
-							tone: "error",
-						});
-						return;
-					}
-
-					setImportResult(null);
-					setPendingImportData(data);
-					setImportPreview(previewResponse.preview);
-					setShowImportConfirm(true);
-				} catch {
-					setPendingImportData(null);
-					setImportPreview(null);
-					showFeedback({ message: t("exportImport.invalidFile"), tone: "error" });
-				}
-			};
-			reader.readAsText(file);
-			// Reset file input
-			e.target.value = "";
-		},
-		[authFetch, showFeedback, t]
-	);
-
-	// Confirm and execute import
-	const handleImportConfirm = useCallback(async () => {
-		if (!pendingImportData) return;
-		setImporting(true);
-		setShowImportConfirm(false);
-
-		try {
-			const res = await authFetch("/api/import", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(pendingImportData),
-			});
-
-			// Get the response text first to handle non-JSON responses
-			const text = await res.text();
-			let data: {
-				error?: string;
-				message?: string;
-				imported?:
-					| {
-							medications?: number;
-							doseHistory?: number;
-							refillHistory?: number;
-							shareLinks?: number;
-					  }
-					| number;
-			} = {};
-			try {
-				data = text ? JSON.parse(text) : {};
-			} catch {
-				log.error("Import response parse error:", text);
-				showFeedback({
-					message: `${t("exportImport.importError")}: Server returned invalid response`,
-					tone: "error",
-				});
-				return;
-			}
-
-			if (!res.ok) {
-				showFeedback({
-					message: `${t("exportImport.importError")}: ${data.error || `HTTP ${res.status}`}`,
-					tone: "error",
-				});
-				return;
-			}
-
-			// Show success message in UI instead of browser alert
-			const importedCounts = typeof data.imported === "object" && data.imported !== null ? data.imported : null;
-			setImportResult({
-				medications: importedCounts?.medications || 0,
-				doses: importedCounts?.doseHistory || 0,
-				refills: importedCounts?.refillHistory || 0,
-				shares: importedCounts?.shareLinks || 0,
-			});
-
-			// Reload all data
-			medications.loadMeds();
-			settingsHook.loadSettings();
-			doses.loadTakenDoses();
-		} catch (err) {
-			log.error("Import error:", err);
-			showFeedback({ message: t("exportImport.importError"), tone: "error" });
-		} finally {
-			setPendingImportData(null);
-			setImportPreview(null);
-			setImporting(false);
-		}
-	}, [authFetch, pendingImportData, t, medications, settingsHook, doses, showFeedback]);
-
 	// Compute settingsChanged
 	const settingsChanged = useMemo(() => {
 		const settings = settingsHook.settings;
@@ -1132,21 +925,21 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 			closeUserFilter,
 
 			// Export/Import
-			exporting,
-			importing,
-			showExportModal,
-			setShowExportModal,
-			showImportConfirm,
-			setShowImportConfirm,
-			pendingImportData,
-			setPendingImportData,
-			importPreview,
-			setImportPreview,
-			importResult,
-			setImportResult,
-			handleExport,
-			handleImportFileSelect,
-			handleImportConfirm,
+			exporting: importExport.exporting,
+			importing: importExport.importing,
+			showExportModal: importExport.showExportModal,
+			setShowExportModal: importExport.setShowExportModal,
+			showImportConfirm: importExport.showImportConfirm,
+			setShowImportConfirm: importExport.setShowImportConfirm,
+			pendingImportData: importExport.pendingImportData,
+			setPendingImportData: importExport.setPendingImportData,
+			importPreview: importExport.importPreview,
+			setImportPreview: importExport.setImportPreview,
+			importResult: importExport.importResult,
+			setImportResult: importExport.setImportResult,
+			handleExport: importExport.handleExport,
+			handleImportFileSelect: importExport.handleImportFileSelect,
+			handleImportConfirm: importExport.handleImportConfirm,
 			settingsChanged,
 		}),
 		[
@@ -1185,16 +978,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 			openUserFilter,
 			closeUserFilter,
 			openShareDialog,
-			exporting,
-			importing,
-			showExportModal,
-			showImportConfirm,
-			pendingImportData,
-			importPreview,
-			importResult,
-			handleExport,
-			handleImportFileSelect,
-			handleImportConfirm,
+			importExport,
 			settingsChanged,
 		]
 	);

--- a/frontend/src/context/useImportExport.ts
+++ b/frontend/src/context/useImportExport.ts
@@ -1,0 +1,258 @@
+import type React from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "../components/Auth";
+import { log } from "../utils/logger";
+import { useFeedback } from "./FeedbackContext";
+
+export type ImportPreview = {
+	version: string;
+	exportedAt: string;
+	includeSensitiveData: boolean;
+	incoming: {
+		medications: number;
+		doseHistory: number;
+		refillHistory: number;
+		shareLinks: number;
+		journalEntries: number;
+		imageCount: number;
+		hasSettings: boolean;
+	};
+	current: {
+		medications: number;
+		doseHistory: number;
+		refillHistory: number;
+		shareLinks: number;
+		hasSettings: boolean;
+	};
+	warnings: {
+		replacesExistingData: boolean;
+		regeneratesShareLinks: boolean;
+		containsImages: boolean;
+		containsSensitiveData: boolean;
+	};
+};
+
+export type ImportResult = {
+	medications: number;
+	doses: number;
+	refills: number;
+	shares: number;
+};
+
+type UseImportExportOptions = {
+	onImportComplete: () => void;
+};
+
+export function useImportExport({ onImportComplete }: UseImportExportOptions) {
+	const { user, authFetch } = useAuth();
+	const { showFeedback } = useFeedback();
+	const { t } = useTranslation();
+
+	const [exporting, setExporting] = useState(false);
+	const [importing, setImporting] = useState(false);
+	const [showExportModal, setShowExportModal] = useState(false);
+	const [showImportConfirm, setShowImportConfirm] = useState(false);
+	const [pendingImportData, setPendingImportData] = useState<unknown>(null);
+	const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
+	const [importResult, setImportResult] = useState<ImportResult | null>(null);
+
+	const resetImportExportState = useCallback(() => {
+		setShowExportModal(false);
+		setShowImportConfirm(false);
+		setPendingImportData(null);
+		setImportPreview(null);
+		setImportResult(null);
+		setExporting(false);
+		setImporting(false);
+	}, []);
+
+	const handleExport = useCallback(
+		async (includeImages: boolean = true, includeSensitive: boolean = false) => {
+			setExporting(true);
+			try {
+				const res = await authFetch(`/api/export?includeSensitive=${includeSensitive}&includeImages=${includeImages}`);
+				if (!res.ok) throw new Error("Export failed");
+				const data = await res.json();
+
+				const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+				const url = URL.createObjectURL(blob);
+				const a = document.createElement("a");
+				const now = new Date();
+				const dateStr = now.toISOString().replace(/[-:]/g, "").replace(/T/, "-").slice(0, 13);
+				const userPart = user?.username ? `-${user.username}` : "";
+				a.href = url;
+				a.download = `${t("exportImport.downloadFilename")}${userPart}-${dateStr}.json`;
+				document.body.appendChild(a);
+				a.click();
+				document.body.removeChild(a);
+				URL.revokeObjectURL(url);
+			} catch (err) {
+				log.error("Export error:", err);
+			}
+			setExporting(false);
+		},
+		[authFetch, t, user?.username]
+	);
+
+	const handleImportFileSelect = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (!file) return;
+
+			const reader = new FileReader();
+			reader.onload = async (event) => {
+				try {
+					const data = JSON.parse(event.target?.result as string);
+					if (!data.version || !data.exportedAt) {
+						setPendingImportData(null);
+						setImportPreview(null);
+						showFeedback({ message: t("exportImport.invalidFile"), tone: "error" });
+						return;
+					}
+
+					const res = await authFetch("/api/import/preview", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify(data),
+					});
+
+					const text = await res.text();
+					let previewResponse: { error?: string; preview?: ImportPreview } = {};
+					try {
+						previewResponse = text ? JSON.parse(text) : {};
+					} catch {
+						log.error("Import preview response parse error:", text);
+						showFeedback({
+							message: `${t("exportImport.importError")}: Server returned invalid response`,
+							tone: "error",
+						});
+						return;
+					}
+
+					if (!res.ok || !previewResponse.preview) {
+						setPendingImportData(null);
+						setImportPreview(null);
+						if (previewResponse.error === "Invalid import data format") {
+							showFeedback({ message: t("exportImport.invalidFile"), tone: "error" });
+							return;
+						}
+						showFeedback({
+							message: `${t("exportImport.importError")}: ${previewResponse.error || `HTTP ${res.status}`}`,
+							tone: "error",
+						});
+						return;
+					}
+
+					setImportResult(null);
+					setPendingImportData(data);
+					setImportPreview(previewResponse.preview);
+					setShowImportConfirm(true);
+				} catch {
+					setPendingImportData(null);
+					setImportPreview(null);
+					showFeedback({ message: t("exportImport.invalidFile"), tone: "error" });
+				}
+			};
+			reader.readAsText(file);
+			e.target.value = "";
+		},
+		[authFetch, showFeedback, t]
+	);
+
+	const handleImportConfirm = useCallback(async () => {
+		if (!pendingImportData) return;
+		setImporting(true);
+		setShowImportConfirm(false);
+
+		try {
+			const res = await authFetch("/api/import", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(pendingImportData),
+			});
+
+			const text = await res.text();
+			let data: {
+				error?: string;
+				message?: string;
+				imported?:
+					| {
+							medications?: number;
+							doseHistory?: number;
+							refillHistory?: number;
+							shareLinks?: number;
+					  }
+					| number;
+			} = {};
+			try {
+				data = text ? JSON.parse(text) : {};
+			} catch {
+				log.error("Import response parse error:", text);
+				showFeedback({
+					message: `${t("exportImport.importError")}: Server returned invalid response`,
+					tone: "error",
+				});
+				return;
+			}
+
+			if (!res.ok) {
+				showFeedback({
+					message: `${t("exportImport.importError")}: ${data.error || `HTTP ${res.status}`}`,
+					tone: "error",
+				});
+				return;
+			}
+
+			const importedCounts = typeof data.imported === "object" && data.imported !== null ? data.imported : null;
+			setImportResult({
+				medications: importedCounts?.medications || 0,
+				doses: importedCounts?.doseHistory || 0,
+				refills: importedCounts?.refillHistory || 0,
+				shares: importedCounts?.shareLinks || 0,
+			});
+			onImportComplete();
+		} catch (err) {
+			log.error("Import error:", err);
+			showFeedback({ message: t("exportImport.importError"), tone: "error" });
+		} finally {
+			setPendingImportData(null);
+			setImportPreview(null);
+			setImporting(false);
+		}
+	}, [authFetch, onImportComplete, pendingImportData, showFeedback, t]);
+
+	return useMemo(
+		() => ({
+			exporting,
+			importing,
+			showExportModal,
+			setShowExportModal,
+			showImportConfirm,
+			setShowImportConfirm,
+			pendingImportData,
+			setPendingImportData,
+			importPreview,
+			setImportPreview,
+			importResult,
+			setImportResult,
+			handleExport,
+			handleImportFileSelect,
+			handleImportConfirm,
+			resetImportExportState,
+		}),
+		[
+			exporting,
+			importing,
+			showExportModal,
+			showImportConfirm,
+			pendingImportData,
+			importPreview,
+			importResult,
+			handleExport,
+			handleImportFileSelect,
+			handleImportConfirm,
+			resetImportExportState,
+		]
+	);
+}

--- a/frontend/src/test/context/useImportExport.test.tsx
+++ b/frontend/src/test/context/useImportExport.test.tsx
@@ -1,0 +1,182 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useImportExport } from "../../context/useImportExport";
+
+const feedbackMock = vi.hoisted(() => ({ showFeedback: vi.fn() }));
+const authFetchMock = vi.fn();
+
+vi.mock("../../components/Auth", () => ({
+	useAuth: () => ({
+		user: { id: 7, username: "owner" },
+		authFetch: authFetchMock,
+	}),
+}));
+
+vi.mock("../../context/FeedbackContext", () => ({
+	useFeedback: () => ({
+		showFeedback: feedbackMock.showFeedback,
+	}),
+}));
+
+function createHook(onImportComplete = vi.fn()) {
+	return renderHook(() => useImportExport({ onImportComplete }));
+}
+
+function installFileReader(result: string) {
+	class MockFileReader {
+		onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+		readAsText = vi.fn(() => {
+			this.onload?.({ target: { result } } as unknown as ProgressEvent<FileReader>);
+		});
+	}
+	vi.stubGlobal("FileReader", MockFileReader as unknown as typeof FileReader);
+}
+
+describe("useImportExport", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		authFetchMock.mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve({ version: "1", medications: [] }),
+			text: () => Promise.resolve('{"imported":{"medications":1,"doseHistory":2,"refillHistory":3,"shareLinks":4}}'),
+		});
+	});
+
+	it("exports non-sensitive data with images by default", async () => {
+		const click = vi.fn();
+		const appendChild = vi.spyOn(document.body, "appendChild");
+		const removeChild = vi.spyOn(document.body, "removeChild");
+		const createObjectURL = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:export-url");
+		const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+		const originalCreateElement = document.createElement.bind(document);
+		vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+			const element = originalCreateElement(tagName);
+			if (tagName === "a") {
+				Object.defineProperty(element, "click", { value: click, configurable: true });
+			}
+			return element;
+		});
+
+		const { result } = createHook();
+
+		await act(async () => {
+			await result.current.handleExport();
+		});
+
+		expect(authFetchMock).toHaveBeenCalledWith("/api/export?includeSensitive=false&includeImages=true");
+		expect(createObjectURL).toHaveBeenCalled();
+		expect(click).toHaveBeenCalled();
+		expect(appendChild).toHaveBeenCalled();
+		expect(removeChild).toHaveBeenCalled();
+		expect(revokeObjectURL).toHaveBeenCalledWith("blob:export-url");
+	});
+
+	it("requests sensitive export only when explicitly requested", async () => {
+		vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:sensitive-export-url");
+		vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+		const { result } = createHook();
+
+		await act(async () => {
+			await result.current.handleExport(false, true);
+		});
+
+		expect(authFetchMock).toHaveBeenCalledWith("/api/export?includeSensitive=true&includeImages=false");
+	});
+
+	it("loads an import preview and opens the confirmation state", async () => {
+		const payload = { version: "1", exportedAt: "2026-01-01T00:00:00.000Z", medications: [] };
+		const preview = {
+			version: "1",
+			exportedAt: "2026-01-01T00:00:00.000Z",
+			includeSensitiveData: false,
+			incoming: {
+				medications: 1,
+				doseHistory: 0,
+				refillHistory: 0,
+				shareLinks: 0,
+				journalEntries: 0,
+				imageCount: 0,
+				hasSettings: false,
+			},
+			current: {
+				medications: 0,
+				doseHistory: 0,
+				refillHistory: 0,
+				shareLinks: 0,
+				hasSettings: true,
+			},
+			warnings: {
+				replacesExistingData: true,
+				regeneratesShareLinks: false,
+				containsImages: false,
+				containsSensitiveData: false,
+			},
+		};
+		authFetchMock.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(JSON.stringify({ preview })) });
+		installFileReader(JSON.stringify(payload));
+
+		const { result } = createHook();
+		const file = new File(["ok"], "backup.json", { type: "application/json" });
+
+		act(() => {
+			result.current.handleImportFileSelect({
+				target: { files: [file], value: "backup.json" },
+			} as unknown as React.ChangeEvent<HTMLInputElement>);
+		});
+
+		await waitFor(() => {
+			expect(authFetchMock).toHaveBeenCalledWith(
+				"/api/import/preview",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify(payload),
+				})
+			);
+			expect(result.current.showImportConfirm).toBe(true);
+			expect(result.current.pendingImportData).toEqual(payload);
+			expect(result.current.importPreview).toEqual(preview);
+		});
+	});
+
+	it("confirms import, stores result counts, and reloads app data through callback", async () => {
+		const onImportComplete = vi.fn();
+		const { result } = createHook(onImportComplete);
+
+		act(() => {
+			result.current.setPendingImportData({ version: "1", exportedAt: "2026-01-01T00:00:00.000Z" });
+		});
+
+		await act(async () => {
+			await result.current.handleImportConfirm();
+		});
+
+		expect(authFetchMock).toHaveBeenCalledWith(
+			"/api/import",
+			expect.objectContaining({
+				method: "POST",
+			})
+		);
+		expect(onImportComplete).toHaveBeenCalled();
+		expect(result.current.importResult).toEqual({ medications: 1, doses: 2, refills: 3, shares: 4 });
+		expect(result.current.pendingImportData).toBeNull();
+		expect(result.current.importPreview).toBeNull();
+	});
+
+	it("rejects invalid import files without calling preview endpoint", () => {
+		installFileReader("not-json");
+
+		const { result } = createHook();
+		const file = new File(["bad"], "bad.json", { type: "application/json" });
+
+		act(() => {
+			result.current.handleImportFileSelect({
+				target: { files: [file], value: "bad.json" },
+			} as unknown as React.ChangeEvent<HTMLInputElement>);
+		});
+
+		expect(authFetchMock).not.toHaveBeenCalled();
+		expect(feedbackMock.showFeedback).toHaveBeenCalledWith({ message: "exportImport.invalidFile", tone: "error" });
+	});
+});


### PR DESCRIPTION
## Summary
- extract AppContext import/export state and handlers into `useImportExport`
- keep `useAppContext` external behavior compatible while reducing `AppContext.tsx` responsibility
- add targeted frontend tests for import/export hook behavior

## Validation
- cd frontend && CI=true npm run test:run -- src/test/context/useImportExport.test.tsx src/test/context/AppContext.test.tsx
- cd frontend && npm run lint
- cd frontend && npm run check
- cd frontend && npm run build

Closes #744