### PR TITLE
fix(ui): integrate dashboard reminder card

### DIFF
--- a/frontend/src/components/dashboard/DashboardReminderSection.module.css
+++ b/frontend/src/components/dashboard/DashboardReminderSection.module.css
@@ -1,0 +1,105 @@
+.reminderCard {
+	margin-bottom: 1rem;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+	flex-wrap: wrap;
+}
+
+.icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+	background: color-mix(in srgb, var(--accent-bg) 72%, transparent);
+	color: var(--accent);
+	flex: 0 0 auto;
+}
+
+.title {
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.3;
+	color: var(--text-primary);
+}
+
+.details {
+	display: grid;
+	gap: 0.65rem;
+	margin-top: 0.85rem;
+}
+
+.row {
+	display: grid;
+	grid-template-columns: minmax(9rem, max-content) minmax(0, 1fr);
+	gap: 0.5rem 0.85rem;
+	align-items: baseline;
+	line-height: 1.5;
+}
+
+.label {
+	color: var(--text-secondary);
+	font-weight: 650;
+}
+
+.value {
+	min-width: 0;
+	color: var(--text-primary);
+	overflow-wrap: anywhere;
+}
+
+.medName {
+	font-weight: 700;
+}
+
+.date,
+.takenBy {
+	color: var(--text-secondary);
+}
+
+.sendRow {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+	margin-top: 1rem;
+	padding-top: 1rem;
+	border-top: 1px solid color-mix(in srgb, var(--border-primary) 82%, transparent);
+}
+
+.sendResult {
+	font-size: 0.92rem;
+	font-weight: 700;
+}
+
+.sendResultSuccess {
+	color: var(--success);
+}
+
+.sendResultError {
+	color: var(--danger);
+}
+
+.skeletonLines {
+	display: grid;
+	gap: 0.55rem;
+	margin-top: 0.85rem;
+}
+
+@media (max-width: 600px) {
+	.reminderCard {
+		margin-right: calc(var(--page-padding-x, 0px) * -1);
+		margin-left: calc(var(--page-padding-x, 0px) * -1);
+	}
+
+	.row {
+		grid-template-columns: 1fr;
+		gap: 0.2rem;
+	}
+}

--- a/frontend/src/components/dashboard/DashboardReminderSection.tsx
+++ b/frontend/src/components/dashboard/DashboardReminderSection.tsx
@@ -1,9 +1,11 @@
 import { Text } from "@mantine/core";
 import { type Coverage, getMedDisplayName, type Medication, type StockThresholds } from "../../types";
+import { SectionCard } from "../../ui/components/SectionCard";
 import { AppButton } from "../../ui/primitives/AppButton";
 import { AppTextAction } from "../../ui/primitives/AppTextAction";
 import { StatusBadge, type StatusTone } from "../../ui/primitives/StatusBadge";
 import { getStockStatus } from "../../utils/schedule";
