### PR TITLE
chore(project): add notice when intake field sync is skipped

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -261,6 +261,7 @@ jobs:
             if (!projectItem) {
               if (shouldAlreadyBeTracked) {
                 core.warning(`Issue #${issueNumber} is labeled for project tracking, but no matching project item was found after retry. Skipping field sync for this event.`);
+                core.notice(`Issue #${issueNumber}: project field synchronization skipped for this event; a later issue event can apply field sync once item lookup resolves.`);
                 return;
               }
 


### PR DESCRIPTION
Closes #757

## Summary
Add an explicit notice message in `Project Intake` when field sync is skipped after retry due to unresolved project item lookup.

## Why
This improves operational clarity by making non-fatal skip events obvious in workflow logs.

## Scope
- `.github/workflows/add-to-project.yml` only

## Validation
- `npx --yes actionlint .github/workflows/add-to-project.yml` (passed)
