### PR TITLE
chore: release 1.28.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.28.0
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.28.1
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.28.0
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.28.1
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "dependencies": {
         "@mantine/core": "^8.3.18",
         "@mantine/dates": "^8.3.18",
@@ -43,7 +43,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.28.1",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Prepare patch release v1.28.1 for the merged UI/UX fixes since v1.28.0.

## Included fixes

- b6c8f442 fix(ui): integrate dashboard reminder card
- 9c0fc877 fix(ui): polish dashboard and shared mobile layouts
- bbc0f591 fix(ui): tighten dashboard mobile spacing

## Release metadata

- Bump backend, frontend, and shared package versions to 1.28.1.
- Update package lock version entries for the strict shared package release policy.
- Pin production compose backend and frontend images to 1.28.1.

## Validation

- `npm run release:preflight -- --tag v1.28.1 --static-only`
- `npm run test:release-preflight`
- `npm run check`

Closes #828