### PR TITLE
fix(ci): let Dependabot rebase stale automerge PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -44,12 +44,12 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
 
-  refresh-stale-automerge-branches:
+  request-dependabot-rebase:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Update stale Dependabot auto-merge PR branches
+      - name: Request Dependabot rebase for stale auto-merge PR branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -76,9 +76,9 @@ jobs:
               continue
             fi
 
-            echo "Updating Dependabot PR #$pr_number with the latest base branch."
-            if ! gh pr update-branch "$pr_number" --repo "$REPO"; then
-              echo "::warning::Failed to update Dependabot PR #$pr_number."
+            echo "Requesting Dependabot rebase for PR #$pr_number."
+            if ! gh pr comment "$pr_number" --repo "$REPO" --body "@dependabot rebase"; then
+              echo "::warning::Failed to request Dependabot rebase for PR #$pr_number."
               failed=1
             fi
           done <<< "$prs"


### PR DESCRIPTION
Closes #802

## Summary

This keeps the Dependabot automerge refresh job from creating stale-branch merge commits authored by `github-actions[bot]`.

## Why

PRs #790 and #792 became `action_required` after the previous refresh path ran `gh pr update-branch`. That command updated the Dependabot branches with merge commits authored by `github-actions[bot]`. Because the repository setting `fork-pr-contributor-approval` is `first_time_contributors`, the new pull_request workflow runs were gated for approval instead of running automatically.

## Change

The stale auto-merge branch job now comments `@dependabot rebase` on open Dependabot PRs that already have auto-merge enabled and are `BEHIND`. Dependabot performs the branch update itself, so refreshed heads stay authored by `dependabot[bot]`, matching the behavior that allowed #791 to proceed without manual approval.

Scope is limited to Dependabot auto-merge refresh behavior.