### PR TITLE
fix: retry Project Intake sync lookup to avoid post-add race

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -225,23 +225,38 @@ jobs:
               return;
             }
 
-            const itemResult = await github.graphql(`
-              query($nodeId: ID!) {
-                node(id: $nodeId) {
-                  ... on Issue {
-                    projectItems(first: 20) {
-                      nodes {
-                        id
-                        project { id }
+            const shouldAlreadyBeTracked = labels.some((label) => qualifyingLabels.includes(label));
+            const fetchProjectItem = async () => {
+              const itemResult = await github.graphql(`
+                query($nodeId: ID!) {
+                  node(id: $nodeId) {
+                    ... on Issue {
+                      projectItems(first: 20) {
+                        nodes {
+                          id
+                          project { id }
+                        }
                       }
                     }
                   }
                 }
-              }
-            `, { nodeId: issueNodeId });
+              `, { nodeId: issueNodeId });
 
-            const projectItem = (itemResult.node?.projectItems?.nodes || []).find((item) => item.project.id === project.id) || null;
-            const shouldAlreadyBeTracked = labels.some((label) => qualifyingLabels.includes(label));
+              return (itemResult.node?.projectItems?.nodes || []).find((item) => item.project.id === project.id) || null;
+            };
+
+            let projectItem = await fetchProjectItem();
+
+            // Project item visibility can lag slightly after intake add calls.
+            if (!projectItem && shouldAlreadyBeTracked) {
+              const attempts = 5;
+              for (let attempt = 1; attempt <= attempts && !projectItem; attempt++) {
+                const delayMs = attempt * 1500;
+                console.log(`Issue #${issueNumber}: waiting for project item propagation (${attempt}/${attempts}, ${delayMs}ms)`);
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+                projectItem = await fetchProjectItem();
+              }
+            }
 
             if (!projectItem) {
               if (shouldAlreadyBeTracked) {


### PR DESCRIPTION
Closes #750

## What changed
- Added a short retry loop in `.github/workflows/add-to-project.yml` (`sync-fields` job) when qualifying labels are present but the project item is not yet visible.
- Kept hard failure semantics after retry exhaustion, so true intake breakages are still surfaced.

## Why
Project item creation is eventually consistent. In high-frequency issue events, the add job can succeed while immediate sync query still cannot see the item yet.

## Safety
- The retry only applies when issue labels require project tracking (`enhancement`, `bug`, `triage`).
- Non-qualifying issues still skip sync immediately.
