### PR TITLE
fix: update lockfile versions to 1.27.5 to pass release preflight

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "dependencies": {
         "@medassist/shared": "file:../shared",
         "i18next": "^26.3.1",
@@ -37,7 +37,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"


### PR DESCRIPTION
## Summary

The `docker-build.yml` `create-release` job fails its release preflight check because `backend/package-lock.json`, `frontend/package-lock.json`, and `shared/package-lock.json` still report version `1.27.4` while all `package.json` files are at `1.27.5`.

This PR updates all three lockfiles to `1.27.5` so the release preflight passes and the Docker build can create the GitHub release assets.

## Changes

- Update `backend/package-lock.json` root version to `1.27.5`
- Update `frontend/package-lock.json` root version to `1.27.5`
- Update `shared/package-lock.json` root version to `1.27.5`