### PR TITLE
fix: harden openapi exposure defaults

### DIFF
--- a/backend/src/test/api-docs.test.ts
+++ b/backend/src/test/api-docs.test.ts
@@ -35,6 +35,7 @@ vi.mock("../plugins/env.js", () => ({
 }));
 
 const { registerApiDocs } = await import("../plugins/api-docs.js");
+const { requireAuth } = await import("../plugins/auth.js");
 
 async function createSchema(client: Client) {
 	await client.execute(`
@@ -77,6 +78,7 @@ async function buildDocsApp(options: { docsEnabled: boolean; docsAuthRequired: b
 		enabled: options.docsEnabled,
 		authRequired: options.docsAuthRequired,
 	});
+	app.get("/protected", { preHandler: requireAuth }, async () => ({ ok: true }));
 	await app.ready();
 	return app;
 }
@@ -168,6 +170,21 @@ describe("OpenAPI docs protection", () => {
 				openapi: "3.0.3",
 				info: { title: "MedAssist-ng API" },
 			});
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("does not bypass protected API route auth when anonymous docs are enabled", async () => {
+		const app = await buildDocsApp({ docsEnabled: true, docsAuthRequired: false });
+
+		try {
+			const docsResponse = await app.inject({ method: "GET", url: "/docs/json" });
+			const protectedResponse = await app.inject({ method: "GET", url: "/protected" });
+
+			expect(docsResponse.statusCode).toBe(200);
+			expect(protectedResponse.statusCode).toBe(401);
+			expect(protectedResponse.json()).toEqual({ error: "Authentication required", code: "AUTH_REQUIRED" });
 		} finally {
 			await app.close();
 		}

--- a/backend/src/test/env-runtime.test.ts
+++ b/backend/src/test/env-runtime.test.ts
@@ -67,6 +67,21 @@ describe("plugins/env runtime validation", () => {
 		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
 	});
 
+	it("keeps docs disabled by default when production auth is enabled", async () => {
+		process.env.NODE_ENV = "production";
+		process.env.AUTH_ENABLED = "true";
+		process.env.JWT_SECRET = "jwt-secret-for-runtime-test";
+		process.env.REFRESH_SECRET = "refresh-secret-runtime-test";
+		process.env.COOKIE_SECRET = "cookie-secret-runtime-test";
+		process.env.API_KEY_PEPPER = "a".repeat(64);
+		delete process.env.OPENAPI_DOCS_ENABLED;
+		delete process.env.DOCS_AUTH_REQUIRED;
+
+		const mod = await import("../plugins/env.js");
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(false);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(true);
+	});
+
 	it("requires docs auth by default when auth is enabled", async () => {
 		process.env.NODE_ENV = "production";
 		process.env.AUTH_ENABLED = "true";
@@ -174,11 +189,15 @@ describe("plugins/env runtime validation", () => {
 		process.env.AUTH_ENABLED = "false";
 		delete process.env.ALLOW_UNAUTHENTICATED;
 		delete process.env.OIDC_ENABLED;
+		delete process.env.OPENAPI_DOCS_ENABLED;
+		delete process.env.DOCS_AUTH_REQUIRED;
 
 		const mod = await import("../plugins/env.js");
 		expect(mod.env.NODE_ENV).toBe("development");
 		expect(mod.env.AUTH_ENABLED).toBe(false);
 		expect(mod.env.ALLOW_UNAUTHENTICATED).toBe(false);
+		expect(mod.env.OPENAPI_DOCS_ENABLED).toBe(true);
+		expect(mod.env.DOCS_AUTH_REQUIRED).toBe(false);
 	});
 
 	it("exits when auth is enabled but secrets are missing", async () => {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,6 +29,12 @@ Credentialed browser CORS is allowed only for configured `CORS_ORIGINS`. An unco
 
 Public notification action routes allow arbitrary browser origins without credentials. This is intentional so external notification providers can send token-based actions without receiving browser session cookies.
 
+## OpenAPI Docs Exposure
+
+`/docs` and `/docs/json` are enabled by default only outside production. Production deployments should leave `OPENAPI_DOCS_ENABLED` unset or set it to `false` unless interactive API docs are intentionally needed.
+
+When docs are enabled while `AUTH_ENABLED=true`, `DOCS_AUTH_REQUIRED` defaults to `true`. If a deployment explicitly sets `DOCS_AUTH_REQUIRED=false`, only the documentation routes become public; protected API routes still require their normal cookie, Bearer JWT, or API-key authentication.
+
 ## CSRF Decision
 
 No additional CSRF token is required for the current browser contract because state-changing session requests rely on `SameSite=Lax`, credentialed CORS allowlists, JSON/fetch-based clients, server-side auth, and current-password checks for sensitive account changes.


### PR DESCRIPTION
Closes #769

## Summary
- document and test that production keeps OpenAPI docs disabled by default
- lock the explicit opt-in behavior for docs exposure when auth is enabled
- verify public docs do not bypass protected API route authentication