### PR TITLE
fix: stop exposing auth state to anonymous clients

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -96,8 +96,27 @@ const authErrorSchema = {
 };
 
 const invalidCredentialsResponse = { error: "Invalid username or password", code: "INVALID_CREDENTIALS" } as const;
+const publicAuthStateRateLimitConfig = {
+	max: 60,
+	timeWindow: "1 minute",
+	errorResponseBuilder: () => ({
+		error: "Too many requests. Please try again later.",
+		code: "RATE_LIMIT_EXCEEDED",
+	}),
+};
 
 type LoginFailureReason = "missing_user" | "wrong_password" | "inactive_account" | "sso_only_account";
+
+function toPublicAuthState(state: Awaited<ReturnType<typeof getAuthState>>) {
+	return {
+		authEnabled: state.authEnabled,
+		registrationEnabled: state.registrationEnabled,
+		formLoginEnabled: state.formLoginEnabled,
+		oidcEnabled: state.oidcEnabled,
+		oidcProviderName: state.oidcProviderName,
+		needsSetup: state.needsSetup,
+	};
+}
 
 async function performDummyCredentialWork() {
 	await argon2.hash("dummy", ARGON2_OPTIONS);
@@ -115,33 +134,42 @@ export async function authRoutes(app: FastifyInstance) {
 
 	// ---------------------------------------------------------------------------
 	// GET /auth/state - Public auth state (needed before login)
-	// Exempt from rate limit - lightweight state check called frequently
 	// ---------------------------------------------------------------------------
 	app.get(
 		"/auth/state",
 		{
-			config: { rateLimit: false },
+			config: { rateLimit: publicAuthStateRateLimitConfig },
 			schema: {
 				tags: ["auth"],
 				summary: "Get authentication state",
-				description: "Returns auth and login mode state before user login.",
+				description: "Returns the public auth and login mode state required before user login.",
 				response: {
 					200: {
 						type: "object",
+						additionalProperties: false,
+						required: [
+							"authEnabled",
+							"registrationEnabled",
+							"formLoginEnabled",
+							"oidcEnabled",
+							"oidcProviderName",
+							"needsSetup",
+						],
 						properties: {
 							authEnabled: { type: "boolean" },
 							registrationEnabled: { type: "boolean" },
 							formLoginEnabled: { type: "boolean" },
 							oidcEnabled: { type: "boolean" },
-							hasUsers: { type: "boolean" },
 							oidcProviderName: { type: "string" },
+							needsSetup: { type: "boolean" },
 						},
 					},
 				},
 			},
 		},
-		async () => {
-			return getAuthState();
+		async (_request, reply) => {
+			reply.header("Cache-Control", "no-store");
+			return toPublicAuthState(await getAuthState());
 		}
 	);
 

--- a/backend/src/test/auth.test.ts
+++ b/backend/src/test/auth.test.ts
@@ -33,6 +33,7 @@ vi.mock("../plugins/env.js", () => ({
 		FORM_LOGIN_ENABLED: true,
 		REGISTRATION_ENABLED: true,
 		OIDC_ENABLED: false,
+		OIDC_PROVIDER_NAME: "SSO",
 		NODE_ENV: "test",
 		LOG_LEVEL: "silent",
 		PORT: 3000,
@@ -155,17 +156,22 @@ describe("Auth Routes (AUTH_ENABLED=true)", () => {
 	// ---------------------------------------------------------------------------
 
 	describe("GET /auth/state", () => {
-		it("should return auth state", async () => {
+		it("should return only the unauthenticated public auth state", async () => {
 			const response = await app.inject({
 				method: "GET",
 				url: "/auth/state",
 			});
 
 			expect(response.statusCode).toBe(200);
-			const data = response.json();
-			expect(data.authEnabled).toBe(true);
-			expect(data.registrationEnabled).toBe(true);
-			expect(data.formLoginEnabled).toBe(true);
+			expect(response.headers["cache-control"]).toBe("no-store");
+			expect(response.json()).toEqual({
+				authEnabled: true,
+				registrationEnabled: true,
+				formLoginEnabled: true,
+				oidcEnabled: false,
+				oidcProviderName: "SSO",
+				needsSetup: true,
+			});
 		});
 	});
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,6 +23,17 @@ Cookie-auth state-changing route groups:
 
 Public token routes are not cookie-auth endpoints. Share links, share dose actions, and notification action tokens are authorized by their own opaque token values and must stay scoped to the token target.
 
+## Public Auth State
+
+`GET /auth/state` is intentionally public because the browser must know which login/setup UI to render before a user can authenticate. The response is limited to UX routing fields:
+
+- whether authentication is enabled
+- whether registration, form login, and OIDC login are available
+- the configured OIDC provider display name
+- whether first-user setup should be shown
+
+The endpoint does not expose user records, usernames, provider issuer URLs, client IDs, secrets, token settings, or the raw user count. It is rate-limited and sends `Cache-Control: no-store` so browser setup state does not become stale after first-user registration.
+
 ## CORS Expectations
 
 Credentialed browser CORS is allowed only for configured `CORS_ORIGINS`. An unconfigured browser origin does not receive `Access-Control-Allow-Origin`, so the browser cannot grant credentialed cross-origin API access. Requests from unconfigured origins may still reach the backend outside browser CORS enforcement, so server-side authentication and authorization remain mandatory.

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -24,7 +24,6 @@ export interface AuthState {
 	formLoginEnabled: boolean;
 	oidcEnabled: boolean;
 	oidcProviderName: string;
-	hasUsers: boolean;
 	needsSetup: boolean;
 }
 

--- a/frontend/src/test/components/AppHeader.test.tsx
+++ b/frontend/src/test/components/AppHeader.test.tsx
@@ -32,7 +32,6 @@ function mockAuthDisabled() {
 				Promise.resolve({
 					authEnabled: false,
 					formLoginEnabled: true,
-					hasUsers: false,
 					needsSetup: false,
 				}),
 		})
@@ -270,7 +269,6 @@ describe("AppHeader", () => {
 						formLoginEnabled: true,
 						oidcEnabled: false,
 						oidcProviderName: "",
-						hasUsers: true,
 						needsSetup: false,
 					}),
 			})

--- a/frontend/src/test/components/Auth.test.tsx
+++ b/frontend/src/test/components/Auth.test.tsx
@@ -216,7 +216,6 @@ describe("LoginForm", () => {
 		formLoginEnabled: true,
 		oidcEnabled: false,
 		registrationEnabled: true,
-		hasUsers: true,
 		needsSetup: false,
 		oidcProviderName: "",
 	};
@@ -334,7 +333,6 @@ describe("LoginForm", () => {
 						formLoginEnabled: true,
 						oidcEnabled: false,
 						registrationEnabled: true,
-						hasUsers: true,
 						needsSetup: false,
 						oidcProviderName: "",
 					}),
@@ -370,7 +368,6 @@ describe("RegisterForm", () => {
 		formLoginEnabled: true,
 		oidcEnabled: false,
 		registrationEnabled: true,
-		hasUsers: false,
 		needsSetup: true,
 		oidcProviderName: "",
 	};
@@ -457,7 +454,6 @@ describe("RegisterForm", () => {
 					formLoginEnabled: true,
 					oidcEnabled: false,
 					registrationEnabled: true,
-					hasUsers: false,
 					needsSetup: true,
 					oidcProviderName: "",
 				}),
@@ -492,7 +488,6 @@ describe("AuthPage", () => {
 		formLoginEnabled: true,
 		oidcEnabled: false,
 		registrationEnabled: true,
-		hasUsers: true,
 		needsSetup: false,
 		oidcProviderName: "",
 	};


### PR DESCRIPTION
Closes #768

## Summary
- restrict `/auth/state` to the public UX fields required before login
- add rate limiting and `Cache-Control: no-store` for the anonymous auth-state response
- update backend/frontend tests and security documentation to lock the public contract