### PR TITLE
chore(release): enforce shared package version policy

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -47,7 +47,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.27.2",
+      "version": "1.27.4",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,9 +98,10 @@ Use the root-level commands for full-stack validation when a change spans backen
 - Releases also run `npm run release:preflight` in two stages:
   - early static validation of tag, package versions, release policy, compose tags, and release workflow dependencies
   - late validation of generated changelog and `docker-compose.pinned.yml` before GitHub Release creation
-- The release version policy is documented in `release-policy.json`:
-  - `backend` and `frontend` must match the release tag
-  - `shared` may version independently, but the exception must be reviewed explicitly per release tag
+- The release version policy is documented in `docs/release-policy.md` and enforced by `release-policy.json`:
+  - `backend`, `frontend` and `shared` must all match the release tag
+  - backend and frontend must keep consuming `@medassist/shared` through `file:../shared`
+  - Docker builds must copy and build the intended shared package from source
 - Container smoke covers:
   - backend shared-runtime import plus backend `/health` startup check
   - frontend container boot, static asset serving, and `/api/health` proxy wiring

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,34 @@
+# Release Version Policy
+
+MedAssist-ng uses strict runtime package versioning.
+
+For every release tag `vX.Y.Z`, these package versions must be exactly `X.Y.Z`:
+
+- `backend/package.json`
+- `frontend/package.json`
+- `shared/package.json`
+
+The root `package.json` is a private orchestration package and does not carry the runtime release version.
+
+## Shared Package Contract
+
+Backend and frontend both consume `@medassist/shared` through `file:../shared`. Because the shared package is built into the backend and frontend release artifacts, it must be versioned with the same release number as the runtime packages. Version drift is not allowed.
+
+The release preflight validates:
+
+- backend, frontend and shared package versions match the release tag
+- backend and frontend keep `@medassist/shared` as `file:../shared`
+- package lock entries record the same shared package version
+- Docker builds copy and build the shared package from source
+- the backend runtime image contains the built shared package manifest and `dist/`
+
+## Release Checklist
+
+When preparing a release:
+
+1. Update `backend/package.json`, `frontend/package.json` and `shared/package.json` to the release version.
+2. Refresh all affected lockfiles.
+3. Run `npm run release:preflight -- --tag vX.Y.Z --static-only`.
+4. Continue the release only when preflight passes.
+
+Do not intentionally ship backend/frontend/shared version drift. If independent package versioning is ever needed, update this document, `release-policy.json` and `scripts/release-preflight.mjs` in the same policy PR before changing release behavior.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.27.2",
+      "version": "1.27.4",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "cd shared && npm run check && cd ../backend && npm run check && cd ../frontend && npm run check",
     "build": "cd shared && npm run build && cd ../backend && npm run build && cd ../frontend && npm run build",
     "test:domain": "cd backend && npm run test:domain && cd ../frontend && npm run test:e2e:domain",
+    "test:release-preflight": "node scripts/test-release-preflight.mjs",
     "release:preflight": "node scripts/release-preflight.mjs"
   },
   "devDependencies": {

--- a/release-policy.json
+++ b/release-policy.json
@@ -1,13 +1,12 @@
 {
-  "versionPolicy": "pragmatic",
+  "versionPolicy": "strict",
   "packages": {
     "backend": "tag",
     "frontend": "tag",
-    "shared": "independent"
+    "shared": "tag"
   },
   "shared": {
-    "allowIndependentVersion": true,
-    "lastReviewedTag": "v1.27.4",
-    "rationale": "The shared workspace package is versioned independently from backend/frontend runtime releases and is consumed as a local file dependency."
+    "mustMatchReleaseTag": true,
+    "rationale": "Backend and frontend consume @medassist/shared as a local file dependency, so all runtime workspace packages must carry the same release version."
   }
 }

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -59,33 +59,6 @@ function parseReleaseTag(tag) {
   return { tag, version: match[1] };
 }
 
-function parseNumericSemver(version) {
-  const match = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(version);
-  if (!match) {
-    fail(`Expected a semver-compatible version, received: ${version}`);
-  }
-
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3])
-  };
-}
-
-function isVersionAhead(candidate, baseline) {
-  const candidateParts = parseNumericSemver(candidate);
-  const baselineParts = parseNumericSemver(baseline);
-
-  if (candidateParts.major !== baselineParts.major) {
-    return candidateParts.major > baselineParts.major;
-  }
-  if (candidateParts.minor !== baselineParts.minor) {
-    return candidateParts.minor > baselineParts.minor;
-  }
-
-  return candidateParts.patch > baselineParts.patch;
-}
-
 function extractImageLine(content, imageName) {
   const pattern = new RegExp(`^\\s*image:\\s*(ghcr\\.io\\/[^\\s]+\\/${imageName}:[^\\s]+)\\s*$`, "m");
   const match = content.match(pattern);
@@ -167,50 +140,139 @@ function validateWorkflowNeeds(workflowPath) {
   }
 }
 
