### PR TITLE
fix: bump shared package version to 1.27.5 to match release

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

The v1.27.5 release PR (#780) bumped `backend/package.json` and `frontend/package.json` to `1.27.5` but missed `shared/package.json`, which is still at `1.27.4` on `main`.

This causes the `docker-build.yml` release-preflight check to fail with a version mismatch error, blocking Docker image builds for v1.27.5.

## Changes

- Bump `shared/package.json` version from `1.27.4` to `1.27.5` to match backend and frontend

## Verification

All three version files now report `1.27.5`:
```
backend/package.json:  "version": "1.27.5"
frontend/package.json: "version": "1.27.5"
shared/package.json:   "version": "1.27.5"
```