### PR TITLE
fix(shared): keep intake actions visible and gate container smoke

### DIFF
--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,17 +1,9 @@
 name: Container Smoke
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'shared/**'
-      - 'package*.json'
-      - 'backend/package*.json'
-      - 'frontend/package*.json'
-      - 'shared/package*.json'
-      - 'docker-compose*.yml'
+  workflow_run:
+    workflows: ['Test', 'E2E Tests']
+    types: [completed]
   workflow_call:
     inputs:
       image_source:
@@ -31,15 +23,78 @@ on:
         default: ''
 
 concurrency:
-  group: container-smoke-${{ github.ref }}
+  group: container-smoke-${{ github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
+  checks: read
 
 jobs:
+  gate:
+    name: Evaluate CI Gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.required_check_gate.outputs.should_run || steps.workflow_call_gate.outputs.should_run || 'false' }}
+    steps:
+      - name: Allow smoke when called as reusable workflow
+        id: workflow_call_gate
+        if: github.event_name == 'workflow_call'
+        run: echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure triggering workflow succeeded
+        id: trigger_conclusion
+        if: github.event_name == 'workflow_run'
+        run: |
+          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+            echo "Triggering workflow conclusion is '${{ github.event.workflow_run.conclusion }}'; skipping smoke."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify required checks for this commit
+        id: required_check_gate
+        if: github.event_name == 'workflow_run' && steps.trigger_conclusion.outputs.should_run == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = context.payload.workflow_run.head_sha;
+            const requiredChecks = ['Backend Tests', 'Frontend Build', 'Playwright E2E'];
+
+            const response = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref,
+              per_page: 100,
+            });
+
+            const checkMap = new Map();
+            for (const run of response.data.check_runs) {
+              checkMap.set(run.name, run.conclusion);
+            }
+
+            let shouldRun = true;
+            for (const checkName of requiredChecks) {
+              const conclusion = checkMap.get(checkName);
+              core.info(`${checkName}: ${conclusion ?? 'missing'}`);
+              if (conclusion !== 'success') {
+                shouldRun = false;
+              }
+            }
+
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+
+      - name: Skip smoke when required checks are not all green
+        if: github.event_name == 'workflow_run' && (steps.trigger_conclusion.outputs.should_run != 'true' || steps.required_check_gate.outputs.should_run != 'true')
+        run: echo "Skipping Container Smoke because required checks are not all successful for this commit."
+
   smoke:
     name: Container Smoke
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -53,6 +108,8 @@ jobs:
       - name: Checkout repository
         if: github.event_name != 'workflow_call' || inputs.image_source != 'published'
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Docker Buildx
         if: github.event_name != 'workflow_call' || inputs.image_source != 'published'

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ ops/medtest/
 # ===================
 .codex/
 .github/agents/*.agent.md
+.kilocode/rules/rtk-rules.md

--- a/frontend/e2e/domain-safety.spec.ts
+++ b/frontend/e2e/domain-safety.spec.ts
@@ -213,20 +213,20 @@ test.describe("Domain safety flows", () => {
 		const todayBlock = page.locator(".day-block.today");
 		const doseItem = page.locator(".dose-item").first();
 		await expect(doseItem).toBeVisible({ timeout: 15000 });
-		await expect(doseItem.locator(".dose-btn.take:not(.undo)")).toBeVisible();
+		await expect(doseItem.getByRole("button", { name: /take/i })).toBeVisible();
 
-		await doseItem.locator(".dose-btn.take:not(.undo)").click();
+		await doseItem.getByRole("button", { name: /take/i }).click();
 		await expect.poll(async () => (await getShareDoses(page, share.token)).length).toBe(1);
 		const markedDoses = await getShareDoses(page, share.token);
 		const markedDoseId = markedDoses[0].doseId;
 
-		const undoButton = todayBlock.locator(".dose-btn.undo.take").first();
+		const undoButton = todayBlock.getByRole("button", { name: /undo/i }).first();
 		if (!(await undoButton.isVisible().catch(() => false))) {
 			await todayBlock.locator(".day-divider.clickable").click();
 		}
 		await expect(undoButton).toBeVisible({ timeout: 10000 });
 		await undoButton.click();
-		await expect(todayBlock.locator(".dose-btn.take:not(.undo)").first()).toBeVisible({ timeout: 10000 });
+		await expect(todayBlock.getByRole("button", { name: /take/i }).first()).toBeVisible({ timeout: 10000 });
 		await expect
 			.poll(async () => (await getShareDoses(page, share.token)).some((dose) => dose.doseId === markedDoseId))
 			.toBe(false);

--- a/frontend/src/components/DoseActionButton.module.css
+++ b/frontend/src/components/DoseActionButton.module.css
@@ -48,6 +48,20 @@
 		--button-padding-x: 0.62rem;
 		--button-fz: 0.78rem;
 	}
+
+	.undo:global(.mantine-Button-root) {
+		--button-padding-x: 0.5rem;
+		--button-fz: 0.74rem;
+	}
+
+	.undo :global(.mantine-Button-label) {
+		gap: 0.22rem;
+	}
+
+	.undo .actionIcon {
+		width: 0.8rem;
+		height: 0.8rem;
+	}
 }
 
 .take {

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -613,7 +613,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn undo take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.undo,
@@ -636,7 +635,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn take",
 					"take-action-button",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
@@ -673,7 +671,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn undo skip",
 					doseButtonClasses.button,
 					doseButtonClasses.skipAction,
 					doseButtonClasses.undo,
@@ -688,7 +685,7 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx("dose-btn skip", doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
+				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken || !canMarkTaken}
 			>
@@ -708,7 +705,6 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
-					"dose-btn journal",
 					doseButtonClasses.button,
 					doseButtonClasses.journalAction,
 					doseButtonClasses.journal,

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -645,7 +645,7 @@ export function SharedSchedule() {
 					options.isEmpty && doseButtonClasses.outOfStock
 				)}
 				onClick={() => markDoseTaken(options.doseId)}
-				disabled={options.isEmpty}
+				disabled={options.isEmpty || !canMarkTaken}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
 				{options.isEmpty ? (
@@ -658,6 +658,10 @@ export function SharedSchedule() {
 		const takeButton =
 			!options.isTaken && options.isEmpty ? (
 				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
+					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
+				</AppTooltip>
+			) : !canMarkTaken ? (
+				<AppTooltip label={t("share.readOnly")}>
 					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
 				</AppTooltip>
 			) : (
@@ -686,10 +690,17 @@ export function SharedSchedule() {
 				size="sm"
 				className={cx("dose-btn skip", doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
-				disabled={options.isTaken}
+				disabled={options.isTaken || !canMarkTaken}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.skip")}</span>
 			</AppButton>
+		);
+		const skipButtonWithReadOnlyTooltip = !canMarkTaken ? (
+			<AppTooltip label={t("share.readOnly")}>
+				<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.skipAction)}>{skipButton}</span>
+			</AppTooltip>
+		) : (
+			skipButton
 		);
 
 		const journalButtonControl = showSharedJournalAction ? (
@@ -727,8 +738,8 @@ export function SharedSchedule() {
 
 		return (
 			<>
-				{canMarkTaken ? takeButton : null}
-				{canMarkTaken ? skipButton : null}
+				{takeButton}
+				{skipButtonWithReadOnlyTooltip}
 				{journalButton}
 			</>
 		);


### PR DESCRIPTION
## Summary
- keep shared read-only intake action buttons visible by restoring shared action button classes
- update domain safety e2e coverage for shared action selectors
- gate container smoke workflow behind required test workflow success to fail fast
- include pending local ignore alignment

## Validation
- frontend check/build previously run locally in this workspace (`npm run check && npm run build`)

## Notes
- This PR is created from commits already present on local `main` but intentionally pushed on a dedicated branch per branch protection policy.