+function validatePackageVersion(packageName, packageJsonPath, packageJson, releaseVersion) {
+  if (packageJson.version !== releaseVersion) {
+    fail(`${packageJsonPath} version must match ${releaseVersion}, found ${packageJson.version}.`);
+  }
+
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(packageJson.version)) {
+    fail(`${packageName} package version must be semver-compatible, found ${packageJson.version}.`);
+  }
+}
+
+function validateSharedDependency(packageName, packageJsonPath, packageJson) {
+  if (packageJson.dependencies?.["@medassist/shared"] !== "file:../shared") {
+    fail(`${packageJsonPath} must consume @medassist/shared through file:../shared.`);
+  }
+
+  if (packageJson.devDependencies?.["@medassist/shared"] || packageJson.peerDependencies?.["@medassist/shared"]) {
+    fail(`${packageName} must declare @medassist/shared only as a runtime local dependency.`);
+  }
+}
+
+function validatePackageLockVersion(lockfilePath, lockfile, packagePath, releaseVersion) {
+  const packageEntry = packagePath === "" ? lockfile.packages?.[""] : lockfile.packages?.[packagePath];
+  const versions = new Set([lockfile.version, packageEntry?.version].filter(Boolean));
+
+  if (!packageEntry) {
+    fail(`${lockfilePath} is missing package lock entry "${packagePath || "<root>"}".`);
+  }
+
+  for (const version of versions) {
+    if (version !== releaseVersion) {
+      fail(`${lockfilePath} package entry "${packagePath || "<root>"}" must use ${releaseVersion}, found ${version}.`);
+    }
+  }
+}
+
+function validateSharedLockEntry(lockfilePath, lockfile, releaseVersion) {
+  const sharedEntry = lockfile.packages?.["../shared"];
+  if (!sharedEntry) {
+    fail(`${lockfilePath} is missing the local ../shared package lock entry.`);
+  }
+
+  if (sharedEntry.version !== releaseVersion) {
+    fail(`${lockfilePath} ../shared version must match ${releaseVersion}, found ${sharedEntry.version}.`);
+  }
+
+  const linkedEntry = lockfile.packages?.["node_modules/@medassist/shared"];
+  if (!linkedEntry || linkedEntry.resolved !== "../shared" || linkedEntry.link !== true) {
+    fail(`${lockfilePath} must lock @medassist/shared as a local link to ../shared.`);
+  }
+}
+
+function requireDockerPattern(dockerfilePath, dockerfile, pattern, description) {
+  if (!pattern.test(dockerfile)) {
+    fail(`${dockerfilePath} must ${description}.`);
+  }
+}
+
+function validateDockerSharedBuild(dockerfilePath, { requiresRuntimeCopy }) {
+  const dockerfile = readText(dockerfilePath);
+
+  requireDockerPattern(
+    dockerfilePath,
+    dockerfile,
+    /COPY shared\/package\.json shared\/package-lock\.json\* \.\/shared\//,
+    "copy the shared package manifest and lockfile before installing dependencies"
+  );
+  requireDockerPattern(
+    dockerfilePath,
+    dockerfile,
+    /COPY shared\/src \.\/shared\/src/,
+    "copy the shared package source into the image build context"
+  );
+  requireDockerPattern(dockerfilePath, dockerfile, /RUN cd shared && npm run build/, "build the shared package from source");
+
+  if (requiresRuntimeCopy) {
+    requireDockerPattern(
+      dockerfilePath,
+      dockerfile,
+      /COPY --from=builder \/app\/shared\/package\.json \/shared\/package\.json/,
+      "copy the built shared package manifest into the runtime image"
+    );
+    requireDockerPattern(
+      dockerfilePath,
+      dockerfile,
+      /COPY --from=builder \/app\/shared\/dist \/shared\/dist/,
+      "copy the built shared package output into the runtime image"
+    );
+  }
+}
+
 function validatePolicy(releaseTag, releaseVersion) {
   const policy = readJson("release-policy.json");
   const backendPackage = readJson("backend/package.json");
   const frontendPackage = readJson("frontend/package.json");
   const sharedPackage = readJson("shared/package.json");
+  const backendLockfile = readJson("backend/package-lock.json");
+  const frontendLockfile = readJson("frontend/package-lock.json");
+  const sharedLockfile = readJson("shared/package-lock.json");
 
-  if (policy.versionPolicy !== "pragmatic") {
-    fail(`Unsupported release policy "${policy.versionPolicy}". Expected "pragmatic".`);
+  if (policy.versionPolicy !== "strict") {
+    fail(`Unsupported release policy "${policy.versionPolicy}". Expected "strict".`);
   }
 
-  if (policy.packages?.backend !== "tag" || policy.packages?.frontend !== "tag") {
-    fail("release-policy.json must require backend/frontend to match the release tag.");
+  for (const packageName of ["backend", "frontend", "shared"]) {
+    if (policy.packages?.[packageName] !== "tag") {
+      fail(`release-policy.json must require ${packageName} to match the release tag.`);
+    }
   }
 
-  if (backendPackage.version !== releaseVersion) {
-    fail(`backend/package.json version must match ${releaseVersion}, found ${backendPackage.version}.`);
-  }
-
-  if (frontendPackage.version !== releaseVersion) {
-    fail(`frontend/package.json version must match ${releaseVersion}, found ${frontendPackage.version}.`);
-  }
-
-  if (policy.packages?.shared !== "independent") {
-    fail("release-policy.json must explicitly mark shared as independently versioned for the pragmatic policy.");
-  }
-
-  if (policy.shared?.allowIndependentVersion !== true) {
-    fail("release-policy.json must explicitly allow the shared package to version independently.");
-  }
-
-  if (policy.shared?.lastReviewedTag !== releaseTag) {
-    fail(
-      `release-policy.json shared.lastReviewedTag must be reviewed for ${releaseTag}; found ${policy.shared?.lastReviewedTag ?? "<missing>"}.`
-    );
+  if (policy.shared?.mustMatchReleaseTag !== true) {
+    fail("release-policy.json must require shared.mustMatchReleaseTag=true for the strict policy.");
   }
 
   if (typeof policy.shared?.rationale !== "string" || policy.shared.rationale.trim().length === 0) {
-    fail("release-policy.json must document why shared is allowed to differ from the release tag.");
+    fail("release-policy.json must document why shared must match the release tag.");
   }
 
-  parseNumericSemver(sharedPackage.version);
-  if (isVersionAhead(sharedPackage.version, releaseVersion)) {
-    fail(`shared/package.json version ${sharedPackage.version} must not be ahead of release version ${releaseVersion}.`);
-  }
+  validatePackageVersion("backend", "backend/package.json", backendPackage, releaseVersion);
+  validatePackageVersion("frontend", "frontend/package.json", frontendPackage, releaseVersion);
+  validatePackageVersion("shared", "shared/package.json", sharedPackage, releaseVersion);
+
+  validateSharedDependency("backend", "backend/package.json", backendPackage);
+  validateSharedDependency("frontend", "frontend/package.json", frontendPackage);
+
+  validatePackageLockVersion("backend/package-lock.json", backendLockfile, "", releaseVersion);
+  validatePackageLockVersion("frontend/package-lock.json", frontendLockfile, "", releaseVersion);
+  validatePackageLockVersion("shared/package-lock.json", sharedLockfile, "", releaseVersion);
+
+  validateSharedLockEntry("backend/package-lock.json", backendLockfile, releaseVersion);
+  validateSharedLockEntry("frontend/package-lock.json", frontendLockfile, releaseVersion);
+
+  validateDockerSharedBuild("backend/Dockerfile", { requiresRuntimeCopy: true });
+  validateDockerSharedBuild("frontend/Dockerfile", { requiresRuntimeCopy: false });
 }
 
 function main() {

--- a/scripts/test-release-preflight.mjs
+++ b/scripts/test-release-preflight.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const preflightScript = path.join(repoRoot, "scripts/release-preflight.mjs");
+const releaseTag = "v1.27.4";
+
+function copyFixture() {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "medassist-release-preflight-"));
+  const pathsToCopy = [
+    "release-policy.json",
+    "docker-compose.yml",
+    "backend/package.json",
+    "backend/package-lock.json",
+    "backend/Dockerfile",
+    "frontend/package.json",
+    "frontend/package-lock.json",
+    "frontend/Dockerfile",
+    "shared/package.json",
+    "shared/package-lock.json",
+    ".github/workflows/docker-build.yml"
+  ];
+
+  for (const relativePath of pathsToCopy) {
+    const destination = path.join(fixtureRoot, relativePath);
+    mkdirSync(path.dirname(destination), { recursive: true });
+    cpSync(path.join(repoRoot, relativePath), destination, { recursive: true });
+  }
+
+  return fixtureRoot;
+}
+
+function readJson(root, relativePath) {
+  return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
+}
+
+function writeJson(root, relativePath, value) {
+  writeFileSync(path.join(root, relativePath), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function runPreflight(root) {
+  return execFileSync("node", [preflightScript, "--tag", releaseTag, "--static-only"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+function expectPreflightFailure(root, expectedMessage) {
+  assert.throws(
+    () => runPreflight(root),
+    (error) => {
+      const output = `${error.stdout ?? ""}\n${error.stderr ?? ""}`;
+      assert.match(output, expectedMessage);
+      return true;
+    }
+  );
+}
+
+test("release preflight accepts the strict package version policy", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    assert.match(runPreflight(fixtureRoot), /static checks passed/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects shared package version drift", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const sharedPackage = readJson(fixtureRoot, "shared/package.json");
+    sharedPackage.version = "1.27.2";
+    writeJson(fixtureRoot, "shared/package.json", sharedPackage);
+
+    expectPreflightFailure(fixtureRoot, /shared\/package\.json version must match 1\.27\.4/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects local shared lockfile drift", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const backendLockfile = readJson(fixtureRoot, "backend/package-lock.json");
+    backendLockfile.packages["../shared"].version = "1.27.2";
+    writeJson(fixtureRoot, "backend/package-lock.json", backendLockfile);
+
+    expectPreflightFailure(fixtureRoot, /backend\/package-lock\.json \.\.\/shared version must match 1\.27\.4/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects Dockerfiles that do not build shared from source", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const frontendDockerfilePath = path.join(fixtureRoot, "frontend/Dockerfile");
+    const frontendDockerfile = readFileSync(frontendDockerfilePath, "utf8").replace(
+      "RUN cd shared && npm run build",
+      "RUN node --version"
+    );
+    writeFileSync(frontendDockerfilePath, frontendDockerfile);
+
+    expectPreflightFailure(fixtureRoot, /frontend\/Dockerfile must build the shared package from source/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.27.2",
+  "version": "1.27.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.27.2",
+      "version": "1.27.4",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.27.2",
+  "version": "1.27.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #762

## Summary
Add and enforce shared package version consistency policy and preflight checks so releases cannot ship silently inconsistent package metadata.

## Files changed
- release-policy.json
- scripts/release-preflight.mjs
- scripts/test-release-preflight.mjs
- docs/release-policy.md
- docs/DEVELOPMENT.md
- package.json
- shared/package.json
- backend/package-lock.json
- frontend/package-lock.json
- shared/package-lock.json

## Tests added/updated
- Added release preflight policy tests.

## Commands run
- `npm run test:release-preflight` (passed)
- `npm run release:preflight -- --tag v1.27.4 --static-only` (passed)
- `npm run check` (passed)
- `npm run build` (passed)
- `git diff --check` (passed)

## Security impact
No runtime auth/permission changes.

## Data migration impact
None.