### PR TITLE
chore: document canonical preview cors origin

### DIFF
--- a/backend/src/test/env-docs-consistency.test.ts
+++ b/backend/src/test/env-docs-consistency.test.ts
@@ -37,6 +37,8 @@ const docsWithDefaultSettings = [
 ];
 const nonEnvDefaultReferences = new Set(["DEFAULT_USER_SETTINGS"]);
 const removedShareStockStatusEnvVar = ["DEFAULT", "SHARE", "STOCK", "STATUS"].join("_");
+const canonicalPreviewOrigin = "http://localhost:4174";
+const stalePreviewOrigin = "http://localhost:4173";
 
 function readRepoFile(path: string): string {
 	return readFileSync(resolve(process.cwd(), "..", path), "utf-8");
@@ -49,6 +51,15 @@ function extractDefaultEnvVars(content: string): Set<string> {
 }
 
 describe("environment documentation consistency", () => {
+	it("keeps the documented frontend preview port aligned", () => {
+		const content = [".env.example", "README.md", "docs/CONFIGURATION.md", "docker-compose.yml"]
+			.map(readRepoFile)
+			.join("\n");
+
+		expect(content).toContain(canonicalPreviewOrigin);
+		expect(content).not.toContain(stalePreviewOrigin);
+	});
+
 	it("does not mention the removed share stock-status default setting", () => {
 		const content = docsWithDefaultSettings.map(readRepoFile).join("\n");
 

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CORS_ORIGINS } from "../utils/server-config.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -32,7 +33,7 @@ describe("plugins/env runtime validation", () => {
 		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
 		expect(mod.env.OIDC_ENABLED).toBe(false);
 		expect(mod.env.PORT).toBe(3000);
-		expect(mod.env.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4174");
+		expect(mod.env.CORS_ORIGINS).toBe(DEFAULT_CORS_ORIGINS);
 		expect(mod.env.RATE_LIMIT_MAX).toBe(100);
 		expect(mod.env.SHARE_TOKEN_TTL_DAYS).toBe(90);
 		expect(mod.env.SENSITIVE_LOGGING_ENABLED).toBe(false);

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { EnvSchema, type ParsedEnv } from "../plugins/env-schema.js";
+import { DEFAULT_CORS_ORIGINS } from "../utils/server-config.js";
 
 // Mock process.exit to prevent tests from exiting
 const mockExit = vi.fn();
@@ -34,7 +35,7 @@ describe("EnvSchema", () => {
 
 			expect(result.NODE_ENV).toBe("production");
 			expect(result.PORT).toBe(3000);
-			expect(result.CORS_ORIGINS).toBe("http://localhost:5173,http://localhost:4174");
+			expect(result.CORS_ORIGINS).toBe(DEFAULT_CORS_ORIGINS);
 			expect(result.LOG_LEVEL).toBe("info");
 			expect(result.SENSITIVE_LOGGING_ENABLED).toBe(false);
 			expect(result.PUBLIC_APP_URL).toBeUndefined();

--- a/backend/src/test/server.test.ts
+++ b/backend/src/test/server.test.ts
@@ -13,6 +13,9 @@ import {
 	buildAppConfig,
 	buildBaseCookieOptions,
 	buildRefreshCookieOptions,
+	DEFAULT_CORS_ORIGINS,
+	DEFAULT_DEV_FRONTEND_ORIGIN,
+	DEFAULT_PREVIEW_FRONTEND_ORIGIN,
 	ensureImagesDirectory,
 	getJwtConfig,
 	parseCorsOrigins,
@@ -20,6 +23,13 @@ import {
 
 describe("Index.ts Utility Functions", () => {
 	describe("parseCorsOrigins", () => {
+		it("should parse canonical default development and preview origins", () => {
+			expect(parseCorsOrigins(DEFAULT_CORS_ORIGINS)).toEqual([
+				DEFAULT_DEV_FRONTEND_ORIGIN,
+				DEFAULT_PREVIEW_FRONTEND_ORIGIN,
+			]);
+		});
+
 		it("should parse comma-separated origins", () => {
 			const origins = parseCorsOrigins("http://localhost:5173,http://localhost:4174");
 			expect(origins).toHaveLength(2);

--- a/backend/src/utils/server-config.ts
+++ b/backend/src/utils/server-config.ts
@@ -9,7 +9,9 @@ import type { CookieSerializeOptions } from "@fastify/cookie";
 import { getDataDir } from "../db/path-utils.js";
 import { parseStringListEnv } from "./env-parsing.js";
 
-export const DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4174";
+export const DEFAULT_DEV_FRONTEND_ORIGIN = "http://localhost:5173";
+export const DEFAULT_PREVIEW_FRONTEND_ORIGIN = "http://localhost:4174";
+export const DEFAULT_CORS_ORIGINS = `${DEFAULT_DEV_FRONTEND_ORIGIN},${DEFAULT_PREVIEW_FRONTEND_ORIGIN}`;
 export const DEFAULT_LOG_LEVEL = "info";
 export const DEFAULT_COOKIE_SECRET = "dev-cookie-secret";
 export const DEFAULT_ACCESS_TOKEN_TTL_MINUTES = 15;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -29,6 +29,7 @@ API docs behavior:
 `CORS_ORIGINS` note:
 
 - The `.env.example` file is optimized for the Docker Compose quickstart, where the frontend runs on `http://localhost:4174`.
+- `http://localhost:4174` is the canonical local preview and Docker quickstart frontend origin.
 - Local frontend development uses the Vite dev server instead, so the backend schema defaults cover `http://localhost:5173` and `http://localhost:4174`.
 - If you use a custom hostname or reverse proxy, include that origin in `CORS_ORIGINS`.
 


### PR DESCRIPTION
Closes #767

## Summary
- centralize the canonical local preview origin constants in backend server config
- align env/runtime tests with the shared CORS default origin string
- document the preview origin so stale preview-port references are caught by tests