### PR TITLE
fix(ui): tighten dashboard mobile spacing

### DIFF
--- a/frontend/e2e/app-shell.spec.ts
+++ b/frontend/e2e/app-shell.spec.ts
@@ -65,31 +65,29 @@ test.describe("App Shell", () => {
 			await expect(page.getByTestId("app-header")).toBeVisible();
 			await page.screenshot({ path: testInfo.outputPath(`top-header-blur-${viewport.name}.png`), fullPage: false });
 
-			const metrics = await page.getByTestId("app-shell-top-blur").evaluate((topBlur) => {
-				const style = window.getComputedStyle(topBlur);
-				const styleWithWebkit = style as CSSStyleDeclaration & { webkitBackdropFilter?: string };
-				const appHeader = document.querySelector<HTMLElement>('[data-testid="app-header"]');
-				const topBlurRect = topBlur.getBoundingClientRect();
-				const appHeaderRect = appHeader?.getBoundingClientRect();
+			const metrics = await page.getByTestId("app-header").evaluate((appHeader) => {
+				const style = window.getComputedStyle(appHeader);
+				const beforeStyle = window.getComputedStyle(appHeader, "::before");
+				const beforeStyleWithWebkit = beforeStyle as CSSStyleDeclaration & { webkitBackdropFilter?: string };
+				const appHeaderRect = appHeader.getBoundingClientRect();
 
 				return {
-					backdropFilter: style.backdropFilter || styleWithWebkit.webkitBackdropFilter,
-					height: topBlurRect.height,
-					bottom: topBlurRect.bottom,
+					backdropFilter: beforeStyle.backdropFilter || beforeStyleWithWebkit.webkitBackdropFilter,
+					borderRadius: style.borderRadius,
+					bottom: appHeaderRect.bottom,
+					height: appHeaderRect.height,
+					overflow: style.overflow,
 					position: style.position,
-					top: topBlurRect.top,
-					appHeaderTop: appHeaderRect?.top ?? 0,
-					appHeaderBottom: appHeaderRect?.bottom ?? 0,
+					top: appHeaderRect.top,
 				};
 			});
 
-			expect(metrics.position).toBe("fixed");
+			expect(metrics.position).toBe("sticky");
 			expect(metrics.height).toBeGreaterThan(0);
-			expect(metrics.top).toBe(0);
-			expect(metrics.appHeaderTop).toBeGreaterThan(0);
-			expect(metrics.bottom).toBeGreaterThanOrEqual(metrics.appHeaderTop + 24);
-			expect(metrics.bottom).toBeLessThanOrEqual(metrics.appHeaderBottom - 8);
-			expect(metrics.appHeaderTop).toBeGreaterThanOrEqual(0);
+			expect(metrics.top).toBeLessThanOrEqual(0);
+			expect(metrics.bottom).toBeGreaterThan(24);
+			expect(metrics.overflow).toBe("hidden");
+			expect(metrics.borderRadius).not.toBe("0px");
 			expect(metrics.backdropFilter).toContain("blur");
 		});
 	}

--- a/frontend/e2e/dashboard-data.spec.ts
+++ b/frontend/e2e/dashboard-data.spec.ts
@@ -80,9 +80,13 @@ test.describe("Dashboard with medications", () => {
 		const overviewTable = page.locator(".dashboard-overview-section .table").first();
 		await expect(overviewTable).toBeVisible({ timeout: 10000 });
 
-		// Each medication row should have a status chip
-		const statusChips = overviewTable.locator(".status-chip");
-		expect(await statusChips.count()).toBeGreaterThanOrEqual(2);
+		// Each medication row should expose a readable stock status.
+		await expect(
+			overviewTable.locator(".table-row").filter({ hasText: MED_1 }).getByRole("cell", { name: "Normal" })
+		).toBeVisible();
+		await expect(
+			overviewTable.locator(".table-row").filter({ hasText: MED_2 }).getByRole("cell", { name: "Normal" })
+		).toBeVisible();
 	});
 
 	test("should show stock information in overview", async ({ page }) => {
@@ -175,7 +179,7 @@ test.describe("Dashboard with medications", () => {
 		const todayBlock = page.locator(".day-block.today");
 		await expect(todayBlock).toBeVisible({ timeout: 10000 });
 
-		const takeButtons = todayBlock.locator("button.dose-btn.take");
+		const takeButtons = todayBlock.getByRole("button", { name: /^Take$/ });
 		expect(await takeButtons.count()).toBeGreaterThanOrEqual(1);
 	});
 
@@ -185,7 +189,7 @@ test.describe("Dashboard with medications", () => {
 		let todayBlock = page.locator(".day-block.today");
 		await expect(todayBlock).toBeVisible({ timeout: 10000 });
 
-		const takeBtn = todayBlock.locator("button.dose-btn.take:not([disabled])").first();
+		const takeBtn = todayBlock.getByRole("button", { name: /^Take$/ }).first();
 		test.skip(!(await takeBtn.isVisible().catch(() => false)), "No actionable take-dose button is visible for today");
 
 		const takeResponsePromise = page.waitForResponse(
@@ -200,7 +204,7 @@ test.describe("Dashboard with medications", () => {
 		await page.waitForLoadState("networkidle");
 		todayBlock = page.locator(".day-block.today");
 		await expect(todayBlock).toBeVisible({ timeout: 10000 });
-		await expect(todayBlock.locator("button.dose-btn.undo").first()).toBeVisible({ timeout: 5000 });
+		await expect(todayBlock.getByRole("button", { name: /^Undo/ }).first()).toBeVisible({ timeout: 5000 });
 	});
 
 	test("should undo a taken dose", async ({ page }) => {
@@ -216,14 +220,14 @@ test.describe("Dashboard with medications", () => {
 
 		// Normalize state first: if a dose is already taken, undo it so we can
 		// always execute the same take -> undo flow deterministically.
-		const existingUndo = todayBlock.locator("button.dose-btn.undo").first();
+		const existingUndo = todayBlock.getByRole("button", { name: /^Undo/ }).first();
 		if (await existingUndo.isVisible().catch(() => false)) {
 			await existingUndo.click();
 			await page.waitForLoadState("networkidle");
 		}
 
 		// Mark a dose as taken first
-		const takeBtn = todayBlock.locator("button.dose-btn.take:not([disabled])").first();
+		const takeBtn = todayBlock.getByRole("button", { name: /^Take$/ }).first();
 		await expect(takeBtn).toBeVisible({ timeout: 10000 });
 		const takeResponsePromise = page.waitForResponse(
 			(response) => response.url().includes("/api/doses/taken") && response.request().method() === "POST",
@@ -241,13 +245,13 @@ test.describe("Dashboard with medications", () => {
 		await expect(todayBlock).toBeVisible({ timeout: 15000 });
 
 		// Wait for undo button to appear (confirms the take succeeded)
-		const undoBtn = todayBlock.locator("button.dose-btn.undo").first();
+		const undoBtn = todayBlock.getByRole("button", { name: /^Undo/ }).first();
 		await expect(undoBtn).toBeVisible({ timeout: 10000 });
 		await undoBtn.click();
 		await page.waitForLoadState("networkidle");
 
 		// Take button should reappear
-		await expect(todayBlock.locator("button.dose-btn.take:not([disabled])").first()).toBeVisible({ timeout: 10000 });
+		await expect(todayBlock.getByRole("button", { name: /^Take$/ }).first()).toBeVisible({ timeout: 10000 });
 	});
 
 	test("should show multiple day blocks in timeline", async ({ page }) => {
@@ -279,13 +283,13 @@ test.describe("Dashboard with medications", () => {
 		await expect(overviewTable).toBeVisible({ timeout: 10000 });
 
 		const medRow = overviewTable.locator(".table-row").filter({ hasText: MED_1 }).first();
-		await medRow.click();
+		await medRow.getByRole("button", { name: MED_1 }).click();
 
-		const modal = page.locator(".modal-overlay");
+		const modal = page.getByRole("dialog");
 		await expect(modal).toBeVisible({ timeout: 5000 });
 		await expect(modal.getByText(MED_1)).toBeVisible();
 
-		await page.locator("button.modal-close").click();
+		await modal.getByLabel(/close/i).click();
 		await expect(modal).not.toBeVisible();
 	});
 

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -42,29 +42,10 @@
 
 .page {
 	--page-pad-x: 1.5rem;
-	--app-shell-top-blur-top: 0;
-	--app-shell-top-blur-height: calc(3.15rem + env(safe-area-inset-top, 0px));
 
 	max-width: 1200px;
 	margin: 0 auto;
 	padding: 0 var(--page-pad-x) 1.5rem;
-}
-
-.topBlur {
-	position: fixed;
-	top: var(--app-shell-top-blur-top);
-	right: 0;
-	left: 0;
-	z-index: 139;
-	height: var(--app-shell-top-blur-height);
-	background: var(--mantine-other-bg-gradient);
-	backdrop-filter: blur(16px) saturate(1.2);
-	-webkit-backdrop-filter: blur(16px) saturate(1.2);
-	pointer-events: none;
-}
-
-:global([data-theme="light"]) .topBlur {
-	background: var(--mantine-other-bg-gradient);
 }
 
 .routeTransitionMask {
@@ -85,7 +66,5 @@
 @media (max-width: 700px) {
 	.page {
 		--page-pad-x: 0.4rem;
-		--app-shell-top-blur-top: 0;
-		--app-shell-top-blur-height: calc(3.15rem + env(safe-area-inset-top, 0px));
 	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -461,7 +461,6 @@ function AppContent() {
 
 	return (
 		<Box className={classes.page} component="main" data-testid="app-shell">
-			<div aria-hidden="true" className={classes.topBlur} data-testid="app-shell-top-blur" />
 			<AppHeader onOpenProfile={openProfile} onOpenAbout={openAbout} />
 
 			{/* Profile Modal */}

--- a/frontend/src/AppSurfaces.css
+++ b/frontend/src/AppSurfaces.css
@@ -612,10 +612,15 @@ textarea.auto-resize {
 	color: var(--text-secondary);
 	line-height: 1.2;
 }
+
 .date-pair-stack-header .date-pair-label {
-	font-size: 0.95rem;
-	font-weight: 750;
+	font-family: inherit;
+	font-size: inherit;
+	font-weight: inherit;
 	letter-spacing: 0;
+	text-transform: none;
+	color: inherit;
+	line-height: 1.25;
 }
 
 .date-pair-value {
@@ -624,6 +629,15 @@ textarea.auto-resize {
 	color: var(--text-primary);
 	line-height: 1.3;
 	word-break: break-word;
+}
+
+@media (max-width: 768px) {
+	.date-pair-entry {
+		display: grid;
+		grid-template-columns: minmax(11rem, 48%) minmax(0, 1fr);
+		align-items: baseline;
+		gap: 0.75rem;
+	}
 }
 
 .form-category {
@@ -2442,13 +2456,13 @@ button.has-validation-error {
 	}
 
 	.dose-person {
+		display: grid;
 		width: 100%;
 		min-width: 0;
 		--dose-action-take-width: clamp(4.9rem, 22vw, 7rem);
 		--dose-action-skip-width: clamp(4.25rem, 18vw, 5.2rem);
 		--dose-action-journal-width: clamp(4.9rem, 20vw, 6.25rem);
 
-		display: grid;
 		grid-template-columns:
 			minmax(0, 1fr) var(--dose-action-take-width) var(--dose-action-skip-width)
 			var(--dose-action-journal-width);
@@ -2468,6 +2482,18 @@ button.has-validation-error {
 		display: none;
 	}
 
+	.dose-checks.has-recipient-summary:not(.multi-person) .dose-person {
+		grid-template-columns:
+			var(--dose-action-take-width) var(--dose-action-skip-width)
+			var(--dose-action-journal-width);
+	}
+
+	.dose-person:not(:has(.person-name)) {
+		grid-template-columns:
+			var(--dose-action-take-width) var(--dose-action-skip-width)
+			var(--dose-action-journal-width);
+	}
+
 	.dose-person .dose-btn {
 		height: 26px;
 		min-height: 26px;
@@ -2475,6 +2501,11 @@ button.has-validation-error {
 		min-width: 0;
 		padding: 0 0.5rem;
 		font-size: 0.72rem;
+	}
+
+	.dose-person button {
+		width: 100%;
+		justify-content: center;
 	}
 
 	.dose-btn .dose-btn-label {

--- a/frontend/src/components/AppHeader.module.css
+++ b/frontend/src/components/AppHeader.module.css
@@ -1,22 +1,39 @@
 .header {
+	--app-header-sticky-bleed: var(--mantine-other-surface-radius);
+
 	position: sticky;
-	top: 0.6rem;
+	top: calc(0px - var(--app-header-sticky-bleed));
 	z-index: 140;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 1.5rem;
-	margin: 0.6rem 0 1.75rem;
-	padding: 0.6rem 1rem;
-	background: color-mix(in srgb, var(--mantine-other-bg-secondary) 90%, transparent);
-	backdrop-filter: blur(14px) saturate(1.3);
-	-webkit-backdrop-filter: blur(14px) saturate(1.3);
+	margin: 0 0 1.75rem;
+	padding: calc(0.6rem + var(--app-header-sticky-bleed)) 1rem 0.6rem;
+	background: transparent;
 	border: 1px solid var(--mantine-other-border-primary);
 	border-radius: var(--mantine-other-surface-radius);
+	isolation: isolate;
+	overflow: hidden;
 	box-shadow: 0 8px 24px color-mix(in srgb, var(--mantine-other-shadow) 30%, transparent);
 	transition:
 		background 200ms ease,
 		border-color 200ms ease;
+}
+
+.header::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: -1;
+	border-radius: inherit;
+	background: color-mix(in srgb, var(--mantine-other-bg-secondary) 82%, transparent);
+	backdrop-filter: blur(24px) saturate(1.05);
+	-webkit-backdrop-filter: blur(24px) saturate(1.05);
+}
+
+:global([data-theme="light"]) .header::before {
+	background: color-mix(in srgb, var(--mantine-other-bg-secondary) 78%, transparent);
 }
 
 .titleGroup {
@@ -158,9 +175,9 @@
 		grid-template-columns: minmax(0, 1fr) auto;
 		align-items: center;
 		gap: 0.55rem 0.75rem;
-		top: 0.4rem;
-		margin: 0.4rem 0 1rem;
-		padding: 0.6rem 0.7rem 0.65rem;
+		top: calc(0px - var(--app-header-sticky-bleed));
+		margin: 0 0 1rem;
+		padding: calc(0.6rem + var(--app-header-sticky-bleed)) 0.7rem 0.65rem;
 	}
 
 	.actions {

--- a/frontend/src/components/dashboard/DashboardReminderSection.module.css
+++ b/frontend/src/components/dashboard/DashboardReminderSection.module.css
@@ -38,7 +38,7 @@
 .row {
 	display: grid;
 	grid-template-columns: minmax(9rem, max-content) minmax(0, 1fr);
-	gap: 0.5rem 0.85rem;
+	gap: 0.5rem 0.35rem;
 	align-items: baseline;
 	line-height: 1.5;
 }

--- a/frontend/src/test/ui/app-shell-blur-contract.test.ts
+++ b/frontend/src/test/ui/app-shell-blur-contract.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readSource(filePath: string) {
+	return readFileSync(resolve(srcRoot, filePath), "utf8");
+}
+
+function extractSimpleCssBlocks(css: string) {
+	return Array.from(css.matchAll(/([^{}]+)\{([^{}]*)\}/g)).map((match) => ({
+		selector: match[1].trim(),
+		body: match[2],
+	}));
+}
+
+function blockFor(css: string, selector: string) {
+	return extractSimpleCssBlocks(css).find((block) => block.selector === selector)?.body ?? "";
+}
+
+describe("app shell header blur contract", () => {
+	it("does not keep a disabled outer top blur in the active app shell", () => {
+		const appSource = readSource("App.tsx");
+		const css = readSource("App.module.css");
+
+		expect(appSource).not.toMatch(/app-shell-top-blur/);
+		expect(css).not.toMatch(/\.topBlur/);
+		expect(css).not.toMatch(/--app-shell-top-blur-height/);
+	});
+
+	it("keeps blur clipped to the header surface and matching rounded corners", () => {
+		const css = readSource("components/AppHeader.module.css");
+		const header = blockFor(css, ".header");
+		const headerBlur = blockFor(css, ".header::before");
+
+		expect(header).toMatch(/--app-header-sticky-bleed\s*:\s*var\(--mantine-other-surface-radius\)/);
+		expect(header).toMatch(/top\s*:\s*calc\(0px - var\(--app-header-sticky-bleed\)\)/);
+		expect(header).toMatch(/margin\s*:\s*0\s+0\s+1\.75rem/);
+		expect(header).toMatch(/padding\s*:\s*calc\(0\.6rem \+ var\(--app-header-sticky-bleed\)\) 1rem 0\.6rem/);
+		expect(header).toMatch(/background\s*:\s*transparent/);
+		expect(header).toMatch(/border-radius\s*:\s*var\(--mantine-other-surface-radius\)/);
+		expect(header).toMatch(/isolation\s*:\s*isolate/);
+		expect(header).toMatch(/overflow\s*:\s*hidden/);
+		expect(headerBlur).toMatch(/inset\s*:\s*0/);
+		expect(headerBlur).toMatch(/border-radius\s*:\s*inherit/);
+		expect(headerBlur).toMatch(
+			/background\s*:\s*color-mix\(in srgb, var\(--mantine-other-bg-secondary\) 82%, transparent\)/
+		);
+		expect(headerBlur).toMatch(/backdrop-filter\s*:\s*blur\(24px\) saturate\(1\.05\)/);
+		expect(headerBlur).toMatch(/-webkit-backdrop-filter\s*:\s*blur\(24px\) saturate\(1\.05\)/);
+	});
+
+	it("keeps the mobile sticky boundary inside the header", () => {
+		const css = readSource("components/AppHeader.module.css");
+
+		expect(css).toMatch(/@media \(max-width: 700px\)[\s\S]*top\s*:\s*calc\(0px - var\(--app-header-sticky-bleed\)\)/);
+		expect(css).toMatch(/@media \(max-width: 700px\)[\s\S]*margin\s*:\s*0\s+0\s+1rem/);
+		expect(css).toMatch(
+			/@media \(max-width: 700px\)[\s\S]*padding\s*:\s*calc\(0\.6rem \+ var\(--app-header-sticky-bleed\)\) 0\.7rem 0\.65rem/
+		);
+	});
+});

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -1,0 +1,118 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readSource(filePath: string) {
+	return readFileSync(resolve(srcRoot, filePath), "utf8");
+}
+
+function extractSimpleCssBlocks(css: string) {
+	return Array.from(css.matchAll(/([^{}]+)\{([^{}]*)\}/g)).map((match) => ({
+		selector: match[1].trim(),
+		body: match[2],
+	}));
+}
+
+function blockFor(css: string, selector: string) {
+	return extractSimpleCssBlocks(css).find((block) => block.selector === selector)?.body ?? "";
+}
+
+function lastBlockFor(css: string, selector: string) {
+	return (
+		extractSimpleCssBlocks(css)
+			.filter((block) => block.selector === selector)
+			.at(-1)?.body ?? ""
+	);
+}
+
+describe("dashboard no-wrap and reminder spacing contract", () => {
+	it("keeps overview table headers visually distinct", () => {
+		const tableCss = readSource("ui/primitives/DataTable.module.css");
+		const surfacesCss = readSource("AppSurfaces.css");
+		const headCell = blockFor(tableCss, ".headCell");
+		const stackedHeaderLabel = blockFor(surfacesCss, ".date-pair-stack-header .date-pair-label");
+
+		expect(headCell).toMatch(/font-size\s*:\s*0\.95rem/);
+		expect(headCell).toMatch(/font-weight\s*:\s*750/);
+		expect(stackedHeaderLabel).toMatch(/font-family\s*:\s*inherit/);
+		expect(stackedHeaderLabel).toMatch(/font-size\s*:\s*inherit/);
+		expect(stackedHeaderLabel).toMatch(/text-transform\s*:\s*none/);
+		expect(stackedHeaderLabel).toMatch(/letter-spacing\s*:\s*0/);
+	});
+
+	it("keeps short overview values on one line when horizontal space is available", () => {
+		const css = readSource("ui/primitives/DataTable.module.css");
+		const mobileBodyCell = lastBlockFor(css, ".bodyCell");
+		const numericValueColumns = blockFor(
+			css,
+			[
+				'.bodyCell[data-column-key="stock"]',
+				'.bodyCell[data-column-key="dailyConsumption"]',
+				'.bodyCell[data-column-key="stockDetails"]',
+				'.bodyCell[data-column-key="daysLeft"]',
+				'.bodyCell[data-column-key="status"]',
+			].join(",\n")
+		);
+		const dateValue = blockFor(css, '.bodyCell[data-column-key="datePair"] :global(.date-pair-value)');
+
+		expect(mobileBodyCell).toMatch(/grid-template-columns\s*:\s*minmax\(11rem, 48%\) minmax\(0, 1fr\)/);
+		expect(numericValueColumns).toMatch(/white-space\s*:\s*nowrap/);
+		expect(dateValue).toMatch(/white-space\s*:\s*nowrap/);
+	});
+
+	it("keeps mobile runs-out and expiry dates in the same value column as other overview values", () => {
+		const css = readSource("AppSurfaces.css");
+		const desktopDatePairEntry = blockFor(css, ".date-pair-entry");
+		const mobileDatePairEntry = lastBlockFor(css, ".date-pair-entry");
+
+		expect(desktopDatePairEntry).toMatch(/display\s*:\s*flex/);
+		expect(desktopDatePairEntry).toMatch(/flex-direction\s*:\s*column/);
+		expect(mobileDatePairEntry).toMatch(/display\s*:\s*grid/);
+		expect(mobileDatePairEntry).toMatch(/grid-template-columns\s*:\s*minmax\(11rem, 48%\) minmax\(0, 1fr\)/);
+		expect(mobileDatePairEntry).toMatch(/align-items\s*:\s*baseline/);
+	});
+
+	it("keeps reminder label/value spacing close to a single typed space", () => {
+		const css = readSource("components/dashboard/DashboardReminderSection.module.css");
+		const row = blockFor(css, ".row");
+
+		expect(row).toMatch(/gap\s*:\s*0\.5rem\s+0\.35rem/);
+		expect(row).not.toMatch(/0\.85rem/);
+	});
+
+	it("keeps mobile dose action buttons in stable slots", () => {
+		const surfacesCss = readSource("AppSurfaces.css");
+		const buttonCss = readSource("components/DoseActionButton.module.css");
+		const dosePerson = lastBlockFor(surfacesCss, ".dose-person");
+		const singleRecipientDosePerson = blockFor(
+			surfacesCss,
+			".dose-checks.has-recipient-summary:not(.multi-person) .dose-person"
+		);
+		const anonymousDosePerson = blockFor(surfacesCss, ".dose-person:not(:has(.person-name))");
+		const dosePersonButton = lastBlockFor(surfacesCss, ".dose-person .dose-btn");
+		const dosePersonRawButton = blockFor(surfacesCss, ".dose-person button");
+		const tooltipTarget = blockFor(buttonCss, ".tooltipTarget");
+
+		expect(dosePerson).toMatch(/display\s*:\s*grid/);
+		expect(dosePerson).toMatch(/--dose-action-take-width\s*:\s*clamp\(4\.9rem, 22vw, 7rem\)/);
+		expect(dosePerson).toMatch(/--dose-action-skip-width\s*:\s*clamp\(4\.25rem, 18vw, 5\.2rem\)/);
+		expect(dosePerson).toMatch(/--dose-action-journal-width\s*:\s*clamp\(4\.9rem, 20vw, 6\.25rem\)/);
+		expect(dosePerson).toMatch(
+			/grid-template-columns\s*:\s*minmax\(0, 1fr\) var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
+		);
+		expect(singleRecipientDosePerson).toMatch(
+			/grid-template-columns\s*:\s*var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
+		);
+		expect(anonymousDosePerson).toMatch(
+			/grid-template-columns\s*:\s*var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
+		);
+		expect(dosePersonButton).toMatch(/width\s*:\s*100%/);
+		expect(dosePersonRawButton).toMatch(/width\s*:\s*100%/);
+		expect(tooltipTarget).toMatch(/width\s*:\s*100%/);
+	});
+});

--- a/frontend/src/ui/primitives/DataTable.module.css
+++ b/frontend/src/ui/primitives/DataTable.module.css
@@ -62,6 +62,18 @@
 	background: transparent;
 }
 
+.bodyCell[data-column-key="stock"],
+.bodyCell[data-column-key="dailyConsumption"],
+.bodyCell[data-column-key="stockDetails"],
+.bodyCell[data-column-key="daysLeft"],
+.bodyCell[data-column-key="status"] {
+	white-space: nowrap;
+}
+
+.bodyCell[data-column-key="datePair"] :global(.date-pair-value) {
+	white-space: nowrap;
+}
+
 .body :global(tr:first-child) .bodyCell {
 	border-top: none;
 }
@@ -123,8 +135,8 @@
 
 	.bodyCell {
 		display: grid;
-		grid-template-columns: minmax(6rem, 38%) minmax(0, 1fr);
-		align-items: center;
+		grid-template-columns: minmax(11rem, 48%) minmax(0, 1fr);
+		align-items: start;
 		gap: 0.75rem;
 		padding: 0.55rem 0.8rem;
 		border-top: 1px solid color-mix(in srgb, var(--border-primary) 70%, transparent);

--- a/frontend/src/ui/primitives/DataTable.module.css
+++ b/frontend/src/ui/primitives/DataTable.module.css
@@ -71,6 +71,8 @@
 }
 
 .bodyCell[data-column-key="datePair"] :global(.date-pair-value) {
+	justify-self: end;
+	text-align: right;
 	white-space: nowrap;
 }
 
@@ -136,7 +138,7 @@
 	.bodyCell {
 		display: grid;
 		grid-template-columns: minmax(11rem, 48%) minmax(0, 1fr);
-		align-items: start;
+		align-items: center;
 		gap: 0.75rem;
 		padding: 0.55rem 0.8rem;
 		border-top: 1px solid color-mix(in srgb, var(--border-primary) 70%, transparent);


### PR DESCRIPTION
## Summary
- Move the app-shell header blur into the clipped `AppHeader` surface and remove the disabled outer top blur DOM/CSS.
- Tighten dashboard reminder spacing and improve Medication Overview header/date/value alignment on mobile.
- Keep mobile dose action buttons in stable action slots for named, single-recipient, and anonymous rows.
- Add focused UI contract coverage for the header blur and dashboard/mobile spacing contracts.

## Validation
- Focused UI contract tests: 8/8 passed.
- `cd frontend && npm run check` passed.
- `git diff --check github/main...HEAD` passed.

Closes #826