### PR TITLE
fix(e2e): disable reuseExistingServer in CI for fresh server instances

### DIFF
--- a/frontend/playwright.base.config.ts
+++ b/frontend/playwright.base.config.ts
@@ -98,13 +98,13 @@ export function buildPlaywrightConfig(runAllBrowsers: boolean) {
 			{
 				command: "cd ../backend && npm run dev",
 				url: `${apiBaseURL}/health`,
-				reuseExistingServer: true,
+				reuseExistingServer: !env.CI,
 				timeout: 120 * 1000,
 			},
 			{
 				command: `npm run dev -- --host 127.0.0.1 --port ${frontendPort} --strictPort`,
 				url: baseURL,
-				reuseExistingServer: true,
+				reuseExistingServer: !env.CI,
 				timeout: 120 * 1000,
 			},
 		],


### PR DESCRIPTION
Setting `reuseExistingServer` to `!env.CI` ensures CI always starts fresh backend and frontend servers, preventing stale state from affecting test runs. Local development still reuses existing servers for speed.