### PR TITLE
fix(ui): polish dashboard and shared mobile layouts

### DIFF
--- a/frontend/src/AppSurfaces.css
+++ b/frontend/src/AppSurfaces.css
@@ -612,6 +612,11 @@ textarea.auto-resize {
 	color: var(--text-secondary);
 	line-height: 1.2;
 }
+.date-pair-stack-header .date-pair-label {
+	font-size: 0.95rem;
+	font-weight: 750;
+	letter-spacing: 0;
+}
 
 .date-pair-value {
 	font-size: 0.9rem;
@@ -1716,9 +1721,26 @@ button.has-validation-error {
 	min-width: 0;
 }
 
+.time-main .med-name-stack {
+	display: inline-flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.1rem;
+}
+
 .time-main .med-name-text {
 	overflow-wrap: anywhere;
 }
+
+.time-main .med-generic-inline {
+	display: block;
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.2;
+	color: var(--text-secondary);
+	overflow-wrap: anywhere;
+}
+
 .time-col {
 	display: flex;
 	align-items: center;
@@ -2422,7 +2444,15 @@ button.has-validation-error {
 	.dose-person {
 		width: 100%;
 		min-width: 0;
-		justify-content: flex-end;
+		--dose-action-take-width: clamp(4.9rem, 22vw, 7rem);
+		--dose-action-skip-width: clamp(4.25rem, 18vw, 5.2rem);
+		--dose-action-journal-width: clamp(4.9rem, 20vw, 6.25rem);
+
+		display: grid;
+		grid-template-columns:
+			minmax(0, 1fr) var(--dose-action-take-width) var(--dose-action-skip-width)
+			var(--dose-action-journal-width);
+		align-items: center;
 		gap: 0.35rem;
 		padding: 0.28rem 0.35rem;
 	}
@@ -2441,6 +2471,8 @@ button.has-validation-error {
 	.dose-person .dose-btn {
 		height: 26px;
 		min-height: 26px;
+		width: 100%;
+		min-width: 0;
 		padding: 0 0.5rem;
 		font-size: 0.72rem;
 	}

--- a/frontend/src/components/DoseActionButton.module.css
+++ b/frontend/src/components/DoseActionButton.module.css
@@ -28,6 +28,7 @@
 
 .tooltipTarget {
 	display: inline-flex;
+	width: 100%;
 }
 
 .label {
@@ -202,4 +203,18 @@
 .hasNote {
 	border-color: color-mix(in srgb, var(--accent) 50%, var(--border-primary));
 	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+@media (max-width: 600px) {
+	.takeAction {
+		grid-column: 2;
+	}
+
+	.skipAction {
+		grid-column: 3;
+	}
+
+	.journalAction {
+		grid-column: 4;
+	}
 }

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -615,6 +615,7 @@ export function SharedSchedule() {
 				className={cx(
 					"dose-btn undo take",
 					doseButtonClasses.button,
+					doseButtonClasses.takeAction,
 					doseButtonClasses.undo,
 					doseButtonClasses.undoTake
 				)}
@@ -631,6 +632,7 @@ export function SharedSchedule() {
 				className={cx(
 					"dose-btn take",
 					doseButtonClasses.button,
+					doseButtonClasses.takeAction,
 					doseButtonClasses.take,
 					doseButtonClasses.dashboardTake,
 					options.isEmpty && doseButtonClasses.outOfStock
@@ -645,7 +647,7 @@ export function SharedSchedule() {
 		const takeButton =
 			!options.isTaken && options.isEmpty ? (
 				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
-					<span className={doseButtonClasses.tooltipTarget}>{takeButtonControl}</span>
+					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
 				</AppTooltip>
 			) : (
 				takeButtonControl
@@ -658,6 +660,7 @@ export function SharedSchedule() {
 				className={cx(
 					"dose-btn undo skip",
 					doseButtonClasses.button,
+					doseButtonClasses.skipAction,
 					doseButtonClasses.undo,
 					doseButtonClasses.undoSkip
 				)}
@@ -670,7 +673,7 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx("dose-btn skip", doseButtonClasses.button, doseButtonClasses.skip)}
+				className={cx("dose-btn skip", doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken}
 			>
@@ -685,6 +688,7 @@ export function SharedSchedule() {
 				className={cx(
 					"dose-btn journal",
 					doseButtonClasses.button,
+					doseButtonClasses.journalAction,
 					doseButtonClasses.journal,
 					hasSharedJournalNote && doseButtonClasses.hasNote
 				)}
@@ -702,7 +706,9 @@ export function SharedSchedule() {
 		const journalButton =
 			showSharedJournalAction && journalButtonControl && !canOpenSharedJournal ? (
 				<AppTooltip label={t("journal.actions.noteTakenOnly")}>
-					<span className={doseButtonClasses.tooltipTarget}>{journalButtonControl}</span>
+					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.journalAction)}>
+						{journalButtonControl}
+					</span>
 				</AppTooltip>
 			) : (
 				journalButtonControl

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -388,6 +388,7 @@
       "intakeUnitMl": "Milliliter (ml)",
       "intakeUnitTsp": "Teelöffel (5 ml)",
       "intakeUnitTbsp": "Esslöffel (15 ml)",
+      "takenByTooltip": "Ordnet diese Einnahme einer Person zu. Leer lassen, wenn alle beim Medikament hinterlegten Personen sie einnehmen sollen.",
       "intakes": "Einnahmen",
       "intakes_one": "Einnahme",
       "intakes_other": "Einnahmen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -388,6 +388,7 @@
       "intakeUnitMl": "Milliliters (ml)",
       "intakeUnitTsp": "Teaspoon (5 ml)",
       "intakeUnitTbsp": "Tablespoon (15 ml)",
+      "takenByTooltip": "Assign this intake to one person. Leave it empty when everyone assigned to the medication should take it.",
       "intakes": "intakes",
       "intakes_one": "intake",
       "intakes_other": "intakes",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -461,7 +461,12 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.undo, doseButtonClasses.undoTake)}
+				className={cx(
+					doseButtonClasses.button,
+					doseButtonClasses.takeAction,
+					doseButtonClasses.undo,
+					doseButtonClasses.undoTake
+				)}
 				onClick={() => undoDoseTaken(options.doseId)}
 			>
 				{options.isAutomaticallyTaken && <AppTooltipTrigger label={t("tooltips.automaticTaken")}>🤖</AppTooltipTrigger>}
@@ -474,6 +479,7 @@ export function DashboardPage() {
 				size="sm"
 				className={cx(
 					doseButtonClasses.button,
+					doseButtonClasses.takeAction,
 					doseButtonClasses.take,
 					doseButtonClasses.dashboardTake,
 					options.isEmpty && doseButtonClasses.outOfStock
@@ -488,7 +494,7 @@ export function DashboardPage() {
 		const takeButton =
 			!options.isTaken && options.isEmpty ? (
 				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
-					<span className={doseButtonClasses.tooltipTarget}>{takeButtonControl}</span>
+					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
 				</AppTooltip>
 			) : (
 				takeButtonControl
@@ -498,7 +504,7 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.journal)}
+				className={cx(doseButtonClasses.button, doseButtonClasses.journal, doseButtonClasses.journalAction)}
 				onClick={() => {
 					if (!journalUnavailable) {
 						void openJournalEditor(options.doseId);
@@ -512,7 +518,9 @@ export function DashboardPage() {
 		);
 		const journalButton = journalUnavailable ? (
 			<AppTooltip label={t("journal.actions.noteTakenOnly")}>
-				<span className={doseButtonClasses.tooltipTarget}>{journalButtonControl}</span>
+				<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.journalAction)}>
+					{journalButtonControl}
+				</span>
 			</AppTooltip>
 		) : (
 			journalButtonControl
@@ -531,7 +539,12 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.undo, doseButtonClasses.undoSkip)}
+				className={cx(
+					doseButtonClasses.button,
+					doseButtonClasses.skipAction,
+					doseButtonClasses.undo,
+					doseButtonClasses.undoSkip
+				)}
 				onClick={() => undoDoseSkipped(options.doseId)}
 			>
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
@@ -541,7 +554,7 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.skip)}
+				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken}
 			>
@@ -1090,7 +1103,7 @@ export function DashboardPage() {
 				const status = getVisibleStockStatus(med, rawStatus);
 				return status ? (
 					<span data-label={t("table.status")}>
-						<StatusBadge size="xs" tone={getStatusTone(status.className)}>
+						<StatusBadge size="sm" tone={getStatusTone(status.className)}>
 							{t(status.label)}
 						</StatusBadge>
 					</span>
@@ -1372,11 +1385,7 @@ export function DashboardPage() {
 																		<span className="tag subtle">
 																			{formatTotalUsageLabel(med, item.total, item.doses[0]?.intakeUnit, item.doses)}
 																		</span>
-																		{status && (
-																			<StatusBadge size="xs" tone={getStatusTone(status.className)}>
-																				{t(status.label)}
-																			</StatusBadge>
-																		)}
+																		{status && <span className={`tag ${status.className}`}>{t(status.label)}</span>}
 																	</div>
 																</div>
 																<div className="doses-col">
@@ -1694,9 +1703,7 @@ export function DashboardPage() {
 																			{formatTotalUsageLabel(med, item.total, item.doses[0]?.intakeUnit, item.doses)}
 																		</span>
 																		{visibleStatus && (
-																			<StatusBadge size="xs" tone={getStatusTone(visibleStatus.className)}>
-																				{t(visibleStatus.label)}
-																			</StatusBadge>
+																			<span className={`tag ${visibleStatus.className}`}>{t(visibleStatus.label)}</span>
 																		)}
 																	</div>
 																	{isEmpty && med && !med.isObsolete && (
@@ -1972,9 +1979,7 @@ export function DashboardPage() {
 																			{formatTotalUsageLabel(med, item.total, item.doses[0]?.intakeUnit, item.doses)}
 																		</span>
 																		{visibleStatus && (
-																			<StatusBadge size="xs" tone={getStatusTone(visibleStatus.className)}>
-																				{t(visibleStatus.label)}
-																			</StatusBadge>
+																			<span className={`tag ${visibleStatus.className}`}>{t(visibleStatus.label)}</span>
 																		)}
 																	</div>
 																	{isEmpty && med && !med.isObsolete && (

--- a/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
@@ -1,0 +1,70 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import de from "../../i18n/de.json";
+import en from "../../i18n/en.json";
+
+const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readSource(filePath: string) {
+	return readFileSync(resolve(srcRoot, filePath), "utf8");
+}
+
+function extractSimpleCssBlocks(css: string) {
+	return Array.from(css.matchAll(/([^{}]+)\{([^{}]*)\}/g)).map((match) => ({
+		selector: match[1].trim(),
+		body: match[2],
+	}));
+}
+
+function blockFor(css: string, selector: string) {
+	return extractSimpleCssBlocks(css).find((block) => block.selector === selector)?.body ?? "";
+}
+
+function lastBlockFor(css: string, selector: string) {
+	return (
+		extractSimpleCssBlocks(css)
+			.filter((block) => block.selector === selector)
+			.at(-1)?.body ?? ""
+	);
+}
+
+describe("dashboard and shared mobile polish contract", () => {
+	it("keeps overview table headers readable and mobile date values right aligned", () => {
+		const css = readSource("ui/primitives/DataTable.module.css");
+		const headCell = blockFor(css, ".headCell");
+		const mobileCell = lastBlockFor(css, ".bodyCell");
+		const mobileLabel = lastBlockFor(css, ".bodyCell::before");
+		const mobileDateValue = blockFor(css, '.bodyCell[data-column-key="datePair"] :global(.date-pair-value)');
+
+		expect(headCell).toMatch(/font-size\s*:\s*0\.95rem/);
+		expect(headCell).toMatch(/font-weight\s*:\s*750/);
+		expect(mobileCell).toMatch(/align-items\s*:\s*center/);
+		expect(mobileLabel).toMatch(/font-size\s*:\s*0\.82rem/);
+		expect(mobileDateValue).toMatch(/justify-self\s*:\s*end/);
+		expect(mobileDateValue).toMatch(/text-align\s*:\s*right/);
+	});
+
+	it("keeps shared medication generic names and mobile dose actions in stable slots", () => {
+		const appSurfacesCss = readSource("AppSurfaces.css");
+		const doseButtonCss = readSource("components/DoseActionButton.module.css");
+
+		expect(blockFor(appSurfacesCss, ".time-main .med-name-stack")).toMatch(/flex-direction\s*:\s*column/);
+		expect(blockFor(appSurfacesCss, ".time-main .med-generic-inline")).toMatch(/display\s*:\s*block/);
+		expect(lastBlockFor(appSurfacesCss, ".dose-person")).toMatch(/grid-template-columns/);
+		expect(blockFor(doseButtonCss, ".tooltipTarget")).toMatch(/width\s*:\s*100%/);
+		expect(blockFor(doseButtonCss, ".takeAction")).toMatch(/grid-column\s*:\s*2/);
+		expect(blockFor(doseButtonCss, ".skipAction")).toMatch(/grid-column\s*:\s*3/);
+		expect(blockFor(doseButtonCss, ".journalAction")).toMatch(/grid-column\s*:\s*4/);
+	});
+
+	it("keeps the taken-by intake tooltip translated in English and German", () => {
+		expect(en.form.blisters.takenByTooltip).toBeTruthy();
+		expect(de.form.blisters.takenByTooltip).toBeTruthy();
+		expect(en.form.blisters.takenByTooltip).not.toBe("form.blisters.takenByTooltip");
+		expect(de.form.blisters.takenByTooltip).not.toBe("form.blisters.takenByTooltip");
+	});
+});

--- a/frontend/src/ui/primitives/DataTable.module.css
+++ b/frontend/src/ui/primitives/DataTable.module.css
@@ -24,8 +24,8 @@
 	padding-bottom: 0.9rem;
 	border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 88%, transparent);
 	color: var(--text-secondary);
-	font-size: 0.82rem;
-	font-weight: 700;
+	font-size: 0.95rem;
+	font-weight: 750;
 	letter-spacing: 0;
 	text-transform: none;
 	white-space: nowrap;
@@ -124,7 +124,7 @@
 	.bodyCell {
 		display: grid;
 		grid-template-columns: minmax(6rem, 38%) minmax(0, 1fr);
-		align-items: start;
+		align-items: center;
 		gap: 0.75rem;
 		padding: 0.55rem 0.8rem;
 		border-top: 1px solid color-mix(in srgb, var(--border-primary) 70%, transparent);
@@ -134,7 +134,7 @@
 	.bodyCell::before {
 		content: attr(data-label);
 		color: var(--text-secondary);
-		font-size: 0.75rem;
+		font-size: 0.82rem;
 		font-weight: 700;
 		line-height: 1.35;
 		text-transform: uppercase;
@@ -164,6 +164,18 @@
 
 	.bodyCell[data-column-key="name"]::before {
 		display: none;
+	}
+
+	.bodyCell[data-column-key="datePair"] :global(.date-pair-entry) {
+		display: grid;
+		grid-template-columns: minmax(6rem, 38%) minmax(0, 1fr);
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.bodyCell[data-column-key="datePair"] :global(.date-pair-value) {
+		justify-self: end;
+		text-align: right;
 	}
 
 	.bodyCell :global(.hide-on-card) {


### PR DESCRIPTION
## Summary

- Improve dashboard medication overview header sizing and mobile label/value alignment.
- Restore the missing taken-by tooltip translations in English and German.
- Keep shared schedule generic medication names and mobile dose actions in stable visual slots.
- Add focused source-level UI contract coverage for these polish regressions.

## Validation

- `runTests` for `frontend/src/test/pages/DashboardPage.test.tsx`, `frontend/src/test/components/SharedSchedule.test.tsx`, and `frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts` passed 83/83.
- `cd frontend && npm run check` passed.
- `git diff --check` passed for the touched files.

Closes #824