### PR TITLE
test: strengthen medication domain safety gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,9 +105,6 @@ docs/SPEC_KIT.md
 .github/skills/seo/
 .playwright-mcp
 
-# Local copilot generated workspace artifacts (not for upstream)
-.github/agents/copilot-instructions.md
-.github/agents/medassist-feature-orchestrator.agent.md
-.github/agents/speckit.*.agent.md
-.github/prompts/speckit.*.prompt.md
 ops/medtest/
+.kilo/kilo.json
+.kilo/kilo.jsonc

--- a/backend/src/test/domain-safety.test.ts
+++ b/backend/src/test/domain-safety.test.ts
@@ -16,7 +16,13 @@ import {
 	getTodayInTimezone,
 	parseLocalDateTime,
 } from "../utils/scheduler-utils.js";
-import { dstCorpus, scheduleCorpus, stockPropertyCorpus } from "./fixtures/domain-safety-corpus.js";
+import {
+	dstCorpus,
+	expiryPrescriptionThresholdCorpus,
+	refillBaselineRegressionCorpus,
+	scheduleCorpus,
+	stockPropertyCorpus,
+} from "./fixtures/domain-safety-corpus.js";
 
 const { testClient, testDb, testDbPath, mockedEnv } = vi.hoisted(() => {
 	const { tmpdir } = require("node:os");
@@ -61,6 +67,7 @@ const { medicationRoutes } = await import("../routes/medications.js");
 const { doseRoutes } = await import("../routes/doses.js");
 const { shareRoutes } = await import("../routes/share.js");
 const { exportRoutes } = await import("../routes/export.js");
+const { refillRoutes } = await import("../routes/refills.js");
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -76,6 +83,9 @@ type MedicationPayload = {
 	pillsPerBlister?: number;
 	looseTablets?: number;
 	totalPills?: number | null;
+	packageAmountValue?: number;
+	packageAmountUnit?: "ml" | "g";
+	doseUnit?: "mg" | "g" | "mcg" | "ml" | "IU" | "units" | "drops" | "puffs" | "injections";
 	expiryDate?: string | null;
 	prescriptionEnabled?: boolean;
 	prescriptionAuthorizedRefills?: number | null;
@@ -164,9 +174,10 @@ async function createMedication(
 			pillsPerBlister: isAmountBased ? 1 : (payload.pillsPerBlister ?? 10),
 			looseTablets: payload.looseTablets ?? 0,
 			totalPills: payload.totalPills ?? null,
-			packageAmountValue: packageType === "tube" || packageType === "liquid_container" ? 30 : 0,
-			packageAmountUnit: packageType === "tube" ? "g" : "ml",
-			doseUnit: medicationForm === "liquid" ? "ml" : "mg",
+			packageAmountValue:
+				payload.packageAmountValue ?? (packageType === "tube" || packageType === "liquid_container" ? 30 : 0),
+			packageAmountUnit: payload.packageAmountUnit ?? (packageType === "tube" ? "g" : "ml"),
+			doseUnit: payload.doseUnit ?? (medicationForm === "liquid" ? "ml" : "mg"),
 			takenBy: payload.takenBy ?? [],
 			...payload,
 		},
@@ -311,6 +322,7 @@ describe("Domain safety corpus: real route and service flows", () => {
 		await app.register(shareRoutes);
 		await app.register(doseRoutes);
 		await app.register(exportRoutes);
+		await app.register(refillRoutes);
 		await app.ready();
 	});
 
@@ -447,6 +459,121 @@ describe("Domain safety corpus: real route and service flows", () => {
 			args: [1],
 		});
 		expect(Number(count.rows[0].count)).toBe(0);
+	});
+
+	it.each(expiryPrescriptionThresholdCorpus)("covers $name", async (testCase) => {
+		await seedSettings({ stockCalculationMode: "automatic", expiryWarningDays: testCase.expiryWarningDays });
+		await createMedication(app, {
+			name: "Expiry Prescription Safety",
+			takenBy: ["Alice"],
+			looseTablets: 10,
+			expiryDate: testCase.expiryDate,
+			prescriptionEnabled: true,
+			prescriptionAuthorizedRefills: testCase.prescriptionAuthorizedRefills,
+			prescriptionRemainingRefills: testCase.prescriptionRemainingRefills,
+			prescriptionLowRefillThreshold: testCase.prescriptionLowRefillThreshold,
+			prescriptionExpiryDate: testCase.prescriptionExpiryDate,
+			intakes: [{ usage: 1, every: 1, start: "2026-06-03T08:00:00", takenBy: "Alice" }],
+		});
+
+		const medicationsResponse = await app.inject({ method: "GET", url: "/medications" });
+		expect(medicationsResponse.statusCode).toBe(200);
+		expect(medicationsResponse.json()).toEqual([
+			expect.objectContaining({
+				expiryDate: testCase.expiryDate,
+				prescriptionEnabled: true,
+				prescriptionAuthorizedRefills: testCase.prescriptionAuthorizedRefills,
+				prescriptionRemainingRefills: testCase.prescriptionRemainingRefills,
+				prescriptionLowRefillThreshold: testCase.prescriptionLowRefillThreshold,
+				prescriptionExpiryDate: testCase.prescriptionExpiryDate,
+			}),
+		]);
+
+		const shareResponse = await app.inject({
+			method: "POST",
+			url: "/share",
+			payload: { takenBy: "Alice", scheduleDays: 14, expiryDays: null },
+		});
+		expect(shareResponse.statusCode).toBe(200);
+
+		const shareRead = await app.inject({ method: "GET", url: `/share/${shareResponse.json().token}` });
+		expect(shareRead.statusCode).toBe(200);
+		expect(shareRead.json().stockThresholds.expiryWarningDays).toBe(testCase.expiryWarningDays);
+
+		const invalidThreshold = await app.inject({
+			method: "POST",
+			url: "/medications",
+			payload: {
+				name: "Invalid Prescription Threshold",
+				medicationForm: "tablet",
+				pillForm: "tablet",
+				packageType: "blister",
+				packCount: 1,
+				blistersPerPack: 1,
+				pillsPerBlister: 10,
+				looseTablets: 0,
+				prescriptionEnabled: true,
+				prescriptionAuthorizedRefills: 1,
+				prescriptionRemainingRefills: 1,
+				prescriptionLowRefillThreshold: 2,
+				intakes: [{ usage: 1, every: 1, start: "2026-06-03T08:00:00" }],
+			},
+		});
+		expect(invalidThreshold.statusCode).toBe(400);
+	});
+
+	it.each(refillBaselineRegressionCorpus)("protects known bug regression: $name", async (testCase) => {
+		await seedSettings({ stockCalculationMode: "manual" });
+		const medication = await createMedication(app, {
+			name: "Manual Liquid Refill Safety",
+			medicationForm: "liquid",
+			packageType: "liquid_container",
+			doseUnit: "ml",
+			packCount: 1,
+			blistersPerPack: 1,
+			pillsPerBlister: 1,
+			packageAmountValue: testCase.initialQuantity,
+			packageAmountUnit: "ml",
+			totalPills: testCase.initialQuantity,
+			looseTablets: testCase.initialQuantity,
+			intakes: [{ usage: testCase.doseUsage, every: 1, start: "2025-01-01T08:00:00" }],
+		});
+
+		await insertDose({
+			doseId: doseId(medication.id, 0, testCase.preRefillDoseDate),
+			takenAt: `${testCase.preRefillDoseDate}T10:00:00.000Z`,
+		});
+
+		const refillResponse = await app.inject({
+			method: "POST",
+			url: `/medications/${medication.id}/refill`,
+			payload: {
+				packsAdded: 1,
+				loosePillsAdded: testCase.refillQuantity,
+				quantityAdded: testCase.refillQuantity,
+			},
+		});
+		expect(refillResponse.statusCode).toBe(200);
+		expect(refillResponse.json().newStock.totalPills).toBe(testCase.initialQuantity + testCase.refillQuantity);
+
+		await testDb
+			.update(medications)
+			.set({ lastStockCorrectionAt: new Date("2026-01-01T00:00:00.000Z") })
+			.where(eq(medications.id, medication.id));
+
+		for (const postRefillDoseDate of testCase.postRefillDoseDates) {
+			const response = await app.inject({
+				method: "POST",
+				url: "/doses/taken",
+				payload: { doseId: doseId(medication.id, 0, postRefillDoseDate) },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json()).toEqual({ success: true });
+		}
+
+		const usageRow = await getUsageRow(app, medication.name);
+		expect(usageRow.currentPills).toBe(0);
 	});
 
 	it("keeps share schedules scoped to per-intake takenBy and invalidates regenerated tokens", async () => {

--- a/backend/src/test/fixtures/domain-safety-corpus.ts
+++ b/backend/src/test/fixtures/domain-safety-corpus.ts
@@ -104,3 +104,26 @@ export const stockPropertyCorpus = [
 	{ name: "small stock and many repeated historical doses", stock: 3, doseCount: 12 },
 	{ name: "larger stock still clamps after excessive history", stock: 10, doseCount: 30 },
 ] as const;
+
+export const expiryPrescriptionThresholdCorpus = [
+	{
+		name: "expiry warning days and low prescription refill threshold stay explicit",
+		expiryWarningDays: 21,
+		expiryDate: "2026-07-01",
+		prescriptionAuthorizedRefills: 4,
+		prescriptionRemainingRefills: 1,
+		prescriptionLowRefillThreshold: 2,
+		prescriptionExpiryDate: "2026-08-15",
+	},
+] as const;
+
+export const refillBaselineRegressionCorpus = [
+	{
+		name: "manual liquid refill baseline ignores pre-refill history",
+		initialQuantity: 5,
+		refillQuantity: 5,
+		doseUsage: 5,
+		preRefillDoseDate: "2025-01-05",
+		postRefillDoseDates: ["2026-01-06", "2026-01-07"],
+	},
+] as const;

--- a/frontend/e2e/domain-safety.spec.ts
+++ b/frontend/e2e/domain-safety.spec.ts
@@ -10,11 +10,36 @@ import {
 	updateSettingsViaAPI,
 } from "./fixtures";
 
-function localDateTimeForToday(hour: number, minute: number): string {
-	const date = new Date();
-	date.setHours(hour, minute, 0, 0);
+type PlannerUsageRequest = {
+	startDate: string;
+	endDate: string;
+	includeUntilStart?: boolean;
+};
+
+function formatDateTimeLocal(date: Date): string {
 	const pad = (value: number) => value.toString().padStart(2, "0");
 	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function localDateTimeForOffset(daysFromToday: number, hour: number, minute: number): string {
+	const date = new Date();
+	date.setDate(date.getDate() + daysFromToday);
+	date.setHours(hour, minute, 0, 0);
+	return formatDateTimeLocal(date);
+}
+
+function localDateTimeForToday(hour: number, minute: number): string {
+	return localDateTimeForOffset(0, hour, minute);
+}
+
+function addLocalDays(dateTimeValue: string, days: number): string {
+	const date = new Date(dateTimeValue);
+	date.setDate(date.getDate() + days);
+	return formatDateTimeLocal(date);
+}
+
+function normalizeText(value: string | null | undefined): string {
+	return value?.replace(/\s+/g, " ").trim() ?? "";
 }
 
 async function calculatePlanner(page: Page): Promise<void> {
@@ -23,12 +48,69 @@ async function calculatePlanner(page: Page): Promise<void> {
 	await expect(page.locator(".table")).toBeVisible({ timeout: 15000 });
 }
 
+async function calculatePlannerWithRequest(page: Page): Promise<PlannerUsageRequest> {
+	await page.waitForLoadState("networkidle");
+	const responsePromise = page.waitForResponse(
+		(response) => response.url().includes("/api/medications/usage") && response.request().method() === "POST"
+	);
+	await page.locator('form.planner button[type="submit"]').click();
+	const response = await responsePromise;
+	expect(response.ok()).toBe(true);
+	await expect(page.locator(".table")).toBeVisible({ timeout: 15000 });
+
+	return JSON.parse(response.request().postData() ?? "{}") as PlannerUsageRequest;
+}
+
+async function setPlannerRange(page: Page, start: string, end: string): Promise<void> {
+	const dateInputs = page.locator('form.planner input[type="datetime-local"]');
+	await expect(dateInputs.first()).toBeAttached();
+	await dateInputs.first().fill(start);
+	await dateInputs.last().fill(end);
+	await expect(dateInputs.first()).toHaveValue(start);
+	await expect(dateInputs.last()).toHaveValue(end);
+}
+
+async function expectedDateTimeDisplay(page: Page, value: string, locale: string): Promise<string> {
+	return page.evaluate(
+		({ dateTimeValue, displayLocale }) => {
+			const match = dateTimeValue.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/);
+			if (!match) return "";
+			const [, year, month, day, hour, minute] = match;
+			const date = new Date(`${year}-${month}-${day}T${hour}:${minute}:00`);
+			const dateText = date.toLocaleDateString(displayLocale, {
+				year: "numeric",
+				month: "2-digit",
+				day: "2-digit",
+			});
+			const timeText = date.toLocaleTimeString(displayLocale, {
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+			return `${dateText} ${timeText}`;
+		},
+		{ dateTimeValue: value, displayLocale: locale }
+	);
+}
+
+async function expectPlannerStartDisplay(page: Page, start: string, locale: string): Promise<void> {
+	const expectedDisplay = await expectedDateTimeDisplay(page, start, locale);
+	await expect(page.locator("form.planner .date-input-display").first()).toHaveText(expectedDisplay);
+}
+
 async function getPlannerUsage(page: Page, medicationName: string): Promise<string> {
 	const row = page.locator(".table-row", { hasText: medicationName });
 	await expect(row).toBeVisible({ timeout: 15000 });
 	const usage = await row.locator("[data-label] strong").first().textContent();
 	expect(usage).toBeTruthy();
 	return usage ?? "";
+}
+
+async function getPlannerRowSnapshot(page: Page, medicationName: string): Promise<string[]> {
+	const row = page.locator(".table-row", { hasText: medicationName });
+	await expect(row).toBeVisible({ timeout: 15000 });
+	const cells = await row.locator("[data-label]").allTextContents();
+	expect(cells.length).toBeGreaterThanOrEqual(6);
+	return cells.map(normalizeText);
 }
 
 async function exportData(page: Page): Promise<unknown> {
@@ -66,6 +148,35 @@ async function getShareDoses(page: Page, token: string): Promise<Array<{ doseId:
 	}, token);
 }
 
+async function getSettingsTimezone(page: Page): Promise<string> {
+	return page.evaluate(async () => {
+		const response = await fetch("/api/settings", { credentials: "include" });
+		if (!response.ok) {
+			throw new Error(`Settings read failed: ${response.status}`);
+		}
+		const body = (await response.json()) as { timezone: string };
+		return body.timezone;
+	});
+}
+
+async function saveTimezoneFromUi(page: Page, timezone: string): Promise<void> {
+	await navigateTo(page, "/settings");
+
+	const timezoneInput = page.locator('input[list="settings-timezone-suggestions"]');
+	await expect(timezoneInput).toBeVisible();
+
+	const settingsSaved = page.waitForResponse(
+		(response) => response.url().includes("/api/settings") && response.request().method() === "PUT"
+	);
+	await timezoneInput.fill(timezone);
+	await timezoneInput.press("Enter");
+	const response = await settingsSaved;
+	expect(response.ok()).toBe(true);
+
+	await expect(timezoneInput).toHaveValue(timezone);
+	await expect.poll(() => getSettingsTimezone(page)).toBe(timezone);
+}
+
 test.describe("Domain safety flows", () => {
 	test.use({ storageState: authFile });
 	test.describe.configure({ mode: "serial", timeout: 90000 });
@@ -93,6 +204,7 @@ test.describe("Domain safety flows", () => {
 
 		await page.goto(`/share/${share.token}`);
 		await page.waitForLoadState("networkidle");
+		expect(await getShareDoses(page, share.token)).toEqual([]);
 		await expect(page.locator(".shared-schedule-loading-skeleton")).toBeHidden({ timeout: 10000 });
 		await expect(page.locator(".med-name-text").filter({ hasText: medicationName }).first()).toBeVisible({
 			timeout: 15000,
@@ -118,34 +230,59 @@ test.describe("Domain safety flows", () => {
 		await expect
 			.poll(async () => (await getShareDoses(page, share.token)).some((dose) => dose.doseId === markedDoseId))
 			.toBe(false);
+		await expect.poll(async () => (await getShareDoses(page, share.token)).length).toBe(0);
 	});
 
-	test("settings timezone override is saved from the UI", async ({ page }) => {
-		await updateSettingsViaAPI({ timezone: "" });
-		await navigateTo(page, "/settings");
+	test("settings timezone override updates planner display and calculation request", async ({ page }) => {
+		const suffix = Date.now().toString(36);
+		const medicationName = `Domain Timezone Planner ${suffix}`;
+		const plannerStart = localDateTimeForOffset(10, 8, 30);
+		const plannerEnd = addLocalDays(plannerStart, 3);
 
-		const timezoneInput = page.locator('input[list="settings-timezone-suggestions"]');
-		await expect(timezoneInput).toBeVisible();
-
-		const settingsSaved = page.waitForResponse(
-			(response) => response.url().includes("/api/settings") && response.request().method() === "PUT"
-		);
-		await timezoneInput.fill("America/New_York");
-		await timezoneInput.press("Enter");
-		await settingsSaved;
-
-		await expect(timezoneInput).toHaveValue("America/New_York");
-		const savedTimezone = await page.evaluate(async () => {
-			const response = await fetch("/api/settings", { credentials: "include" });
-			const body = (await response.json()) as { timezone: string };
-			return body.timezone;
+		await deleteAllMedicationsViaAPI();
+		await createMedicationViaAPI({
+			name: medicationName,
+			packageType: "blister",
+			packCount: 2,
+			blistersPerPack: 2,
+			pillsPerBlister: 10,
+			intakes: [{ usage: 2, every: 1, start: plannerStart }],
 		});
-		expect(savedTimezone).toBe("America/New_York");
+
+		await saveTimezoneFromUi(page, "America/New_York");
+		await navigateTo(page, "/planner");
+		await setPlannerRange(page, plannerStart, plannerEnd);
+		await expectPlannerStartDisplay(page, plannerStart, "en-US");
+
+		const newYorkRequest = await calculatePlannerWithRequest(page);
+		const expectedStartIso = await page.evaluate((value) => new Date(value).toISOString(), plannerStart);
+		const expectedEndIso = await page.evaluate((value) => new Date(value).toISOString(), plannerEnd);
+		expect(newYorkRequest).toMatchObject({
+			startDate: expectedStartIso,
+			endDate: expectedEndIso,
+			includeUntilStart: false,
+		});
+		expect(await getPlannerUsage(page, medicationName)).toBe("6");
+
+		await saveTimezoneFromUi(page, "Europe/Berlin");
+		await navigateTo(page, "/planner");
+		await setPlannerRange(page, plannerStart, plannerEnd);
+		await expectPlannerStartDisplay(page, plannerStart, "de-DE");
+
+		const berlinRequest = await calculatePlannerWithRequest(page);
+		expect(berlinRequest).toMatchObject({
+			startDate: expectedStartIso,
+			endDate: expectedEndIso,
+			includeUntilStart: false,
+		});
+		expect(await getPlannerUsage(page, medicationName)).toBe("6");
 	});
 
 	test("export/import restore produces equivalent planner usage", async ({ page }) => {
 		const suffix = Date.now().toString(36);
 		const medicationName = `Domain Roundtrip Planner ${suffix}`;
+		const plannerStart = localDateTimeForOffset(14, 7, 45);
+		const plannerEnd = addLocalDays(plannerStart, 5);
 
 		await deleteAllMedicationsViaAPI();
 		await createMedicationViaAPI({
@@ -158,17 +295,22 @@ test.describe("Domain safety flows", () => {
 		});
 
 		await navigateTo(page, "/planner");
+		await setPlannerRange(page, plannerStart, plannerEnd);
 		await calculatePlanner(page);
 		const beforeUsage = await getPlannerUsage(page, medicationName);
+		const beforeRow = await getPlannerRowSnapshot(page, medicationName);
 		const exported = await exportData(page);
 
 		await deleteAllMedicationsViaAPI();
 		await importData(page, exported);
 
 		await navigateTo(page, "/planner");
+		await setPlannerRange(page, plannerStart, plannerEnd);
 		await calculatePlanner(page);
 		const afterUsage = await getPlannerUsage(page, medicationName);
+		const afterRow = await getPlannerRowSnapshot(page, medicationName);
 
 		expect(afterUsage).toBe(beforeUsage);
+		expect(afterRow).toEqual(beforeRow);
 	});
 });

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -197,6 +197,20 @@ function requireDockerPattern(dockerfilePath, dockerfile, pattern, description) 
   }
 }
 
+function requireScriptPattern(packageJsonPath, packageJson, scriptName, pattern, description) {
+  const script = packageJson.scripts?.[scriptName];
+  if (typeof script !== "string" || !pattern.test(script)) {
+    fail(`${packageJsonPath} ${scriptName} must ${description}.`);
+  }
+}
+
+function requireTextPattern(filePath, pattern, description) {
+  const content = readText(filePath);
+  if (!pattern.test(content)) {
+    fail(`${filePath} must ${description}.`);
+  }
+}
+
 function validateDockerSharedBuild(dockerfilePath, { requiresRuntimeCopy }) {
   const dockerfile = readText(dockerfilePath);
 
@@ -230,7 +244,38 @@ function validateDockerSharedBuild(dockerfilePath, { requiresRuntimeCopy }) {
   }
 }
 
+function validateDomainSafetyGate(rootPackage, backendPackage, frontendPackage) {
+  requireScriptPattern(
+    "package.json",
+    rootPackage,
+    "test:domain",
+    /backend[\s\S]*npm run test:domain[\s\S]*frontend[\s\S]*npm run test:e2e:domain/,
+    "run the backend and frontend domain safety gates"
+  );
+  requireScriptPattern(
+    "backend/package.json",
+    backendPackage,
+    "test:domain",
+    /src\/test\/domain-safety\.test\.ts/,
+    "run backend/src/test/domain-safety.test.ts"
+  );
+  requireScriptPattern(
+    "frontend/package.json",
+    frontendPackage,
+    "test:e2e:domain",
+    /e2e\/domain-safety\.spec\.ts/,
+    "run frontend/e2e/domain-safety.spec.ts"
+  );
+  requireTextPattern(".github/workflows/test.yml", /run:\s*npm run test:domain/, "run the domain safety release gate");
+  requireTextPattern(
+    ".github/workflows/e2e.yml",
+    /run:\s*npm run test:e2e:domain/,
+    "run the domain E2E release gate"
+  );
+}
+
 function validatePolicy(releaseTag, releaseVersion) {
+  const rootPackage = readJson("package.json");
   const policy = readJson("release-policy.json");
   const backendPackage = readJson("backend/package.json");
   const frontendPackage = readJson("frontend/package.json");
@@ -273,6 +318,7 @@ function validatePolicy(releaseTag, releaseVersion) {
 
   validateDockerSharedBuild("backend/Dockerfile", { requiresRuntimeCopy: true });
   validateDockerSharedBuild("frontend/Dockerfile", { requiresRuntimeCopy: false });
+  validateDomainSafetyGate(rootPackage, backendPackage, frontendPackage);
 }
 
 function main() {

--- a/scripts/test-release-preflight.mjs
+++ b/scripts/test-release-preflight.mjs
@@ -9,11 +9,14 @@ import test from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const preflightScript = path.join(repoRoot, "scripts/release-preflight.mjs");
-const releaseTag = "v1.27.4";
+const releaseVersion = JSON.parse(readFileSync(path.join(repoRoot, "backend/package.json"), "utf8")).version;
+const releaseTag = `v${releaseVersion}`;
+const escapedReleaseVersion = releaseVersion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 function copyFixture() {
   const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "medassist-release-preflight-"));
   const pathsToCopy = [
+    "package.json",
     "release-policy.json",
     "docker-compose.yml",
     "backend/package.json",
@@ -24,7 +27,9 @@ function copyFixture() {
     "frontend/Dockerfile",
     "shared/package.json",
     "shared/package-lock.json",
-    ".github/workflows/docker-build.yml"
+    ".github/workflows/docker-build.yml",
+    ".github/workflows/test.yml",
+    ".github/workflows/e2e.yml"
   ];
 
   for (const relativePath of pathsToCopy) {
@@ -79,7 +84,7 @@ test("release preflight rejects shared package version drift", () => {
     sharedPackage.version = "1.27.2";
     writeJson(fixtureRoot, "shared/package.json", sharedPackage);
 
-    expectPreflightFailure(fixtureRoot, /shared\/package\.json version must match 1\.27\.4/);
+    expectPreflightFailure(fixtureRoot, new RegExp(`shared/package\\.json version must match ${escapedReleaseVersion}`));
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
@@ -92,7 +97,10 @@ test("release preflight rejects local shared lockfile drift", () => {
     backendLockfile.packages["../shared"].version = "1.27.2";
     writeJson(fixtureRoot, "backend/package-lock.json", backendLockfile);
 
-    expectPreflightFailure(fixtureRoot, /backend\/package-lock\.json \.\.\/shared version must match 1\.27\.4/);
+    expectPreflightFailure(
+      fixtureRoot,
+      new RegExp(`backend/package-lock\\.json \\.\\./shared version must match ${escapedReleaseVersion}`)
+    );
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
@@ -109,6 +117,67 @@ test("release preflight rejects Dockerfiles that do not build shared from source
     writeFileSync(frontendDockerfilePath, frontendDockerfile);
 
     expectPreflightFailure(fixtureRoot, /frontend\/Dockerfile must build the shared package from source/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects missing backend domain safety gate script", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const backendPackage = readJson(fixtureRoot, "backend/package.json");
+    backendPackage.scripts["test:domain"] = "vitest run src/test/server.test.ts";
+    writeJson(fixtureRoot, "backend/package.json", backendPackage);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /backend\/package\.json test:domain must run backend\/src\/test\/domain-safety\.test\.ts/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects missing frontend domain E2E gate script", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const frontendPackage = readJson(fixtureRoot, "frontend/package.json");
+    frontendPackage.scripts["test:e2e:domain"] = "playwright test --config=playwright.stable.config.ts e2e/planner.spec.ts";
+    writeJson(fixtureRoot, "frontend/package.json", frontendPackage);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /frontend\/package\.json test:e2e:domain must run frontend\/e2e\/domain-safety\.spec\.ts/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects CI workflow without the domain safety release gate", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/test.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace("run: npm run test:domain", "run: npm run test:run");
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(fixtureRoot, /\.github\/workflows\/test\.yml must run the domain safety release gate/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects CI workflow without the domain E2E release gate", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/e2e.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      "run: npm run test:e2e:domain",
+      "run: npx playwright test --project=chromium"
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(fixtureRoot, /\.github\/workflows\/e2e\.yml must run the domain E2E release gate/);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Strengthen backend medication domain safety coverage for scheduling, stock, refill, expiry, prescription, sharing, and import/export regressions.
- Add frontend domain E2E coverage for shared schedule and planner/export-import flows.
- Extend release preflight checks to require the backend and frontend domain safety gates in local scripts and CI workflows.

## Validation
- `cd backend && CI=true npm run test:domain` passed: 21 tests.
- `cd frontend && PLAYWRIGHT_HTML_OPEN=never PLAYWRIGHT_WORKERS=1 npm run test:e2e:domain` passed: 4 tests.
- `node --test scripts/test-release-preflight.mjs` passed: 8 tests.
- `npm run lint` passed.
- `npm run check` passed.

Closes #785