### PR TITLE
fix: avoid Project Intake hard-fail on post-retry sync miss

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -260,7 +260,7 @@ jobs:
 
             if (!projectItem) {
               if (shouldAlreadyBeTracked) {
-                core.setFailed(`Issue #${issueNumber} should already be in the project after intake sync, but no matching project item was found.`);
+                core.warning(`Issue #${issueNumber} is labeled for project tracking, but no matching project item was found after retry. Skipping field sync for this event.`);
                 return;
               }
 


### PR DESCRIPTION
Closes #753

## What changed
- In `.github/workflows/add-to-project.yml`, changed the `sync-fields` behavior for qualifying issues when project item lookup still misses after retry:
  - from `core.setFailed(...)`
  - to `core.warning(...)` + skip field sync for that event.

## Why
The issue can already be in the project while transient lookup inconsistencies still happen in this path, causing false-negative red workflow runs and noisy notifications.

## Safety
- Only this narrow post-retry miss condition is downgraded.
- Existing hard failures for malformed project config and required field/option contract violations remain intact.
