### PR TITLE
fix(ui): enforce medication edit validation parity across desktop and mobile

### DIFF
--- a/frontend/src/components/MobileEditModal.tsx
+++ b/frontend/src/components/MobileEditModal.tsx
@@ -7,6 +7,7 @@
 import { Bell, Minus, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MEDICATION_FORM_FIELD_LIMITS } from "../hooks/medicationFormModel";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import { useScrollLock } from "../hooks/useScrollLock";
 import type {
@@ -42,14 +43,6 @@ import { DateInput } from "./DateInput";
 import { FormNumberStepper } from "./FormNumberStepper";
 import type { MedicationEnrichmentViewModel } from "./MedicationEnrichmentSection";
 import { MedicationEnrichmentSection } from "./MedicationEnrichmentSection";
-
-// Field limits for validation
-const FIELD_LIMITS = {
-	name: { max: 100 },
-	genericName: { max: 100 },
-	takenBy: { max: 50 },
-	notes: { max: 1000 },
-};
 
 const MOBILE_TAB_ORDER = ["general", "stock", "schedule", "prescription"] as const;
 type MobileTab = (typeof MOBILE_TAB_ORDER)[number];
@@ -494,7 +487,7 @@ export function MobileEditModal({
 												}}
 												onBlur={() => setShowNameValidation(true)}
 												placeholder={t("form.placeholders.commercial")}
-												maxLength={FIELD_LIMITS.name.max}
+												maxLength={MEDICATION_FORM_FIELD_LIMITS.name.max}
 											/>
 											{!readOnlyMode && showNameValidation && fieldErrors.name && (
 												<span className="field-error">{fieldErrors.name}</span>
@@ -512,7 +505,7 @@ export function MobileEditModal({
 												}}
 												onBlur={() => setShowNameValidation(true)}
 												placeholder={t("form.placeholders.generic")}
-												maxLength={FIELD_LIMITS.genericName.max}
+												maxLength={MEDICATION_FORM_FIELD_LIMITS.genericName.max}
 											/>
 											{!readOnlyMode && showNameValidation && fieldErrors.genericName && (
 												<span className="field-error">{fieldErrors.genericName}</span>
@@ -635,7 +628,7 @@ export function MobileEditModal({
 															? t("form.placeholders.takenBy")
 															: t("form.placeholders.addPerson")
 													}
-													maxLength={FIELD_LIMITS.takenBy.max}
+													maxLength={MEDICATION_FORM_FIELD_LIMITS.takenBy.max}
 													list="takenby-suggestions-modal"
 												/>
 												<datalist id="takenby-suggestions-modal">
@@ -885,7 +878,7 @@ export function MobileEditModal({
 												onChange={(e) => onFormChange({ ...form, notes: e.target.value })}
 												placeholder={t("form.placeholders.notes")}
 												rows={2}
-												maxLength={FIELD_LIMITS.notes.max}
+												maxLength={MEDICATION_FORM_FIELD_LIMITS.notes.max}
 												className="auto-resize"
 												onInput={(e) => {
 													const target = e.target as HTMLTextAreaElement;
@@ -895,9 +888,12 @@ export function MobileEditModal({
 											/>
 											{form.notes.length > 0 && (
 												<span
-													className={`char-count ${form.notes.length > FIELD_LIMITS.notes.max * 0.9 ? "warning" : ""}`}
+													className={`char-count ${form.notes.length > MEDICATION_FORM_FIELD_LIMITS.notes.max * 0.9 ? "warning" : ""}`}
 												>
-													{t("common.validation.tooLong", { current: form.notes.length, max: FIELD_LIMITS.notes.max })}
+													{t("common.validation.tooLong", {
+														current: form.notes.length,
+														max: MEDICATION_FORM_FIELD_LIMITS.notes.max,
+													})}
 												</span>
 											)}
 											{fieldErrors.notes && <span className="field-error">{fieldErrors.notes}</span>}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,5 +1,11 @@
 // Hooks barrel export
 
+export {
+	hasMedicationFormValidationErrors,
+	MEDICATION_FORM_FIELD_LIMITS,
+	validateMedicationForm,
+	validateMedicationFormField,
+} from "./medicationFormModel";
 export type { UseCollapsedDaysReturn } from "./useCollapsedDays";
 export { useCollapsedDays } from "./useCollapsedDays";
 export type { UseDosesReturn } from "./useDoses";

--- a/frontend/src/hooks/medicationFormModel.ts
+++ b/frontend/src/hooks/medicationFormModel.ts
@@ -1,0 +1,48 @@
+import type { FieldErrors, FormState } from "../types";
+import { FIELD_LIMITS } from "../types";
+
+export const MEDICATION_FORM_FIELD_LIMITS = FIELD_LIMITS;
+
+type TranslationFunction = (key: string, options?: Record<string, unknown>) => string;
+
+export function validateMedicationFormField(
+	field: keyof FieldErrors,
+	value: string | string[],
+	t: TranslationFunction
+): string | undefined {
+	if (field === "takenBy") return undefined;
+
+	const limits = MEDICATION_FORM_FIELD_LIMITS[field];
+	const strValue = typeof value === "string" ? value : "";
+	if ("max" in limits && strValue.length > limits.max) {
+		return t("common.validation.maxLength", { max: limits.max, current: strValue.length });
+	}
+
+	return undefined;
+}
+
+export function validateMedicationForm(
+	form: Pick<FormState, "name" | "genericName" | "notes">,
+	t: TranslationFunction
+): FieldErrors {
+	const errors: FieldErrors = {};
+
+	for (const field of ["name", "genericName", "notes"] as const) {
+		const error = validateMedicationFormField(field, form[field], t);
+		if (error) errors[field] = error;
+	}
+
+	const hasName = form.name.trim().length > 0;
+	const hasGenericName = form.genericName.trim().length > 0;
+	if (!hasName && !hasGenericName) {
+		const message = t("common.validation.nameOrGenericRequired");
+		errors.name = errors.name || message;
+		errors.genericName = errors.genericName || message;
+	}
+
+	return errors;
+}
+
+export function hasMedicationFormValidationErrors(errors: FieldErrors): boolean {
+	return Object.values(errors).some((error) => error !== undefined);
+}

--- a/frontend/src/hooks/useMedicationForm.ts
+++ b/frontend/src/hooks/useMedicationForm.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { FieldErrors, FormBlister, FormIntake, FormState, Medication } from "../types";
 import {
-	FIELD_LIMITS,
 	isAmountBasedPackageType,
 	isDiscreteCountPackageType,
 	isLiquidContainerPackageType,
@@ -13,6 +12,12 @@ import {
 import { toDateValue, toTimeValue } from "../utils/formatters";
 import { normalizeWeekdays } from "../utils/intake-schedule";
 import { personTagsMatch } from "../utils/person-tags";
+import {
+	hasMedicationFormValidationErrors,
+	MEDICATION_FORM_FIELD_LIMITS,
+	validateMedicationForm,
+	validateMedicationFormField,
+} from "./medicationFormModel";
 
 export const defaultBlister = (): FormBlister => {
 	const now = new Date();
@@ -131,21 +136,14 @@ export function useMedicationForm(): UseMedicationFormReturn {
 	// Validate form fields
 	const validateField = useCallback(
 		(field: keyof FieldErrors, value: string | string[]): string | undefined => {
-			const limits = FIELD_LIMITS[field];
-			// Skip validation for takenBy array (individual items validated on add)
-			if (field === "takenBy") return undefined;
-			const strValue = typeof value === "string" ? value : "";
-			if ("max" in limits && strValue.length > limits.max) {
-				return t("common.validation.maxLength", { max: limits.max, current: strValue.length });
-			}
-			return undefined;
+			return validateMedicationFormField(field, value, t);
 		},
 		[t]
 	);
 
 	// Check if form has any errors
 	const hasValidationErrors = useMemo(() => {
-		return Object.values(fieldErrors).some((error) => error !== undefined);
+		return hasMedicationFormValidationErrors(fieldErrors);
 	}, [fieldErrors]);
 
 	// Check if form has been modified from original state
@@ -162,21 +160,17 @@ export function useMedicationForm(): UseMedicationFormReturn {
 
 	// Validate all fields when form changes
 	useEffect(() => {
-		const errors: FieldErrors = {};
-		(["name", "genericName", "notes"] as const).forEach((f) => {
-			const error = validateField(f, form[f]);
-			if (error) errors[f] = error;
-		});
-		// Cross-field validation: at least one of name or genericName is required
-		const hasName = form.name && form.name.trim().length > 0;
-		const hasGenericName = form.genericName && form.genericName.trim().length > 0;
-		if (!hasName && !hasGenericName) {
-			const msg = t("common.validation.nameOrGenericRequired");
-			errors.name = errors.name || msg;
-			errors.genericName = errors.genericName || msg;
-		}
-		setFieldErrors(errors);
-	}, [form.name, form.genericName, form.notes, validateField, form, t]);
+		setFieldErrors(
+			validateMedicationForm(
+				{
+					name: form.name,
+					genericName: form.genericName,
+					notes: form.notes,
+				},
+				t
+			)
+		);
+	}, [form.name, form.genericName, form.notes, t]);
 
 	const setBlisterValue = useCallback((idx: number, field: keyof FormBlister, value: string) => {
 		setForm((prev) => {
@@ -490,7 +484,7 @@ export function useMedicationForm(): UseMedicationFormReturn {
 		(name: string) => {
 			const trimmed = name.trim();
 			const alreadyExists = form.takenBy.some((person) => personTagsMatch(person, trimmed));
-			if (trimmed && trimmed.length <= FIELD_LIMITS.takenBy.max && !alreadyExists) {
+			if (trimmed && trimmed.length <= MEDICATION_FORM_FIELD_LIMITS.takenBy.max && !alreadyExists) {
 				setForm((prev) => ({ ...prev, takenBy: [...prev.takenBy, trimmed] }));
 			}
 			setTakenByInput("");

--- a/frontend/src/pages/MedicationsPage.tsx
+++ b/frontend/src/pages/MedicationsPage.tsx
@@ -21,6 +21,7 @@ import {
 	useModalHistory,
 	useUnsavedChangesWarning,
 } from "../hooks";
+import { MEDICATION_FORM_FIELD_LIMITS } from "../hooks/medicationFormModel";
 import type {
 	DoseUnit,
 	FormState,
@@ -35,7 +36,6 @@ import type {
 import {
 	allowsPillFormSelection,
 	DOSE_UNITS,
-	FIELD_LIMITS,
 	getMedDisplayName,
 	getPackageProfile,
 	getPackageSize,
@@ -1577,7 +1577,7 @@ export function MedicationsPage() {
 									}}
 									onBlur={() => setShowNameValidation(true)}
 									placeholder={t("form.placeholders.commercial")}
-									maxLength={FIELD_LIMITS.name.max}
+									maxLength={MEDICATION_FORM_FIELD_LIMITS.name.max}
 								/>
 								{!readOnlyView && showNameValidation && fieldErrors.name && (
 									<span className="field-error">{fieldErrors.name}</span>
@@ -1593,7 +1593,7 @@ export function MedicationsPage() {
 									}}
 									onBlur={() => setShowNameValidation(true)}
 									placeholder={t("form.placeholders.generic")}
-									maxLength={FIELD_LIMITS.genericName.max}
+									maxLength={MEDICATION_FORM_FIELD_LIMITS.genericName.max}
 								/>
 								{!readOnlyView && showNameValidation && fieldErrors.genericName && (
 									<span className="field-error">{fieldErrors.genericName}</span>
@@ -1716,7 +1716,7 @@ export function MedicationsPage() {
 												placeholder={
 													form.takenBy.length === 0 ? t("form.placeholders.takenBy") : t("form.placeholders.addPerson")
 												}
-												maxLength={FIELD_LIMITS.takenBy.max}
+												maxLength={MEDICATION_FORM_FIELD_LIMITS.takenBy.max}
 												list="takenby-suggestions"
 											/>
 											<datalist id="takenby-suggestions">
@@ -1986,7 +1986,7 @@ export function MedicationsPage() {
 									onChange={(e) => handleValueChange("notes", e.target.value)}
 									placeholder={t("form.placeholders.notes")}
 									rows={2}
-									maxLength={FIELD_LIMITS.notes.max}
+									maxLength={MEDICATION_FORM_FIELD_LIMITS.notes.max}
 									className="auto-resize"
 									onInput={(e) => {
 										const t = e.target as HTMLTextAreaElement;
@@ -1995,8 +1995,13 @@ export function MedicationsPage() {
 									}}
 								/>
 								{form.notes.length > 0 && (
-									<span className={`char-count ${form.notes.length > FIELD_LIMITS.notes.max * 0.9 ? "warning" : ""}`}>
-										{t("common.validation.tooLong", { current: form.notes.length, max: FIELD_LIMITS.notes.max })}
+									<span
+										className={`char-count ${form.notes.length > MEDICATION_FORM_FIELD_LIMITS.notes.max * 0.9 ? "warning" : ""}`}
+									>
+										{t("common.validation.tooLong", {
+											current: form.notes.length,
+											max: MEDICATION_FORM_FIELD_LIMITS.notes.max,
+										})}
 									</span>
 								)}
 								{fieldErrors.notes && <span className="field-error">{fieldErrors.notes}</span>}

--- a/frontend/src/test/components/MobileEditModal.test.tsx
+++ b/frontend/src/test/components/MobileEditModal.test.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MedicationEnrichmentViewModel } from "../../components/MedicationEnrichmentSection";
 import { MobileEditModal } from "../../components/MobileEditModal";
+import { MEDICATION_FORM_FIELD_LIMITS } from "../../hooks/medicationFormModel";
 import type { FormState, WeekdayCode } from "../../types";
 
 const defaultForm: FormState = {
@@ -500,10 +501,46 @@ describe("MobileEditModal with form errors", () => {
 		expect(screen.getByText("Name is required")).toBeInTheDocument();
 	});
 
+	it("shows the shared required-name errors when validation is active", () => {
+		render(
+			<MobileEditModal
+				{...defaultProps}
+				hasValidationErrors={true}
+				fieldErrors={{
+					name: "common.validation.nameOrGenericRequired",
+					genericName: "common.validation.nameOrGenericRequired",
+				}}
+			/>
+		);
+
+		expect(screen.getAllByText("common.validation.nameOrGenericRequired")).toHaveLength(2);
+	});
+
 	it("shows notes error when present", () => {
 		render(<MobileEditModal {...defaultProps} fieldErrors={{ notes: "Notes too long" }} />);
 
 		expect(screen.getByText("Notes too long")).toBeInTheDocument();
+	});
+
+	it("uses shared max-length limits for mobile edit fields", () => {
+		render(<MobileEditModal {...defaultProps} />);
+
+		expect(screen.getByPlaceholderText("form.placeholders.commercial")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.name.max)
+		);
+		expect(screen.getByPlaceholderText("form.placeholders.generic")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.genericName.max)
+		);
+		expect(screen.getByPlaceholderText("form.placeholders.takenBy")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.takenBy.max)
+		);
+		expect(screen.getByPlaceholderText("form.placeholders.notes")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.notes.max)
+		);
 	});
 });
 

--- a/frontend/src/test/hooks/medicationFormModel.test.ts
+++ b/frontend/src/test/hooks/medicationFormModel.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+	hasMedicationFormValidationErrors,
+	MEDICATION_FORM_FIELD_LIMITS,
+	validateMedicationForm,
+	validateMedicationFormField,
+} from "../../hooks/medicationFormModel";
+import { FIELD_LIMITS } from "../../types";
+
+const t = (key: string) => key;
+
+describe("medicationFormModel", () => {
+	it("exposes the shared medication field limits", () => {
+		expect(MEDICATION_FORM_FIELD_LIMITS).toBe(FIELD_LIMITS);
+		expect(MEDICATION_FORM_FIELD_LIMITS.takenBy.max).toBe(100);
+		expect(MEDICATION_FORM_FIELD_LIMITS.notes.max).toBe(2000);
+	});
+
+	it("requires either commercial or generic name", () => {
+		const errors = validateMedicationForm({ name: " ", genericName: "", notes: "" }, t);
+
+		expect(errors.name).toBe("common.validation.nameOrGenericRequired");
+		expect(errors.genericName).toBe("common.validation.nameOrGenericRequired");
+		expect(hasMedicationFormValidationErrors(errors)).toBe(true);
+	});
+
+	it("accepts a generic-only medication name", () => {
+		const errors = validateMedicationForm({ name: "", genericName: "Ibuprofen", notes: "" }, t);
+
+		expect(errors.name).toBeUndefined();
+		expect(errors.genericName).toBeUndefined();
+		expect(hasMedicationFormValidationErrors(errors)).toBe(false);
+	});
+
+	it("applies shared max-length validation to edge-case fields", () => {
+		expect(validateMedicationFormField("name", "a".repeat(MEDICATION_FORM_FIELD_LIMITS.name.max + 1), t)).toBe(
+			"common.validation.maxLength"
+		);
+		expect(validateMedicationFormField("notes", "a".repeat(MEDICATION_FORM_FIELD_LIMITS.notes.max + 1), t)).toBe(
+			"common.validation.maxLength"
+		);
+		expect(validateMedicationFormField("takenBy", ["Alice"], t)).toBeUndefined();
+	});
+});

--- a/frontend/src/test/pages/MedicationsPage.test.tsx
+++ b/frontend/src/test/pages/MedicationsPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MEDICATION_FORM_FIELD_LIMITS } from "../../hooks/medicationFormModel";
 import { MedicationsPage } from "../../pages/MedicationsPage";
 
 const authFetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init));
@@ -323,6 +324,48 @@ describe("MedicationsPage", () => {
 		openNewMedicationForm();
 		expect(screen.getByText(/form\.commercialName/i)).toBeInTheDocument();
 		expect(screen.getByText(/form\.genericName/i)).toBeInTheDocument();
+	});
+
+	it("shows the shared required-name errors on desktop edit submit", async () => {
+		mockFormHookValue = createMockFormHook({
+			hasValidationErrors: true,
+			fieldErrors: {
+				name: "common.validation.nameOrGenericRequired",
+				genericName: "common.validation.nameOrGenericRequired",
+			},
+		});
+
+		renderPage();
+		openNewMedicationForm();
+		fireEvent.submit(document.querySelector("form.form-grid") as HTMLFormElement);
+
+		await waitFor(() => {
+			expect(screen.getAllByText("common.validation.nameOrGenericRequired")).toHaveLength(2);
+		});
+	});
+
+	it("uses shared max-length limits for desktop edit fields", () => {
+		renderPage();
+		openNewMedicationForm();
+
+		expect(screen.getByPlaceholderText("form.placeholders.commercial")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.name.max)
+		);
+		expect(screen.getByPlaceholderText("form.placeholders.generic")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.genericName.max)
+		);
+		expect(screen.getByPlaceholderText("form.placeholders.takenBy")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.takenBy.max)
+		);
+
+		fireEvent.click(screen.getByRole("tab", { name: "form.sections.stock" }));
+		expect(screen.getByPlaceholderText("form.placeholders.notes")).toHaveAttribute(
+			"maxlength",
+			String(MEDICATION_FORM_FIELD_LIMITS.notes.max)
+		);
 	});
 
 	it("renders medication start and end dates as one desktop date pair group", () => {


### PR DESCRIPTION
Closes #745

## Summary
Centralized medication edit form validation and field limits in `medicationFormModel`. Desktop and mobile edit surfaces now use the same required-name validation and max-length limits. Mobile drift was removed so `takenBy` and `notes` now match shared limits.

## Files changed
- frontend/src/hooks/medicationFormModel.ts
- frontend/src/hooks/useMedicationForm.ts
- frontend/src/hooks/index.ts
- frontend/src/pages/MedicationsPage.tsx
- frontend/src/components/MobileEditModal.tsx
- frontend/src/test/hooks/medicationFormModel.test.ts
- frontend/src/test/components/MobileEditModal.test.tsx
- frontend/src/test/pages/MedicationsPage.test.tsx

## Tests added/updated
- Shared medication form model unit tests
- Desktop required-name + max-length parity tests
- Mobile required-name + max-length parity tests

## Commands run
- `cd frontend && npm run check` (passed)
- `cd frontend && npm test -- --run` (passed: 55 files, 973 tests)
- `cd frontend && npm run build` (passed)

## Security impact
No auth/security behavior changed. This reduces UI validation drift for medication/person data entry.

## Data migration impact
None.

## Remaining risk
JSDOM still logs existing `window.scrollTo()` not-implemented warnings during tests, but tests pass. No UI visual E2E was run because this was a focused validation/refactor package.