+import classes from "./DashboardReminderSection.module.css";
 
 type ReminderData = {
 	status: { className: string; text: string };
@@ -91,17 +93,19 @@ export function DashboardReminderSection({
 	if (remindersLoading) {
 		return (
 			<section className="reminder-status-bar reminder-status-skeleton" aria-busy="true">
-				<div className="reminder-status-header">
-					<span className="reminder-status-icon">
-						<NotificationBellIcon />
-					</span>
-					<span className="reminder-status-title">{t("dashboard.reminders.active")}</span>
-				</div>
-				<div className="reminder-status-details reminder-status-skeleton-lines">
-					<span className="skeleton-line skeleton-line-long" />
-					<span className="skeleton-line skeleton-line-medium" />
-					<span className="skeleton-line skeleton-line-short" />
-				</div>
+				<SectionCard className={classes.reminderCard} padding="md" data-testid="dashboard-reminder-card">
+					<div className={`reminder-status-header ${classes.header}`}>
+						<span className={`reminder-status-icon ${classes.icon}`}>
+							<NotificationBellIcon />
+						</span>
+						<span className={`reminder-status-title ${classes.title}`}>{t("dashboard.reminders.active")}</span>
+					</div>
+					<div className={`reminder-status-details reminder-status-skeleton-lines ${classes.skeletonLines}`}>
+						<span className="skeleton-line skeleton-line-long" />
+						<span className="skeleton-line skeleton-line-medium" />
+						<span className="skeleton-line skeleton-line-short" />
+					</div>
+				</SectionCard>
 			</section>
 		);
 	}
@@ -112,158 +116,178 @@ export function DashboardReminderSection({
 
 	return (
 		<section className="reminder-status-bar">
-			<div className="reminder-status-header">
-				<span className="reminder-status-icon">
-					<NotificationBellIcon />
-				</span>
-				<span className="reminder-status-title">{t("dashboard.reminders.active")}</span>
-				{stockRemindersEnabled && (
-					<StatusBadge size="xs" tone={getStatusTone(reminderData.status.className)}>
-						{reminderData.status.text}
-					</StatusBadge>
-				)}
-				{prescriptionStatus && (
-					<StatusBadge size="xs" tone={getStatusTone(prescriptionStatus.className)}>
-						{prescriptionStatus.text}
-					</StatusBadge>
-				)}
-			</div>
-			{(reminderData.lowStockMeds.length > 0 ||
-				(prescriptionRemindersEnabled && prescriptionLowMeds.length > 0) ||
-				(stockRemindersEnabled && reminderData.lastStockSent) ||
-				(intakeRemindersEnabled && reminderData.lastIntakeSent)) && (
-				<div className="reminder-status-details">
-					{stockRemindersEnabled && reminderData.lowStockMeds.length > 0 && (
-						<div className="reminder-status-row">
-							<span className="reminder-status-label">{t("dashboard.reminders.needsRefill")}:</span>
-							<span className="reminder-status-value">
-								{reminderData.lowStockMeds.map((med, idx) => {
-									const medication = meds.find((m) => getMedDisplayName(m) === med.name);
-									const cov = coverage.all.find((c) => c.name === med.name);
-									const status = cov
-										? getStockStatus(cov.daysLeft, cov.medsLeft, stockThresholds, medication?.packageType)
-										: null;
-									const textColor = getStatusTextColor(status?.className);
-									return (
-										<span key={med.name}>
-											{idx > 0 && ", "}
-											{medication ? (
-												<AppTextAction
-													color={textColor}
-													fontWeight={700}
-													onClick={() => onOpenMedicationDetail(medication)}
-												>
-													{med.name}
+			<SectionCard className={classes.reminderCard} padding="md" data-testid="dashboard-reminder-card">
+				<div className={`reminder-status-header ${classes.header}`}>
+					<span className={`reminder-status-icon ${classes.icon}`}>
+						<NotificationBellIcon />
+					</span>
+					<span className={`reminder-status-title ${classes.title}`}>{t("dashboard.reminders.active")}</span>
+					{stockRemindersEnabled && (
+						<StatusBadge size="xs" tone={getStatusTone(reminderData.status.className)}>
+							{reminderData.status.text}
+						</StatusBadge>
+					)}
+					{prescriptionStatus && (
+						<StatusBadge size="xs" tone={getStatusTone(prescriptionStatus.className)}>
+							{prescriptionStatus.text}
+						</StatusBadge>
+					)}
+				</div>
+				{(reminderData.lowStockMeds.length > 0 ||
+					(prescriptionRemindersEnabled && prescriptionLowMeds.length > 0) ||
+					(stockRemindersEnabled && reminderData.lastStockSent) ||
+					(intakeRemindersEnabled && reminderData.lastIntakeSent)) && (
+					<div className={`reminder-status-details ${classes.details}`}>
+						{stockRemindersEnabled && reminderData.lowStockMeds.length > 0 && (
+							<div className={`reminder-status-row ${classes.row}`}>
+								<span className={`reminder-status-label ${classes.label}`}>
+									{t("dashboard.reminders.needsRefill")}:
+								</span>
+								<span className={`reminder-status-value ${classes.value}`}>
+									{reminderData.lowStockMeds.map((med, idx) => {
+										const medication = meds.find((m) => getMedDisplayName(m) === med.name);
+										const cov = coverage.all.find((c) => c.name === med.name);
+										const status = cov
+											? getStockStatus(cov.daysLeft, cov.medsLeft, stockThresholds, medication?.packageType)
+											: null;
+										const textColor = getStatusTextColor(status?.className);
+										return (
+											<span key={med.name}>
+												{idx > 0 && ", "}
+												{medication ? (
+													<AppTextAction
+														color={textColor}
+														fontWeight={700}
+														onClick={() => onOpenMedicationDetail(medication)}
+													>
+														{med.name}
+													</AppTextAction>
+												) : (
+													<Text c={textColor} component="span" fw={700}>
+														{med.name}
+													</Text>
+												)}
+												<Text c={textColor} component="span" fw={textColor ? 700 : undefined}>
+													{" "}
+													{t("dashboard.reminders.daysLeft", { count: med.daysLeft, days: med.daysLeft })}
+												</Text>
+											</span>
+										);
+									})}
+								</span>
+							</div>
+						)}
+						{prescriptionRemindersEnabled && prescriptionLowMeds.length > 0 && (
+							<div className={`reminder-status-row ${classes.row}`}>
+								<span className={`reminder-status-label ${classes.label}`}>
+									{t("dashboard.reminders.needsPrescriptionRefill")}:
+								</span>
+								<span className={`reminder-status-value ${classes.value}`}>
+									{prescriptionLowMeds.map((med, idx) => {
+										const medication = meds.find((m) => m.id === med.id);
+										const textColor = med.remainingRefills <= 0 ? "red" : "yellow";
+										return (
+											<span key={med.id}>
+												{idx > 0 && ", "}
+												<Text c={textColor} component="span" fw={700}>
+													{t("prescription.remainingRefills")}: {med.remainingRefills},{" "}
+													{t("dashboard.reminders.usedBy")}:{" "}
+												</Text>
+												{medication ? (
+													<AppTextAction
+														color={textColor}
+														fontWeight={700}
+														onClick={() => onOpenMedicationDetail(medication)}
+													>
+														{med.name}
+													</AppTextAction>
+												) : (
+													<Text c={textColor} component="span" fw={700}>
+														{med.name}
+													</Text>
+												)}
+											</span>
+										);
+									})}
+								</span>
+							</div>
+						)}
+						{stockRemindersEnabled && reminderData.lastStockSent && (
+							<div className={`reminder-status-row ${classes.row}`}>
+								<span className={`reminder-status-label ${classes.label}`}>
+									{t("dashboard.reminders.lastStockSent")}:
+								</span>
+								<span className={`reminder-status-value ${classes.value}`}>
+									{reminderData.lastStockSent.medNames &&
+										(() => {
+											const names = reminderData.lastStockSent?.medNames?.split(", ") ?? [];
+											return names.map((name, idx) => {
+												const medication = meds.find((m) => getMedDisplayName(m) === name);
+												return (
+													<span key={name}>
+														{idx > 0 && ", "}
+														{medication ? (
+															<AppTextAction onClick={() => onOpenMedicationDetail(medication)}>{name}</AppTextAction>
+														) : (
+															<span className={`reminder-med-name ${classes.medName}`}>{name}</span>
+														)}
+													</span>
+												);
+											});
+										})()}
+									<span className={`reminder-date ${classes.date}`}> {reminderData.lastStockSent.date}</span>
+								</span>
+							</div>
+						)}
+						{intakeRemindersEnabled && reminderData.lastIntakeSent && (
+							<div className={`reminder-status-row ${classes.row}`}>
+								<span className={`reminder-status-label ${classes.label}`}>{t("dashboard.reminders.lastSent")}:</span>
+								<span className={`reminder-status-value ${classes.value}`}>
+									{reminderData.lastIntakeSent.medName &&
+										(() => {
+											const medication = meds.find(
+												(m) => getMedDisplayName(m) === reminderData.lastIntakeSent?.medName
+											);
+											return medication ? (
+												<AppTextAction onClick={() => onOpenMedicationDetail(medication)}>
+													{reminderData.lastIntakeSent?.medName}
 												</AppTextAction>
 											) : (
-												<Text c={textColor} component="span" fw={700}>
-													{med.name}
-												</Text>
-											)}
-											<Text c={textColor} component="span" fw={textColor ? 700 : undefined}>
-												{" "}
-												{t("dashboard.reminders.daysLeft", { count: med.daysLeft, days: med.daysLeft })}
-											</Text>
-										</span>
-									);
-								})}
-							</span>
-						</div>
-					)}
-					{prescriptionRemindersEnabled && prescriptionLowMeds.length > 0 && (
-						<div className="reminder-status-row">
-							<span className="reminder-status-label">{t("dashboard.reminders.needsPrescriptionRefill")}:</span>
-							<span className="reminder-status-value">
-								{prescriptionLowMeds.map((med, idx) => {
-									const medication = meds.find((m) => m.id === med.id);
-									const textColor = med.remainingRefills <= 0 ? "red" : "yellow";
-									return (
-										<span key={med.id}>
-											{idx > 0 && ", "}
-											<Text c={textColor} component="span" fw={700}>
-												{t("prescription.remainingRefills")}: {med.remainingRefills}, {t("dashboard.reminders.usedBy")}:{" "}
-											</Text>
-											{medication ? (
-												<AppTextAction
-													color={textColor}
-													fontWeight={700}
-													onClick={() => onOpenMedicationDetail(medication)}
-												>
-													{med.name}
-												</AppTextAction>
-											) : (
-												<Text c={textColor} component="span" fw={700}>
-													{med.name}
-												</Text>
-											)}
-										</span>
-									);
-								})}
-							</span>
-						</div>
-					)}
-					{stockRemindersEnabled && reminderData.lastStockSent && (
-						<div className="reminder-status-row">
-							<span className="reminder-status-label">{t("dashboard.reminders.lastStockSent")}:</span>
-							<span className="reminder-status-value">
-								{reminderData.lastStockSent.medNames &&
-									(() => {
-										const names = reminderData.lastStockSent?.medNames?.split(", ") ?? [];
-										return names.map((name, idx) => {
-											const medication = meds.find((m) => getMedDisplayName(m) === name);
-											return (
-												<span key={name}>
-													{idx > 0 && ", "}
-													{medication ? (
-														<AppTextAction onClick={() => onOpenMedicationDetail(medication)}>{name}</AppTextAction>
-													) : (
-														<span className="reminder-med-name">{name}</span>
-													)}
+												<span className={`reminder-med-name ${classes.medName}`}>
+													{reminderData.lastIntakeSent?.medName}
 												</span>
 											);
-										});
-									})()}
-								<span className="reminder-date"> {reminderData.lastStockSent.date}</span>
+										})()}
+									{reminderData.lastIntakeSent.takenBy && (
+										<span className={`reminder-taken-by ${classes.takenBy}`}>
+											{" "}
+											({reminderData.lastIntakeSent.takenBy})
+										</span>
+									)}
+									<span className={`reminder-date ${classes.date}`}> {reminderData.lastIntakeSent.date}</span>
+								</span>
+							</div>
+						)}
+					</div>
+				)}
+				{((stockRemindersEnabled && reminderData.lowStockMeds.length > 0) ||
+					(prescriptionRemindersEnabled && prescriptionLowMeds.length > 0)) && (
+					<div className={`reminder-send-row ${classes.sendRow}`}>
+						<AppButton type="button" tone="secondary" onClick={onSendManualReminder} disabled={sendingReminder}>
+							{sendingReminder ? t("common.sending") : t("dashboard.reorder.sendReminder")}
+						</AppButton>
+						{reminderResult && (
+							<span
+								className={`reminder-send-result ${classes.sendResult} ${
+									reminderResult.success ? `success ${classes.sendResultSuccess}` : `error ${classes.sendResultError}`
+								}`}
+							>
+								{reminderResult.message}
 							</span>
-						</div>
-					)}
-					{intakeRemindersEnabled && reminderData.lastIntakeSent && (
-						<div className="reminder-status-row">
-							<span className="reminder-status-label">{t("dashboard.reminders.lastSent")}:</span>
-							<span className="reminder-status-value">
-								{reminderData.lastIntakeSent.medName &&
-									(() => {
-										const medication = meds.find((m) => getMedDisplayName(m) === reminderData.lastIntakeSent?.medName);
-										return medication ? (
-											<AppTextAction onClick={() => onOpenMedicationDetail(medication)}>
-												{reminderData.lastIntakeSent?.medName}
-											</AppTextAction>
-										) : (
-											<span className="reminder-med-name">{reminderData.lastIntakeSent?.medName}</span>
-										);
-									})()}
-								{reminderData.lastIntakeSent.takenBy && (
-									<span className="reminder-taken-by"> ({reminderData.lastIntakeSent.takenBy})</span>
-								)}
-								<span className="reminder-date"> {reminderData.lastIntakeSent.date}</span>
-							</span>
-						</div>
-					)}
-				</div>
-			)}
-			{((stockRemindersEnabled && reminderData.lowStockMeds.length > 0) ||
-				(prescriptionRemindersEnabled && prescriptionLowMeds.length > 0)) && (
-				<div className="reminder-send-row">
-					<AppButton type="button" tone="secondary" onClick={onSendManualReminder} disabled={sendingReminder}>
-						{sendingReminder ? t("common.sending") : t("dashboard.reorder.sendReminder")}
-					</AppButton>
-					{reminderResult && (
-						<span className={`reminder-send-result ${reminderResult.success ? "success" : "error"}`}>
-							{reminderResult.message}
-						</span>
-					)}
-				</div>
-			)}
+						)}
+					</div>
+				)}
+			</SectionCard>
 		</section>
 	);
 }

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -1094,6 +1094,7 @@ describe("DashboardPage with email notifications", () => {
 		// Should show reminder status bar
 		const statusBar = document.querySelector(".reminder-status-bar");
 		expect(statusBar).toBeInTheDocument();
+		expect(within(statusBar as HTMLElement).getByTestId("dashboard-reminder-card")).toBeInTheDocument();
 	});
 
 	it("hides reorder reminder card when reminders are enabled (to avoid redundancy)", () => {


### PR DESCRIPTION
## Summary

- Integrates the dashboard reminder card into the dashboard reminder section.
- Adds the dashboard test assertion for the reminder-card action.

## Validation

- Pre-PR local validation was completed before this release-manager continuation.

Closes #822