### PR TITLE
chore: streamline agent instructions and ignores

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,75 +1,58 @@
 # MedAssist Copilot Instructions
 
-This is the single committed instruction source for Copilot and remote/cloud agent sessions.
+Committed entry point for Copilot and remote/cloud agent sessions.
 
-If a local-only `AGENTS.md` exists in the current workspace, treat it as an optional local overlay for that checkout only.
+If `AGENTS.md` exists in the checkout or is provided in the session context, treat it as the canonical repository governance file. This file is only the portable baseline for sessions that do not have the local overlay.
 
-## Required startup steps
+## Startup
 
 1. Read this file first.
-2. If `AGENTS.md` exists locally in the workspace, apply it as an additional local overlay.
-3. Ensure `doku/memory_notes.md` and `doku/report.md` exist and keep them updated during meaningful work. These files are local-only and must not be staged or committed unless explicitly requested.
-4. Identify triggered skills from this file and any local overlay, then read only the matching `SKILL.md` files before making changes.
-5. Follow the repository delegation boundaries for testing and release work, including the documented fallback protocol when a required specialist is unavailable.
+2. Apply `AGENTS.md` when available.
+3. Ensure `doku/memory_notes.md` exists, read its current-state/relevant durable notes before meaningful work, and keep it updated with concise continuity notes. It is local-only and must not be staged or committed unless explicitly requested.
+4. Identify triggered skills and read only the matching `.github/skills/*/SKILL.md` files before changing code.
+5. Keep work scoped to the user's current objective and existing repository patterns.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan.
 <!-- SPECKIT END -->
 
-## Product and stack
+## Baseline Rules
 
-- MedAssist-ng is a medication planning app with stock tracking, reminders, refill history, sharing, and optional auth/SSO.
-- Frontend: React + TypeScript + Vite in `frontend/`
-- Backend: Fastify + TypeScript + Drizzle + SQLite in `backend/`
-- Shared package: `shared/`
-
-## Repo-critical rules
-
-- English only for code, comments, docs, and commit messages.
-- Frontend browser code must call `/api/*`; do not hardcode backend hostnames in UI code.
-- Docs must be updated when behavior, setup, workflow, or operational commands change.
-- Keep changes scoped and surgical. Do not fix unrelated issues while touching CI or release files.
-- Never push, tag, merge, or create a release from an agent session unless the repository's explicit release workflow says so.
-
-## Placement and parity rules
-
-- Backend HTTP routes and validation live in `backend/src/routes/**`.
-- Backend business logic and schedulers live in `backend/src/services/**`.
-- Persistence/schema compatibility lives in `backend/src/db/**` and `backend/drizzle/**`.
-- Frontend page/UI flow changes belong in `frontend/src/pages/**` and `frontend/src/components/**`.
-- Frontend orchestration belongs in `frontend/src/context/**` and `frontend/src/hooks/**`.
-- Localization strings belong in `frontend/src/i18n/en.json` and `frontend/src/i18n/de.json`.
-
-Always preserve these parity rules:
-
-1. Medication edit changes must update both desktop and mobile edit flows.
-2. Notification behavior changes must update both scheduler and manual/planner code paths.
-
-## Safety rules
-
-- Preserve backward compatibility for existing SQLite data files.
-- Never remove or rename existing database columns.
-- Validate and surface configuration errors clearly; do not add silent fallbacks that hide broken releases.
+- Use English for code, comments, docs, and commit messages.
+- Frontend browser code must call `/api/*`; do not hardcode backend hosts.
+- Keep behavior, setup, config, workflow, and operations docs aligned with changes.
+- Preserve backward compatibility for existing SQLite files; never remove or rename DB columns.
+- Validate and surface errors clearly; do not add silent fallbacks that hide broken releases.
 - Keep health checks and structured operational logging intact.
+- Keep changes scoped and avoid unrelated cleanup.
+- Do not push, tag, merge, create PRs, or publish releases from a normal agent session; hand off release work to `release-manager`.
 
-## CI and release expectations
+## Placement
 
-- PR validation lives in `.github/workflows/test.yml` and `.github/workflows/e2e.yml`.
-- Docker release publishing lives in `.github/workflows/docker-build.yml`.
-- Project automation lives in `.github/workflows/add-to-project.yml` and related project workflows.
-- CI changes must keep docs and operational guidance in sync.
+- Backend routes and validation: `backend/src/routes/**`.
+- Backend services, schedulers, and domain behavior: `backend/src/services/**`.
+- Persistence and migrations: `backend/src/db/**`, `backend/drizzle/**`.
+- Frontend pages and UI flows: `frontend/src/pages/**`, `frontend/src/components/**`.
+- Frontend orchestration and hooks: `frontend/src/context/**`, `frontend/src/hooks/**`.
+- Localization: `frontend/src/i18n/en.json`, `frontend/src/i18n/de.json`.
+- E2E tests: `frontend/e2e/**`.
+- Unit tests: `backend/src/test/**`, `frontend/src/test/**`.
 
-## Preferred specialist routing
+## Parity
 
-- Use `testing-manager` for test planning, local validation, and CI test triage.
+- Medication edit changes must update both desktop and mobile edit flows.
+- Notification behavior changes must update both scheduler and manual/planner code paths.
+
+## Specialists
+
+- Use `testing-manager` for test planning, test execution, and CI test triage.
 - Use `release-manager` for PR shipping, merge, release, and workflow monitoring.
-- Use `project-bot` for issue, PR metadata, and GitHub Project board coordination work when no product code change is required.
+- Use `project-bot` for issue, PR metadata, and GitHub Project board coordination when no product code change is required.
 
-## Local-only artifacts
+## Local-Only Artifacts
 
-The following are local workspace state and must not be committed unless a user explicitly asks for that exact action:
+Do not stage or commit local workspace state unless the user explicitly asks for that exact action:
 
 - `doku/memory_notes.md`
-- `doku/report.md`
-- local planning / agent scratch artifacts
+- local planning, agent, or scratch artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,11 @@ docs/SPEC_KIT.md
 ops/medtest/
 .kilo/kilo.json
 .kilo/kilo.jsonc
+
+.kilo/
+
+# ===================
+# Codex / agent local files
+# ===================
+.codex/
+.github/agents/*.agent.md


### PR DESCRIPTION
Closes #788

This cleanup:
- streamlines committed Copilot/cloud-agent instructions
- removes the `report.md` persistence requirement in favor of `doku/memory_notes.md`
- ignores local Codex/agent artifacts (`.kilo/`, `.codex/`, `.github/agents/*.agent.md`)

Validation:
- `git diff --check github/main...HEAD` passed
- no tracked `report.md` requirement remains