### PR TITLE
refactor(frontend): centralize modal history handling

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -11,6 +11,7 @@ import {
 	useSettings,
 	useShare,
 } from "../hooks";
+import { useModalHistory } from "../hooks/useModalHistory";
 import {
 	type Coverage,
 	type FormState,
@@ -318,31 +319,43 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 	// Modal state
 	const [selectedMed, setSelectedMed] = useState<Medication | null>(null);
 	const selectedMedIdRef = useRef<number | null>(null);
-	const medDetailOpenedAtRef = useRef(0);
-	const medDetailCloseInFlightRef = useRef(false);
 	useEffect(() => {
 		selectedMedIdRef.current = selectedMed?.id ?? null;
-		if (!selectedMed) {
-			medDetailCloseInFlightRef.current = false;
-		}
 	}, [selectedMed]);
 	const [showImageLightbox, setShowImageLightbox] = useState(false);
-	const imageLightboxOpenedAtRef = useRef(0);
-	const imageLightboxCloseInFlightRef = useRef(false);
 	const [scheduleLightboxImage, setScheduleLightboxImage] = useState<string | null>(null);
-	const scheduleLightboxOpenedAtRef = useRef(0);
-	const scheduleLightboxCloseInFlightRef = useRef(false);
 	const [selectedUser, setSelectedUser] = useState<string | null>(null);
-	useEffect(() => {
-		if (!showImageLightbox) {
-			imageLightboxCloseInFlightRef.current = false;
-		}
-	}, [showImageLightbox]);
-	useEffect(() => {
-		if (!scheduleLightboxImage) {
-			scheduleLightboxCloseInFlightRef.current = false;
-		}
-	}, [scheduleLightboxImage]);
+	const dismissMedDetail = useCallback(() => {
+		selectedMedIdRef.current = null;
+		setSelectedMed(null);
+	}, []);
+	const dismissImageLightbox = useCallback(() => {
+		setShowImageLightbox(false);
+	}, []);
+	const dismissScheduleLightbox = useCallback(() => {
+		setScheduleLightboxImage(null);
+	}, []);
+	const dismissUserFilter = useCallback(() => {
+		setSelectedUser(null);
+	}, []);
+	const medDetailHistoryState = useMemo(() => (selectedMed ? { medId: selectedMed.id } : undefined), [selectedMed]);
+	const userFilterHistoryState = useMemo(() => (selectedUser ? { person: selectedUser } : undefined), [selectedUser]);
+	const { closeModal: closeMedDetail } = useModalHistory(Boolean(selectedMed), "medDetail", dismissMedDetail, {
+		state: medDetailHistoryState,
+		minOpenMs: 320,
+	});
+	const { closeModal: closeImageLightbox } = useModalHistory(showImageLightbox, "imageLightbox", dismissImageLightbox, {
+		minOpenMs: 320,
+	});
+	const { closeModal: closeScheduleLightbox } = useModalHistory(
+		Boolean(scheduleLightboxImage),
+		"scheduleLightbox",
+		dismissScheduleLightbox,
+		{ minOpenMs: 320 }
+	);
+	const { closeModal: closeUserFilter } = useModalHistory(Boolean(selectedUser), "userFilter", dismissUserFilter, {
+		state: userFilterHistoryState,
+	});
 
 	useEffect(() => {
 		setDefaultFormattingTimezone(settingsHook.settings.timezone || settingsHook.settings.serverTimezone || null);
@@ -596,95 +609,33 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		(med: Medication) => {
 			if (selectedMedIdRef.current === med.id) return;
 			selectedMedIdRef.current = med.id;
-			medDetailOpenedAtRef.current = Date.now();
-			medDetailCloseInFlightRef.current = false;
 			setSelectedMed(med);
 			refill.setRefillHistoryExpanded(false);
 			refill.loadRefillHistory(med.id);
-			window.history.pushState({ modal: "medDetail", medId: med.id }, "");
 		},
 		[refill]
 	);
 
-	const closeMedDetail = useCallback(() => {
-		if (!selectedMed || medDetailCloseInFlightRef.current) return;
-
-		// Ignore ultra-fast close requests caused by rapid double-click races
-		if (Date.now() - medDetailOpenedAtRef.current < 320) return;
-
-		const currentState = window.history.state as { modal?: string } | null;
-		if (currentState?.modal !== "medDetail") {
-			// State already popped by another event: close locally without another back step.
-			selectedMedIdRef.current = null;
-			setSelectedMed(null);
-			return;
-		}
-
-		medDetailCloseInFlightRef.current = true;
-		window.history.back();
-	}, [selectedMed]);
-
 	const openImageLightbox = useCallback(() => {
 		if (showImageLightbox) return;
-		imageLightboxOpenedAtRef.current = Date.now();
-		imageLightboxCloseInFlightRef.current = false;
 		setShowImageLightbox(true);
-		window.history.pushState({ modal: "imageLightbox" }, "");
-	}, [showImageLightbox]);
-
-	const closeImageLightbox = useCallback(() => {
-		if (!showImageLightbox || imageLightboxCloseInFlightRef.current) return;
-		if (Date.now() - imageLightboxOpenedAtRef.current < 320) return;
-
-		const currentState = window.history.state as { modal?: string } | null;
-		if (currentState?.modal !== "imageLightbox") {
-			setShowImageLightbox(false);
-			return;
-		}
-
-		imageLightboxCloseInFlightRef.current = true;
-		window.history.back();
 	}, [showImageLightbox]);
 
 	const openScheduleLightbox = useCallback(
 		(imageUrl: string) => {
 			if (scheduleLightboxImage) return;
-			scheduleLightboxOpenedAtRef.current = Date.now();
-			scheduleLightboxCloseInFlightRef.current = false;
 			setScheduleLightboxImage(imageUrl);
-			window.history.pushState({ modal: "scheduleLightbox" }, "");
 		},
 		[scheduleLightboxImage]
 	);
-
-	const closeScheduleLightbox = useCallback(() => {
-		if (!scheduleLightboxImage || scheduleLightboxCloseInFlightRef.current) return;
-		if (Date.now() - scheduleLightboxOpenedAtRef.current < 320) return;
-
-		const currentState = window.history.state as { modal?: string } | null;
-		if (currentState?.modal !== "scheduleLightbox") {
-			setScheduleLightboxImage(null);
-			return;
-		}
-
-		scheduleLightboxCloseInFlightRef.current = true;
-		window.history.back();
-	}, [scheduleLightboxImage]);
 
 	const openUserFilter = useCallback(
 		(person: string) => {
 			if (selectedUser === person) return;
 			setSelectedUser(person);
-			window.history.pushState({ modal: "userFilter", person }, "");
 		},
 		[selectedUser]
 	);
-
-	const closeUserFilter = useCallback(() => {
-		if (selectedUser) {
-			window.history.back();
-		}
-	}, [selectedUser]);
 
 	// Wrapper to pass meds to openShareDialog
 	const openShareDialog = useCallback(() => {

--- a/frontend/src/hooks/useModalHistory.ts
+++ b/frontend/src/hooks/useModalHistory.ts
@@ -1,33 +1,89 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+
+type ModalHistoryOptions = {
+	state?: Record<string, unknown>;
+	minOpenMs?: number;
+};
+
+type ModalHistoryController = {
+	closeModal: () => void;
+};
+
+const modalStack: symbol[] = [];
+
+function removeFromStack(id: symbol) {
+	const index = modalStack.lastIndexOf(id);
+	if (index >= 0) {
+		modalStack.splice(index, 1);
+	}
+}
+
+function isTopModal(id: symbol) {
+	return modalStack[modalStack.length - 1] === id;
+}
 
 /**
  * Push a history entry when a modal opens so the browser back button closes it.
  * On popstate (back), calls `onClose` to dismiss the modal.
  */
-export function useModalHistory(isOpen: boolean, modalKey: string, onClose: () => void) {
+export function useModalHistory(
+	isOpen: boolean,
+	modalKey: string,
+	onClose: () => void,
+	options: ModalHistoryOptions = {}
+): ModalHistoryController {
 	const pushedRef = useRef(false);
+	const openedAtRef = useRef(0);
+	const idRef = useRef(Symbol(modalKey));
+	const onCloseRef = useRef(onClose);
+	const stateRef = useRef(options.state);
+
+	onCloseRef.current = onClose;
+	stateRef.current = options.state;
 
 	useEffect(() => {
 		if (isOpen) {
-			window.history.pushState({ modal: modalKey }, "");
-			pushedRef.current = true;
-		} else if (pushedRef.current) {
-			pushedRef.current = false;
+			if (!pushedRef.current) {
+				window.history.pushState({ modal: modalKey, ...stateRef.current }, "");
+				pushedRef.current = true;
+				openedAtRef.current = Date.now();
+				modalStack.push(idRef.current);
+			}
+
+			return () => {
+				removeFromStack(idRef.current);
+			};
 		}
+
+		pushedRef.current = false;
+		removeFromStack(idRef.current);
 	}, [isOpen, modalKey]);
+
+	const closeModal = useCallback(() => {
+		if (!isOpen || !pushedRef.current) return;
+		if (options.minOpenMs && Date.now() - openedAtRef.current < options.minOpenMs) return;
+
+		pushedRef.current = false;
+		removeFromStack(idRef.current);
+		onCloseRef.current();
+		window.history.back();
+	}, [isOpen, options.minOpenMs]);
 
 	useEffect(() => {
 		if (!isOpen) return;
 
 		const handlePopState = (event: PopStateEvent) => {
-			if (pushedRef.current) {
-				pushedRef.current = false;
-				onClose();
-				event.stopImmediatePropagation();
-			}
+			if (!pushedRef.current || !isTopModal(idRef.current)) return;
+
+			pushedRef.current = false;
+			removeFromStack(idRef.current);
+			onCloseRef.current();
+			event.stopImmediatePropagation();
 		};
 
 		window.addEventListener("popstate", handlePopState, { capture: true });
 		return () => window.removeEventListener("popstate", handlePopState, true);
-	}, [isOpen, onClose]);
+	}, [isOpen]);
+
+	return { closeModal };
 }

--- a/frontend/src/test/context/AppContext.test.tsx
+++ b/frontend/src/test/context/AppContext.test.tsx
@@ -415,6 +415,39 @@ describe("useAppContext", () => {
 		expect(window.history.back).toHaveBeenCalled();
 	});
 
+	it("closes an AppContext modal when browser back pops the modal history entry", () => {
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		act(() => {
+			result.current.openImageLightbox();
+		});
+
+		expect(result.current.showImageLightbox).toBe(true);
+
+		act(() => {
+			window.dispatchEvent(new PopStateEvent("popstate"));
+		});
+
+		expect(result.current.showImageLightbox).toBe(false);
+	});
+
+	it("uses modal history for direct AppContext modal close", () => {
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		act(() => {
+			result.current.openUserFilter("Max");
+		});
+
+		expect(result.current.selectedUser).toBe("Max");
+
+		act(() => {
+			result.current.closeUserFilter();
+		});
+
+		expect(result.current.selectedUser).toBeNull();
+		expect(window.history.back).toHaveBeenCalledTimes(1);
+	});
+
 	it("imports data and triggers reload plus import result state", async () => {
 		const { result } = renderHook(() => useAppContext(), { wrapper });
 

--- a/frontend/src/test/hooks/useModalHistory.test.ts
+++ b/frontend/src/test/hooks/useModalHistory.test.ts
@@ -28,6 +28,34 @@ describe("useModalHistory", () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
+	it("includes modal-specific state in the pushed history entry", () => {
+		const onClose = vi.fn();
+
+		renderHook(() => useModalHistory(true, "medDetail", onClose, { state: { medId: 42 } }));
+
+		expect(window.history.pushState).toHaveBeenCalledWith({ modal: "medDetail", medId: 42 }, "");
+	});
+
+	it("direct close closes locally and removes the modal history entry", () => {
+		const onClose = vi.fn();
+		vi.spyOn(window.history, "back").mockImplementation(() => {});
+
+		const { result } = renderHook(() => useModalHistory(true, "journal-editor", onClose));
+
+		act(() => {
+			result.current.closeModal();
+		});
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(window.history.back).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			window.dispatchEvent(new PopStateEvent("popstate"));
+		});
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
 	it("stops parent popstate handlers when a nested modal consumes browser back", () => {
 		const onClose = vi.fn();
 		const parentClose = vi.fn();
@@ -43,5 +71,22 @@ describe("useModalHistory", () => {
 		expect(parentClose).not.toHaveBeenCalled();
 
 		window.removeEventListener("popstate", parentClose);
+	});
+
+	it("closes only the top modal when nested modal-history hooks are open", () => {
+		const parentClose = vi.fn();
+		const nestedClose = vi.fn();
+
+		renderHook(() => {
+			useModalHistory(true, "parent-modal", parentClose);
+			useModalHistory(true, "nested-modal", nestedClose);
+		});
+
+		act(() => {
+			window.dispatchEvent(new PopStateEvent("popstate"));
+		});
+
+		expect(nestedClose).toHaveBeenCalledTimes(1);
+		expect(parentClose).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Closes #759

## Summary
Centralize browser-history integration for modal open/close flows so the history behavior is handled in one place.

## Files changed
- frontend/src/context/AppContext.tsx
- frontend/src/hooks/useModalHistory.ts
- frontend/src/test/context/AppContext.test.tsx
- frontend/src/test/hooks/useModalHistory.test.ts

## Tests added/updated
- Updated AppContext tests for modal history flow behavior.
- Updated useModalHistory tests for centralized history handling.

## Commands run
- `cd frontend && npm run check` (passed)
- `cd frontend && CI=true npm run test:run -- src/test/context/AppContext.test.tsx src/test/hooks/useModalHistory.test.ts` (passed)
- `cd frontend && npm run build` (passed)

## Security impact
No auth or security boundary changes.

## Data migration impact
None.