### PR TITLE
refactor(frontend): centralize settings diff and schema

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -23,6 +23,7 @@ import {
 import { getSystemLocale, setDefaultFormattingTimezone } from "../utils/formatters";
 import { mergePersonTags } from "../utils/person-tags";
 import { buildSchedulePreview, calculateCoverage, computeMissedPastDoseIds, getStockStatus } from "../utils/schedule";
+import { settingsChanged as hasSettingsChanged } from "../utils/settings";
 import { ShareContextProvider } from "./ShareContext";
 import { type ImportPreview, useImportExport } from "./useImportExport";
 
@@ -644,34 +645,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
 	// Compute settingsChanged
 	const settingsChanged = useMemo(() => {
-		const settings = settingsHook.settings;
-		const savedSettings = settingsHook.savedSettings;
-		return (
-			settings.emailEnabled !== savedSettings.emailEnabled ||
-			settings.notificationEmail !== savedSettings.notificationEmail ||
-			settings.emailStockReminders !== savedSettings.emailStockReminders ||
-			settings.emailIntakeReminders !== savedSettings.emailIntakeReminders ||
-			settings.emailPrescriptionReminders !== savedSettings.emailPrescriptionReminders ||
-			settings.reminderDaysBefore !== savedSettings.reminderDaysBefore ||
-			settings.repeatDailyReminders !== savedSettings.repeatDailyReminders ||
-			settings.lowStockDays !== savedSettings.lowStockDays ||
-			settings.normalStockDays !== savedSettings.normalStockDays ||
-			settings.highStockDays !== savedSettings.highStockDays ||
-			settings.shoutrrrEnabled !== savedSettings.shoutrrrEnabled ||
-			settings.shoutrrrUrl !== savedSettings.shoutrrrUrl ||
-			settings.shoutrrrStockReminders !== savedSettings.shoutrrrStockReminders ||
-			settings.shoutrrrIntakeReminders !== savedSettings.shoutrrrIntakeReminders ||
-			settings.shoutrrrPrescriptionReminders !== savedSettings.shoutrrrPrescriptionReminders ||
-			settings.skipRemindersForTakenDoses !== savedSettings.skipRemindersForTakenDoses ||
-			settings.repeatRemindersEnabled !== savedSettings.repeatRemindersEnabled ||
-			settings.reminderRepeatIntervalMinutes !== savedSettings.reminderRepeatIntervalMinutes ||
-			settings.maxNaggingReminders !== savedSettings.maxNaggingReminders ||
-			settings.stockCalculationMode !== savedSettings.stockCalculationMode ||
-			settings.shareMedicationOverview !== savedSettings.shareMedicationOverview ||
-			settings.upcomingTodayOnly !== savedSettings.upcomingTodayOnly ||
-			settings.shareScheduleTodayOnly !== savedSettings.shareScheduleTodayOnly ||
-			settings.expiryWarningDays !== savedSettings.expiryWarningDays
-		);
+		return hasSettingsChanged(settingsHook.savedSettings, settingsHook.settings);
 	}, [settingsHook.settings, settingsHook.savedSettings]);
 
 	const shareValue = useMemo(

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { log } from "../utils/logger";
+import { settingsChanged } from "../utils/settings";
 
 export interface Settings {
 	timezone: string;
@@ -471,8 +472,8 @@ export function useSettings(): UseSettingsReturn {
 			return;
 		}
 
-		// Don't save if nothing changed
-		if (JSON.stringify(settings) === JSON.stringify(savedSettings)) {
+		// Don't save if no user-editable setting changed
+		if (!settingsChanged(savedSettings, settings)) {
 			return;
 		}
 
@@ -498,7 +499,7 @@ export function useSettings(): UseSettingsReturn {
 
 	useEffect(() => {
 		const flushPendingSettings = () => {
-			if (JSON.stringify(latestSettingsRef.current) === JSON.stringify(latestSavedSettingsRef.current)) {
+			if (!settingsChanged(latestSavedSettingsRef.current, latestSettingsRef.current)) {
 				return;
 			}
 
@@ -514,7 +515,7 @@ export function useSettings(): UseSettingsReturn {
 				clearTimeout(debounceRef.current);
 			}
 
-			if (JSON.stringify(latestSettingsRef.current) === JSON.stringify(latestSavedSettingsRef.current)) {
+			if (!settingsChanged(latestSavedSettingsRef.current, latestSettingsRef.current)) {
 				return;
 			}
 
@@ -587,7 +588,7 @@ export function useSettings(): UseSettingsReturn {
 	}, [fetchWithRefresh, getErrorMessage, settings.shoutrrrUrl]);
 
 	// Check for unsaved changes
-	const hasUnsavedChanges = JSON.stringify(settings) !== JSON.stringify(savedSettings);
+	const hasUnsavedChanges = settingsChanged(savedSettings, settings);
 
 	return {
 		settings,

--- a/frontend/src/test/context/AppContext.test.tsx
+++ b/frontend/src/test/context/AppContext.test.tsx
@@ -333,6 +333,52 @@ describe("useAppContext", () => {
 		});
 	});
 
+	it("marks settings as changed when timezone differs", async () => {
+		const settingsValue = mockUseSettings();
+		mockUseSettings.mockReturnValue({
+			...settingsValue,
+			settings: {
+				...settingsValue.settings,
+				timezone: "Europe/Berlin",
+			},
+			savedSettings: {
+				...settingsValue.savedSettings,
+				timezone: "",
+			},
+		});
+
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		await waitFor(() => {
+			expect(result.current.settingsChanged).toBe(true);
+		});
+	});
+
+	it("does not mark settings as changed for scheduler metadata refreshes", async () => {
+		const settingsValue = mockUseSettings();
+		mockUseSettings.mockReturnValue({
+			...settingsValue,
+			settings: {
+				...settingsValue.settings,
+				lastAutoEmailSent: "2026-06-06T08:00:00.000Z",
+				lastNotificationType: "stock",
+				lastStockReminderChannel: "both",
+			},
+			savedSettings: {
+				...settingsValue.savedSettings,
+				lastAutoEmailSent: null,
+				lastNotificationType: null,
+				lastStockReminderChannel: null,
+			},
+		});
+
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		await waitFor(() => {
+			expect(result.current.settingsChanged).toBe(false);
+		});
+	});
+
 	it("exposes the settings load error from useSettings", async () => {
 		const settingsValue = mockUseSettings();
 		mockUseSettings.mockReturnValue({

--- a/frontend/src/test/hooks/useSettings.test.ts
+++ b/frontend/src/test/hooks/useSettings.test.ts
@@ -116,6 +116,31 @@ describe("useSettings", () => {
 		expect(result.current.settings.notificationEmail).toBe("test@example.com");
 	});
 
+	it("tracks unsaved changes only for user-editable settings fields", async () => {
+		const { result } = renderHook(() => useSettings());
+
+		await waitFor(() => {
+			expect(result.current.settingsLoading).toBe(false);
+		});
+
+		act(() => {
+			result.current.setSettings((settings) => ({
+				...settings,
+				lastAutoEmailSent: "2026-06-06T08:00:00.000Z",
+				nextScheduledCheck: "2026-06-06T09:00:00.000Z",
+				lastNotificationType: "stock",
+			}));
+		});
+
+		expect(result.current.hasUnsavedChanges).toBe(false);
+
+		act(() => {
+			result.current.setSettings((settings) => ({ ...settings, timezone: "Europe/Berlin" }));
+		});
+
+		expect(result.current.hasUnsavedChanges).toBe(true);
+	});
+
 	it("handles API error on load", async () => {
 		(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Network error"));
 

--- a/frontend/src/test/utils/settings.test.ts
+++ b/frontend/src/test/utils/settings.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { Settings } from "../../hooks/useSettings";
+import {
+	normalizeSettingsForComparison,
+	settingsChanged,
+	USER_EDITABLE_SETTINGS_FIELDS,
+	type UserEditableSettingsField,
+} from "../../utils/settings";
+
+const baseSettings: Settings = {
+	timezone: "Europe/Berlin",
+	availableTimezones: ["Europe/Berlin", "UTC"],
+	serverTimezone: "UTC",
+	emailEnabled: false,
+	notificationEmail: "",
+	reminderDaysBefore: 7,
+	repeatDailyReminders: false,
+	skipRemindersForTakenDoses: false,
+	repeatRemindersEnabled: false,
+	reminderRepeatIntervalMinutes: 30,
+	maxNaggingReminders: 5,
+	lowStockDays: 30,
+	normalStockDays: 90,
+	highStockDays: 180,
+	smtpHost: "smtp.example.com",
+	smtpPort: 587,
+	smtpUser: "smtp-user",
+	smtpPass: "",
+	smtpFrom: "medassist@example.com",
+	smtpSecure: false,
+	hasSmtpPassword: false,
+	lastAutoEmailSent: null,
+	nextScheduledCheck: null,
+	lastNotificationType: null,
+	lastNotificationChannel: null,
+	lastReminderMedName: null,
+	lastReminderTakenBy: null,
+	lastStockReminderSent: null,
+	lastStockReminderChannel: null,
+	lastStockReminderMedNames: null,
+	lastPrescriptionReminderSent: null,
+	lastPrescriptionReminderChannel: null,
+	lastPrescriptionReminderMedNames: null,
+	shoutrrrEnabled: false,
+	shoutrrrUrl: "",
+	emailStockReminders: true,
+	emailIntakeReminders: true,
+	emailPrescriptionReminders: true,
+	shoutrrrStockReminders: true,
+	shoutrrrIntakeReminders: true,
+	shoutrrrPrescriptionReminders: true,
+	stockCalculationMode: "automatic",
+	shareMedicationOverview: false,
+	upcomingTodayOnly: false,
+	shareScheduleTodayOnly: false,
+	swapDashboardMainSections: false,
+	reminderHour: 6,
+	reminderMinutesBefore: 15,
+	expiryWarningDays: 30,
+};
+
+function changeEditableField(field: UserEditableSettingsField): Settings {
+	const currentValue = baseSettings[field];
+	if (typeof currentValue === "boolean") {
+		return { ...baseSettings, [field]: !currentValue };
+	}
+	if (typeof currentValue === "number") {
+		return { ...baseSettings, [field]: currentValue + 1 };
+	}
+	if (field === "stockCalculationMode") {
+		return { ...baseSettings, stockCalculationMode: "manual" };
+	}
+	return { ...baseSettings, [field]: `${currentValue}-changed` };
+}
+
+describe("settings comparison utilities", () => {
+	it("documents the one canonical list of user-editable settings fields", () => {
+		expect([...USER_EDITABLE_SETTINGS_FIELDS]).toEqual([
+			"timezone",
+			"emailEnabled",
+			"notificationEmail",
+			"emailStockReminders",
+			"emailIntakeReminders",
+			"emailPrescriptionReminders",
+			"reminderDaysBefore",
+			"repeatDailyReminders",
+			"skipRemindersForTakenDoses",
+			"repeatRemindersEnabled",
+			"reminderRepeatIntervalMinutes",
+			"maxNaggingReminders",
+			"lowStockDays",
+			"normalStockDays",
+			"highStockDays",
+			"shoutrrrEnabled",
+			"shoutrrrUrl",
+			"shoutrrrStockReminders",
+			"shoutrrrIntakeReminders",
+			"shoutrrrPrescriptionReminders",
+			"stockCalculationMode",
+			"shareMedicationOverview",
+			"upcomingTodayOnly",
+			"shareScheduleTodayOnly",
+			"swapDashboardMainSections",
+		]);
+	});
+
+	it.each(USER_EDITABLE_SETTINGS_FIELDS)("marks %s as dirty when changed", (field) => {
+		expect(settingsChanged(baseSettings, changeEditableField(field))).toBe(true);
+	});
+
+	it("normalizes only editable fields for comparison", () => {
+		expect(Object.keys(normalizeSettingsForComparison(baseSettings))).toEqual([...USER_EDITABLE_SETTINGS_FIELDS]);
+	});
+
+	it("does not treat scheduler or server-managed fields as user-editable", () => {
+		const current: Settings = {
+			...baseSettings,
+			availableTimezones: ["UTC"],
+			serverTimezone: "Europe/London",
+			smtpHost: "smtp.changed.example.com",
+			smtpPort: 2525,
+			hasSmtpPassword: true,
+			lastAutoEmailSent: "2026-06-06T08:00:00.000Z",
+			nextScheduledCheck: "2026-06-06T09:00:00.000Z",
+			lastNotificationType: "stock",
+			lastNotificationChannel: "email",
+			lastReminderMedName: "Aspirin",
+			lastReminderTakenBy: "Max",
+			lastStockReminderSent: "2026-06-06T07:00:00.000Z",
+			lastStockReminderChannel: "both",
+			lastStockReminderMedNames: "Aspirin",
+			lastPrescriptionReminderSent: "2026-06-06T06:00:00.000Z",
+			lastPrescriptionReminderChannel: "push",
+			lastPrescriptionReminderMedNames: "Rx Med",
+			reminderHour: 8,
+			reminderMinutesBefore: 30,
+			expiryWarningDays: 90,
+		};
+
+		expect(settingsChanged(baseSettings, current)).toBe(false);
+	});
+});

--- a/frontend/src/utils/settings.ts
+++ b/frontend/src/utils/settings.ts
@@ -1,0 +1,46 @@
+import type { Settings } from "../hooks/useSettings";
+
+export const USER_EDITABLE_SETTINGS_FIELDS = [
+	"timezone",
+	"emailEnabled",
+	"notificationEmail",
+	"emailStockReminders",
+	"emailIntakeReminders",
+	"emailPrescriptionReminders",
+	"reminderDaysBefore",
+	"repeatDailyReminders",
+	"skipRemindersForTakenDoses",
+	"repeatRemindersEnabled",
+	"reminderRepeatIntervalMinutes",
+	"maxNaggingReminders",
+	"lowStockDays",
+	"normalStockDays",
+	"highStockDays",
+	"shoutrrrEnabled",
+	"shoutrrrUrl",
+	"shoutrrrStockReminders",
+	"shoutrrrIntakeReminders",
+	"shoutrrrPrescriptionReminders",
+	"stockCalculationMode",
+	"shareMedicationOverview",
+	"upcomingTodayOnly",
+	"shareScheduleTodayOnly",
+	"swapDashboardMainSections",
+] as const satisfies readonly (keyof Settings)[];
+
+export type UserEditableSettingsField = (typeof USER_EDITABLE_SETTINGS_FIELDS)[number];
+
+export type ComparableSettings = Pick<Settings, UserEditableSettingsField>;
+
+export function normalizeSettingsForComparison(settings: Settings): ComparableSettings {
+	return Object.fromEntries(
+		USER_EDITABLE_SETTINGS_FIELDS.map((field) => [field, settings[field]])
+	) as ComparableSettings;
+}
+
+export function settingsChanged(original: Settings, current: Settings): boolean {
+	const normalizedOriginal = normalizeSettingsForComparison(original);
+	const normalizedCurrent = normalizeSettingsForComparison(current);
+
+	return USER_EDITABLE_SETTINGS_FIELDS.some((field) => normalizedOriginal[field] !== normalizedCurrent[field]);
+}


### PR DESCRIPTION
Closes #760

## Summary
Centralize editable settings normalization and dirty-state comparison so new editable settings are added in one obvious place.

## Files changed
- frontend/src/context/AppContext.tsx
- frontend/src/hooks/useSettings.ts
- frontend/src/utils/settings.ts
- frontend/src/test/context/AppContext.test.tsx
- frontend/src/test/hooks/useSettings.test.ts
- frontend/src/test/utils/settings.test.ts

## Tests added/updated
- Added focused settings utility tests.
- Extended useSettings and AppContext tests for dirty-state coverage.

## Commands run
- `cd frontend && npm run check` (passed)
- `cd frontend && CI=true npm run test:run -- src/test/context/AppContext.test.tsx src/test/hooks/useSettings.test.ts src/test/utils/settings.test.ts` (passed)
- `cd frontend && npm run build` (passed)

## Security impact
No auth or security boundary changes.

## Data migration impact
None.