### PR TITLE
fix: run dependabot automerge on synchronize events

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   enable-automerge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- update Dependabot automerge workflow guard to check PR author login instead of event actor
- ensure synchronize/update events on Dependabot-authored PRs still run the enable-automerge job

## Why
Synchronize/update events can be triggered by actors other than `dependabot[bot]`, which caused the job to be skipped even for Dependabot PRs.

## Scope
- .github/workflows/dependabot-automerge.yml only