### PR TITLE
fix: mobile intake parity between main and shared schedules

### DIFF
--- a/frontend/src/AppSurfaces.css
+++ b/frontend/src/AppSurfaces.css
@@ -2459,9 +2459,9 @@ button.has-validation-error {
 		display: grid;
 		width: 100%;
 		min-width: 0;
-		--dose-action-take-width: clamp(4.9rem, 22vw, 7rem);
-		--dose-action-skip-width: clamp(4.25rem, 18vw, 5.2rem);
-		--dose-action-journal-width: clamp(4.9rem, 20vw, 6.25rem);
+		--dose-action-take-width: clamp(5.35rem, 23vw, 7.1rem);
+		--dose-action-skip-width: clamp(4.45rem, 19vw, 5.35rem);
+		--dose-action-journal-width: clamp(5rem, 21vw, 6.35rem);
 
 		grid-template-columns:
 			minmax(0, 1fr) var(--dose-action-take-width) var(--dose-action-skip-width)
@@ -2480,18 +2480,6 @@ button.has-validation-error {
 
 	.dose-checks.has-recipient-summary:not(.multi-person) .person-name {
 		display: none;
-	}
-
-	.dose-checks.has-recipient-summary:not(.multi-person) .dose-person {
-		grid-template-columns:
-			var(--dose-action-take-width) var(--dose-action-skip-width)
-			var(--dose-action-journal-width);
-	}
-
-	.dose-person:not(:has(.person-name)) {
-		grid-template-columns:
-			var(--dose-action-take-width) var(--dose-action-skip-width)
-			var(--dose-action-journal-width);
 	}
 
 	.dose-person .dose-btn {

--- a/frontend/src/components/DoseActionButton.module.css
+++ b/frontend/src/components/DoseActionButton.module.css
@@ -23,7 +23,14 @@
 .button :global(.mantine-Button-label) {
 	display: inline-flex;
 	align-items: center;
+	justify-content: center;
 	gap: 0.35rem;
+}
+
+.actionIcon {
+	width: 0.9rem;
+	height: 0.9rem;
+	flex-shrink: 0;
 }
 
 .tooltipTarget {

--- a/frontend/src/components/SharedSchedule.module.css
+++ b/frontend/src/components/SharedSchedule.module.css
@@ -473,33 +473,6 @@
 		overflow: hidden;
 	}
 
-	.shared-schedule-section .dose-checks {
-		grid-column: 1 / -1;
-		overflow: visible;
-	}
-
-	.shared-schedule-section .dose-person {
-		display: grid;
-		grid-template-columns: minmax(0, 1fr) auto auto auto;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.4rem;
-		overflow: visible;
-	}
-
-	.shared-schedule-section .dose-person .person-name {
-		grid-column: 1 / -1;
-		justify-self: stretch;
-		max-width: 100%;
-		margin-right: 0;
-	}
-
-	.shared-schedule-section .dose-person button {
-		height: 28px;
-		min-height: 28px;
-		padding-inline: 0.55rem;
-	}
-
 	.shared-overview-table-wrap {
 		display: none;
 	}

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -613,6 +613,7 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"dose-btn undo take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.undo,
@@ -629,6 +630,7 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"dose-btn take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.take,
@@ -660,6 +662,7 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"dose-btn undo skip",
 					doseButtonClasses.button,
 					doseButtonClasses.skipAction,
 					doseButtonClasses.undo,
@@ -674,7 +677,7 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
+				className={cx("dose-btn skip", doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken}
 			>
@@ -687,6 +690,7 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"dose-btn journal",
 					doseButtonClasses.button,
 					doseButtonClasses.journalAction,
 					doseButtonClasses.journal,

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -4,7 +4,7 @@
 /* biome-ignore-all lint/style/noNestedTernary: rendering branches are intentionally explicit in schedule UI */
 /* biome-ignore-all lint/correctness/useExhaustiveDependencies: modal and helper callbacks are stable at runtime */
 
-import { NotebookPen } from "lucide-react";
+import { Check, NotebookPen, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -613,7 +613,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn undo take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.undo,
@@ -623,14 +622,13 @@ export function SharedSchedule() {
 			>
 				{options.isAutomaticallyTaken && <AppTooltipTrigger label={t("tooltips.automaticTaken")}>🤖</AppTooltipTrigger>}
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
-				<span aria-hidden="true">↩</span>
+				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.take,
@@ -641,7 +639,11 @@ export function SharedSchedule() {
 				disabled={options.isEmpty}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
-				<span aria-hidden="true">{options.isEmpty ? "⊘" : "✓"}</span>
+				{options.isEmpty ? (
+					<span aria-hidden="true">⊘</span>
+				) : (
+					<Check className={doseButtonClasses.actionIcon} aria-hidden="true" />
+				)}
 			</AppButton>
 		);
 		const takeButton =
@@ -658,7 +660,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn undo skip",
 					doseButtonClasses.button,
 					doseButtonClasses.skipAction,
 					doseButtonClasses.undo,
@@ -667,13 +668,13 @@ export function SharedSchedule() {
 				onClick={() => undoDoseSkipped(options.doseId)}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.undoSkip")}</span>
-				<span aria-hidden="true">↩</span>
+				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx("dose-btn skip", doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
+				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken}
 			>
@@ -686,7 +687,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn journal",
 					doseButtonClasses.button,
 					doseButtonClasses.journalAction,
 					doseButtonClasses.journal,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 /* biome-ignore-all lint/style/noNestedTernary: timeline rendering uses explicit UI-state branching */
 import { ActionIcon, Group } from "@mantine/core";
-import { Archive, Bell, ClipboardList, NotebookPen, Share2 } from "lucide-react";
+import { Archive, Bell, Check, ClipboardList, NotebookPen, Share2, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
@@ -471,7 +471,7 @@ export function DashboardPage() {
 			>
 				{options.isAutomaticallyTaken && <AppTooltipTrigger label={t("tooltips.automaticTaken")}>🤖</AppTooltipTrigger>}
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
-				<span aria-hidden="true">↩</span>
+				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
@@ -488,7 +488,11 @@ export function DashboardPage() {
 				disabled={options.isEmpty || options.isSkipped}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
-				<span aria-hidden="true">{options.isEmpty ? "⊘" : "✓"}</span>
+				{options.isEmpty ? (
+					<span aria-hidden="true">⊘</span>
+				) : (
+					<Check className={doseButtonClasses.actionIcon} aria-hidden="true" />
+				)}
 			</AppButton>
 		);
 		const takeButton =
@@ -548,7 +552,7 @@ export function DashboardPage() {
 				onClick={() => undoDoseSkipped(options.doseId)}
 			>
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
-				<span aria-hidden="true">↩</span>
+				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -1,6 +1,6 @@
 /* biome-ignore-all lint/style/noNestedTernary: schedule timeline branches are intentionally explicit */
 import { Group } from "@mantine/core";
-import { Archive, Bell, ClipboardList, NotebookPen } from "lucide-react";
+import { Archive, Bell, Check, ClipboardList, NotebookPen, Undo2 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
@@ -339,12 +339,17 @@ export function SchedulePage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.undo, doseButtonClasses.undoTake)}
+				className={cx(
+					doseButtonClasses.button,
+					doseButtonClasses.takeAction,
+					doseButtonClasses.undo,
+					doseButtonClasses.undoTake
+				)}
 				onClick={() => undoDoseTaken(options.doseId)}
 			>
 				{options.isAutomaticallyTaken && <AppTooltipTrigger label={t("tooltips.automaticTaken")}>🤖</AppTooltipTrigger>}
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
-				<span aria-hidden="true">↩</span>
+				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
@@ -352,6 +357,7 @@ export function SchedulePage() {
 				size="sm"
 				className={cx(
 					doseButtonClasses.button,
+					doseButtonClasses.takeAction,
 					doseButtonClasses.take,
 					options.isEmpty && doseButtonClasses.outOfStock
 				)}
@@ -359,13 +365,17 @@ export function SchedulePage() {
 				disabled={options.isEmpty || options.isSkipped}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
-				<span aria-hidden="true">{options.isEmpty ? "⊘" : "✓"}</span>
+				{options.isEmpty ? (
+					<span aria-hidden="true">⊘</span>
+				) : (
+					<Check className={doseButtonClasses.actionIcon} aria-hidden="true" />
+				)}
 			</AppButton>
 		);
 		const takeButton =
 			!options.isTaken && options.isEmpty ? (
 				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
-					<span className={doseButtonClasses.tooltipTarget}>{takeButtonControl}</span>
+					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
 				</AppTooltip>
 			) : (
 				takeButtonControl
@@ -375,17 +385,22 @@ export function SchedulePage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.undo, doseButtonClasses.undoSkip)}
+				className={cx(
+					doseButtonClasses.button,
+					doseButtonClasses.skipAction,
+					doseButtonClasses.undo,
+					doseButtonClasses.undoSkip
+				)}
 				onClick={() => undoDoseSkipped(options.doseId)}
 			>
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
-				<span aria-hidden="true">↩</span>
+				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.skip)}
+				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken}
 			>
@@ -397,7 +412,7 @@ export function SchedulePage() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.journal)}
+				className={cx(doseButtonClasses.button, doseButtonClasses.journalAction, doseButtonClasses.journal)}
 				onClick={() => {
 					if (!journalUnavailable) {
 						void openJournalEditor(options.doseId);
@@ -411,7 +426,9 @@ export function SchedulePage() {
 		);
 		const journalButton = journalUnavailable ? (
 			<AppTooltip label={t("journal.actions.noteTakenOnly")}>
-				<span className={doseButtonClasses.tooltipTarget}>{journalButtonControl}</span>
+				<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.journalAction)}>
+					{journalButtonControl}
+				</span>
 			</AppTooltip>
 		) : (
 			journalButtonControl

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -105,12 +105,8 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 		expect(dosePerson).toMatch(
 			/grid-template-columns\s*:\s*minmax\(0, 1fr\) var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
 		);
-		expect(singleRecipientDosePerson).toMatch(
-			/grid-template-columns\s*:\s*var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
-		);
-		expect(anonymousDosePerson).toMatch(
-			/grid-template-columns\s*:\s*var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
-		);
+		expect(singleRecipientDosePerson).not.toMatch(/grid-template-columns/);
+		expect(anonymousDosePerson).not.toMatch(/grid-template-columns/);
 		expect(dosePersonButton).toMatch(/width\s*:\s*100%/);
 		expect(dosePersonRawButton).toMatch(/width\s*:\s*100%/);
 		expect(tooltipTarget).toMatch(/width\s*:\s*100%/);

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -99,9 +99,9 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 		const tooltipTarget = blockFor(buttonCss, ".tooltipTarget");
 
 		expect(dosePerson).toMatch(/display\s*:\s*grid/);
-		expect(dosePerson).toMatch(/--dose-action-take-width\s*:\s*clamp\(4\.9rem, 22vw, 7rem\)/);
-		expect(dosePerson).toMatch(/--dose-action-skip-width\s*:\s*clamp\(4\.25rem, 18vw, 5\.2rem\)/);
-		expect(dosePerson).toMatch(/--dose-action-journal-width\s*:\s*clamp\(4\.9rem, 20vw, 6\.25rem\)/);
+		expect(dosePerson).toMatch(/--dose-action-take-width\s*:\s*clamp\(5\.35rem, 23vw, 7\.1rem\)/);
+		expect(dosePerson).toMatch(/--dose-action-skip-width\s*:\s*clamp\(4\.45rem, 19vw, 5\.35rem\)/);
+		expect(dosePerson).toMatch(/--dose-action-journal-width\s*:\s*clamp\(5rem, 21vw, 6\.35rem\)/);
 		expect(dosePerson).toMatch(
 			/grid-template-columns\s*:\s*minmax\(0, 1fr\) var\(--dose-action-take-width\) var\(--dose-action-skip-width\)\s*var\(--dose-action-journal-width\)/
 		);


### PR DESCRIPTION
Closes #831

## Summary
- align mobile intake action sizing and layout between main and shared schedules
- keep icon/action parity between schedule surfaces
- preserve existing behavior while normalizing visual treatment

## Scope
- frontend parity update only
- no backend or database changes