### PR TITLE
fix(ci): grant checks read permission to container smoke caller

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -154,6 +154,7 @@ jobs:
     name: Container Smoke
     needs: [prepare-image-coordinates, build-and-push]
     permissions:
+      checks: read
       contents: read
       packages: read
     uses: ./.github/workflows/container-smoke.yml


### PR DESCRIPTION
## Summary
- add `checks: read` to `container-smoke` job permissions in `.github/workflows/docker-build.yml`
- resolve reusable workflow permission mismatch that caused startup failure in run #564

## Validation
- scoped hotfix diff: one file, one insertion

Closes #835