### PR TITLE
fix(ci): harden Dependabot automerge workflow and CodeQL check context

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -45,11 +45,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: javascript-typescript
-            autobuild: true
-          - language: actions
-            autobuild: false
+        language:
+          - javascript-typescript
+          - actions
 
     steps:
       - name: Checkout repository
@@ -62,7 +60,7 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        if: matrix.autobuild
+        if: matrix.language == 'javascript-typescript'
         uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Enable auto-merge for safe updates
         if: >-
           (steps.metadata.outputs.package-ecosystem == 'npm' ||
+          steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' ||
           steps.metadata.outputs.package-ecosystem == 'github_actions') &&
           (contains(steps.metadata.outputs.update-type, 'version-update:semver-minor') ||
           contains(steps.metadata.outputs.update-type, 'version-update:semver-patch'))

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -91,6 +91,8 @@ Use the root-level commands for full-stack validation when a change spans backen
 - Within product-relevant PRs, required product checks still emit their stable names and report a no-op success when a backend/frontend lane is not relevant inside that product scope.
 - Workflow-only edits are validated by `Workflow Validation / Actionlint`; they do not trigger backend/frontend/Playwright/container smoke lanes by themselves, but they still run CodeQL for the `actions` language.
 - Release-relevant PRs also run `.github/workflows/container-smoke.yml` as a dedicated container runtime check.
+- Dependabot auto-merge for safe updates is gated by `.github/workflows/dependabot-automerge.yml` and currently allows `npm`, `npm_and_yarn`, and `github_actions` ecosystems for semver minor/patch updates only.
+- The default-branch ruleset requires the stable CodeQL context `Analyze (javascript-typescript)`, so workflow changes must keep the CodeQL job name aligned with that exact required-check context.
 - Docker publishing is handled by `.github/workflows/docker-build.yml`.
 - The reusable container smoke workflow is used in two places:
   - directly on release-relevant PRs as the visible `Container Smoke` check


### PR DESCRIPTION
## Summary
- accept `npm_and_yarn` as valid `package-ecosystem` in Dependabot automerge workflow logic
- stabilize CodeQL required check context to `Analyze (javascript-typescript)` by using language-only matrix naming
- document the Dependabot auto-merge behavior and troubleshooting notes in development docs

## Scope
This PR intentionally contains only:
- `.github/workflows/dependabot-automerge.yml`
- `.github/workflows/codeql.yml`
- `docs/DEVELOPMENT.md`

## Validation
- branch is based on current `main`
- single cohesive CI/workflow hardening + docs update