### PR TITLE
fix: show patient name in mobile shared schedule intake list

### DIFF
--- a/frontend/src/components/SharedSchedule.module.css
+++ b/frontend/src/components/SharedSchedule.module.css
@@ -165,23 +165,10 @@
 	gap: 0.9rem;
 }
 
-.shared-timeline {
-	background: var(--bg-secondary);
-	border-radius: 12px;
-	padding: 1.5rem;
-	border: 1px solid var(--border-primary);
-}
-
 .shared-schedule-empty {
 	text-align: center;
 	padding: 2rem;
 	color: var(--text-secondary);
-}
-
-.shared-dose {
-	background: transparent;
-	border: none;
-	padding: 0.5rem 0;
 }
 
 .med-name-stack {
@@ -196,6 +183,10 @@
 	font-size: 0.875rem;
 	color: var(--text-secondary);
 	margin-left: 0;
+}
+
+.shared-dose-recipients {
+	display: none;
 }
 
 .shared-schedule-footer {
@@ -389,14 +380,14 @@
 
 	.shared-schedule-container,
 	.shared-schedule-section,
-	.shared-schedule-section .timeline,
-	.shared-schedule-section .day-block,
-	.shared-schedule-section .time-row,
-	.shared-schedule-section .time-main,
-	.shared-schedule-section .doses-col,
-	.shared-schedule-section .dose-item,
-	.shared-schedule-section .dose-checks,
-	.shared-schedule-section .dose-person {
+	.shared-schedule-section :global(.timeline),
+	.shared-schedule-section :global(.day-block),
+	.shared-schedule-section :global(.time-row),
+	.shared-schedule-section :global(.time-main),
+	.shared-schedule-section :global(.doses-col),
+	.shared-schedule-section :global(.dose-item),
+	.shared-schedule-section :global(.dose-checks),
+	.shared-schedule-section :global(.dose-person) {
 		width: 100%;
 		min-width: 0;
 		max-width: 100%;
@@ -439,38 +430,161 @@
 		font-size: 0.9rem;
 	}
 
-	.shared-timeline {
-		padding: 1rem;
-	}
-
-	.shared-schedule-section .timeline {
+	.shared-schedule-section :global(.timeline) {
 		gap: 0.85rem;
 	}
 
-	.shared-schedule-section .day-block {
+	.shared-schedule-section :global(.day-block) {
 		overflow: hidden;
 		border-radius: 12px;
 		padding: 0.75rem;
 	}
 
-	.shared-schedule-section .time-row {
+	.shared-schedule-section :global(.time-row) {
 		gap: 0.65rem;
 	}
 
-	.shared-schedule-section .time-main .med-name {
+	.shared-schedule-section :global(.time-main .med-name) {
 		overflow-wrap: anywhere;
 	}
 
-	.shared-schedule-section .doses-col {
+	.shared-schedule-section :global(.doses-col) {
 		gap: 0.55rem;
 		overflow: hidden;
 	}
 
-	.shared-schedule-section .dose-item {
-		grid-template-columns: minmax(3.5rem, auto) minmax(0, 1fr);
-		gap: 0.45rem 0.6rem;
-		padding: 0.55rem 0.6rem;
+	.shared-schedule-section :global(.dose-item) {
+		display: grid;
+		grid-template-columns: minmax(3.35rem, auto) minmax(0, 1fr) auto;
+		align-items: center;
+		width: 100%;
+		min-width: 0;
+		column-gap: 0.35rem;
+		row-gap: 0.48rem;
+		padding: 0.55rem 0.5rem;
 		overflow: hidden;
+	}
+
+	.shared-schedule-section :global(.dose-item.has-recipients) {
+		grid-template-columns: minmax(3.35rem, auto) minmax(0, 1fr) auto;
+	}
+
+	.shared-schedule-section :global(.dose-time) {
+		min-width: 0;
+		padding-left: 0;
+		white-space: nowrap;
+	}
+
+	.shared-schedule-section :global(.dose-summary) {
+		grid-column: 2;
+		display: flex;
+		align-items: center;
+		flex-wrap: nowrap;
+		min-width: 0;
+		gap: 0.32rem;
+	}
+
+	.shared-schedule-section :global(.dose-usage) {
+		display: flex;
+		flex: 0 1 auto;
+		flex-direction: row;
+		flex-wrap: nowrap;
+		align-items: center;
+		line-height: 1.15;
+		min-width: 0;
+		gap: 0 0.25rem;
+	}
+
+	.shared-schedule-section :global(.dose-usage-main-full) {
+		display: none;
+	}
+
+	.shared-schedule-section :global(.dose-usage-main-compact) {
+		display: inline;
+		white-space: nowrap;
+	}
+
+	.shared-schedule-section :global(.dose-usage-weight) {
+		white-space: nowrap;
+	}
+
+	.shared-dose-recipients {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		flex: 1 1 auto;
+		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
+		gap: 0.35rem;
+		flex-wrap: nowrap;
+		text-align: right;
+	}
+
+	.shared-dose-recipient-name {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		cursor: default;
+	}
+
+	.shared-schedule-section :global(.dose-checks) {
+		display: flex;
+		flex-direction: column;
+		grid-column: 1 / -1;
+		width: 100%;
+		min-width: 0;
+		margin-left: 0;
+		gap: 0.3rem;
+		align-items: stretch;
+	}
+
+	.shared-schedule-section :global(.dose-person) {
+		display: grid;
+		width: 100%;
+		min-width: 0;
+		--dose-action-take-width: clamp(5.35rem, 23vw, 7.1rem);
+		--dose-action-skip-width: clamp(4.45rem, 19vw, 5.35rem);
+		--dose-action-journal-width: clamp(5rem, 21vw, 6.35rem);
+
+		grid-template-columns:
+			minmax(0, 1fr) var(--dose-action-take-width) var(--dose-action-skip-width)
+			var(--dose-action-journal-width);
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.28rem 0.35rem;
+	}
+
+	.shared-schedule-section :global(.dose-person .person-name) {
+		min-width: 0;
+		max-width: none;
+		margin-right: 0;
+	}
+
+	.shared-schedule-section :global(.dose-checks.has-recipient-summary:not(.multi-person) .person-name) {
+		display: none;
+	}
+
+	.shared-action-recipient-name {
+		display: none;
+	}
+
+	.shared-schedule-section :global(.dose-person button) {
+		width: 100%;
+		justify-content: center;
+	}
+
+	.shared-schedule-section :global(.shared-dose-action-take) {
+		grid-column: 2;
+	}
+
+	.shared-schedule-section :global(.shared-dose-action-skip) {
+		grid-column: 3;
+	}
+
+	.shared-schedule-section :global(.shared-dose-action-journal) {
+		grid-column: 4;
 	}
 
 	.shared-overview-table-wrap {

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -613,6 +613,8 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"shared-dose-action-button",
+					"shared-dose-action-take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.undo,
@@ -636,6 +638,8 @@ export function SharedSchedule() {
 				size="sm"
 				className={cx(
 					"take-action-button",
+					"shared-dose-action-button",
+					"shared-dose-action-take",
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
 					doseButtonClasses.take,
@@ -656,11 +660,19 @@ export function SharedSchedule() {
 		const takeButton =
 			!options.isTaken && options.isEmpty ? (
 				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
-					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
+					<span
+						className={cx("shared-dose-action-take", doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}
+					>
+						{takeButtonControl}
+					</span>
 				</AppTooltip>
 			) : !canMarkTaken ? (
 				<AppTooltip label={t("share.readOnly")}>
-					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
+					<span
+						className={cx("shared-dose-action-take", doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}
+					>
+						{takeButtonControl}
+					</span>
 				</AppTooltip>
 			) : (
 				takeButtonControl
@@ -671,6 +683,8 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"shared-dose-action-button",
+					"shared-dose-action-skip",
 					doseButtonClasses.button,
 					doseButtonClasses.skipAction,
 					doseButtonClasses.undo,
@@ -685,7 +699,13 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
-				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
+				className={cx(
+					"shared-dose-action-button",
+					"shared-dose-action-skip",
+					doseButtonClasses.button,
+					doseButtonClasses.skipAction,
+					doseButtonClasses.skip
+				)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken || !canMarkTaken}
 			>
@@ -694,7 +714,9 @@ export function SharedSchedule() {
 		);
 		const skipButtonWithReadOnlyTooltip = !canMarkTaken ? (
 			<AppTooltip label={t("share.readOnly")}>
-				<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.skipAction)}>{skipButton}</span>
+				<span className={cx("shared-dose-action-skip", doseButtonClasses.tooltipTarget, doseButtonClasses.skipAction)}>
+					{skipButton}
+				</span>
 			</AppTooltip>
 		) : (
 			skipButton
@@ -705,6 +727,8 @@ export function SharedSchedule() {
 				type="button"
 				size="sm"
 				className={cx(
+					"shared-dose-action-button",
+					"shared-dose-action-journal",
 					doseButtonClasses.button,
 					doseButtonClasses.journalAction,
 					doseButtonClasses.journal,
@@ -724,7 +748,13 @@ export function SharedSchedule() {
 		const journalButton =
 			showSharedJournalAction && journalButtonControl && !canOpenSharedJournal ? (
 				<AppTooltip label={t("journal.actions.noteTakenOnly")}>
-					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.journalAction)}>
+					<span
+						className={cx(
+							"shared-dose-action-journal",
+							doseButtonClasses.tooltipTarget,
+							doseButtonClasses.journalAction
+						)}
+					>
 						{journalButtonControl}
 					</span>
 				</AppTooltip>
@@ -1149,6 +1179,61 @@ export function SharedSchedule() {
 		);
 	}
 
+	const getDoseRecipientNames = (
+		takenBy: string | null,
+		med: SharedScheduleData["medications"][number] | undefined
+	): string[] => {
+		const directRecipient = takenBy?.trim();
+		if (directRecipient) {
+			return [directRecipient];
+		}
+
+		return Array.from(
+			new Set((med?.takenBy ?? []).map((person) => person.trim()).filter((person) => person.length > 0))
+		);
+	};
+
+	const renderDoseRecipients = (people: string[]) => {
+		if (people.length === 0) {
+			return null;
+		}
+
+		return (
+			<div className={cx("dose-recipients", sharedClasses["shared-dose-recipients"])}>
+				{people.map((person) => (
+					<span key={person} className={cx("dose-recipient-name", sharedClasses["shared-dose-recipient-name"])}>
+						{person}
+					</span>
+				))}
+			</div>
+		);
+	};
+
+	const renderDosePersonName = (people: string[]) =>
+		people.length > 0 ? (
+			<span className={cx("person-name", sharedClasses["shared-action-recipient-name"])}>{people.join(", ")}</span>
+		) : null;
+
+	const renderDoseSummary = (
+		med: SharedScheduleData["medications"][number] | undefined,
+		dose: { timeStr: string; usage: number; intakeUnit?: IntakeUnit | null; takenBy: string | null },
+		people: string[]
+	) => (
+		<>
+			<span className="dose-time">{dose.timeStr}</span>
+			<div className="dose-summary">
+				<span className="dose-usage">
+					<span className="dose-usage-main dose-usage-main-full">{renderDoseUsage(med, dose)}</span>
+					<span className="dose-usage-main dose-usage-main-compact">{renderDoseUsage(med, dose)}</span>
+					{allowsPillFormSelection(med?.packageType) && med?.pillWeightMg && (
+						<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
+					)}
+				</span>
+				{renderDoseRecipients(people)}
+			</div>
+		</>
+	);
+
 	return (
 		<div className={sharedClasses["shared-schedule-page"]}>
 			<div className={cx(sharedClasses["shared-schedule-container"], "shared-schedule-container")}>
@@ -1358,24 +1443,25 @@ export function SharedSchedule() {
 																		const isAutomaticallyTaken =
 																			isTaken && isDoseTakenAutomatically(dose.id) && dose.when <= Date.now();
 																		const isSkipped = dismissedDoses.has(dose.id);
+																		const namedPeople = getDoseRecipientNames(dose.takenBy, med);
 																		const doseClasses = ["dose-item", "past"];
 																		if (isTaken) doseClasses.push("all-taken");
 																		if (isEmpty) doseClasses.push("med-empty");
 																		else if (isLowStock) doseClasses.push("med-low");
+																		if (namedPeople.length > 0) doseClasses.push("has-recipients");
 																		return (
 																			<div key={dose.id} className={doseClasses.join(" ")}>
-																				<span className="dose-time">{dose.timeStr}</span>
-																				<span className="dose-usage">
-																					<span className="dose-usage-main">{renderDoseUsage(med, dose)}</span>
-																					{allowsPillFormSelection(med?.packageType) && med?.pillWeightMg && (
-																						<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
+																				{renderDoseSummary(med, dose, namedPeople)}
+																				<div
+																					className={cx(
+																						"dose-checks",
+																						namedPeople.length > 0 && "has-recipient-summary"
 																					)}
-																				</span>
-																				<div className="dose-checks">
+																				>
 																					<div
 																						className={`dose-person ${isTaken ? "taken" : ""} ${isSkipped ? "skipped" : ""}`}
 																					>
-																						{dose.takenBy && <span className="person-name">{dose.takenBy}</span>}
+																						{renderDosePersonName(namedPeople)}
 																						{renderDoseActionButtons({
 																							doseId: dose.id,
 																							isTaken,
@@ -1566,25 +1652,26 @@ export function SharedSchedule() {
 																			isTaken && isDoseTakenAutomatically(dose.id) && dose.when <= Date.now();
 																		const isSkipped = dismissedDoses.has(dose.id);
 																		const isOverdue = dose.when < Date.now() && !isTaken && !isSkipped && !isEmpty;
+																		const namedPeople = getDoseRecipientNames(dose.takenBy, med);
 																		const doseClasses = ["dose-item"];
 																		if (isOverdue) doseClasses.push("overdue");
 																		if (isTaken) doseClasses.push("all-taken");
 																		if (isEmpty) doseClasses.push("med-empty");
 																		else if (isLowStock) doseClasses.push("med-low");
+																		if (namedPeople.length > 0) doseClasses.push("has-recipients");
 																		return (
 																			<div key={dose.id} className={doseClasses.join(" ")}>
-																				<span className="dose-time">{dose.timeStr}</span>
-																				<span className="dose-usage">
-																					<span className="dose-usage-main">{renderDoseUsage(med, dose)}</span>
-																					{allowsPillFormSelection(med?.packageType) && med?.pillWeightMg && (
-																						<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
+																				{renderDoseSummary(med, dose, namedPeople)}
+																				<div
+																					className={cx(
+																						"dose-checks",
+																						namedPeople.length > 0 && "has-recipient-summary"
 																					)}
-																				</span>
-																				<div className="dose-checks">
+																				>
 																					<div
 																						className={`dose-person ${isTaken ? "taken" : ""} ${isSkipped ? "skipped" : ""} ${isOverdue ? "overdue" : ""}`}
 																					>
-																						{dose.takenBy && <span className="person-name">{dose.takenBy}</span>}
+																						{renderDosePersonName(namedPeople)}
 																						{renderDoseActionButtons({
 																							doseId: dose.id,
 																							isTaken,
@@ -1757,24 +1844,25 @@ export function SharedSchedule() {
 																		const isAutomaticallyTaken =
 																			isTaken && isDoseTakenAutomatically(dose.id) && dose.when <= Date.now();
 																		const isSkipped = dismissedDoses.has(dose.id);
+																		const namedPeople = getDoseRecipientNames(dose.takenBy, med);
 																		const doseClasses = ["dose-item", "future"];
 																		if (isTaken) doseClasses.push("all-taken");
 																		if (isEmpty) doseClasses.push("med-empty");
 																		else if (isLowStock) doseClasses.push("med-low");
+																		if (namedPeople.length > 0) doseClasses.push("has-recipients");
 																		return (
 																			<div key={dose.id} className={doseClasses.join(" ")}>
-																				<span className="dose-time">{dose.timeStr}</span>
-																				<span className="dose-usage">
-																					<span className="dose-usage-main">{renderDoseUsage(med, dose)}</span>
-																					{allowsPillFormSelection(med?.packageType) && med?.pillWeightMg && (
-																						<span className="dose-usage-weight">{`${dose.usage * med.pillWeightMg} ${med.doseUnit ?? "mg"}`}</span>
+																				{renderDoseSummary(med, dose, namedPeople)}
+																				<div
+																					className={cx(
+																						"dose-checks",
+																						namedPeople.length > 0 && "has-recipient-summary"
 																					)}
-																				</span>
-																				<div className="dose-checks">
+																				>
 																					<div
 																						className={`dose-person ${isTaken ? "taken" : ""} ${isSkipped ? "skipped" : ""}`}
 																					>
-																						{dose.takenBy && <span className="person-name">{dose.takenBy}</span>}
+																						{renderDosePersonName(namedPeople)}
 																						{renderDoseActionButtons({
 																							doseId: dose.id,
 																							isTaken,

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -111,4 +111,36 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 		expect(dosePersonRawButton).toMatch(/width\s*:\s*100%/);
 		expect(tooltipTarget).toMatch(/width\s*:\s*100%/);
 	});
+
+	it("keeps shared mobile recipient names in the dose summary row", () => {
+		const sharedCss = readSource("components/SharedSchedule.module.css");
+		const doseSummary = blockFor(sharedCss, ".shared-schedule-section :global(.dose-summary)");
+		const recipients = lastBlockFor(sharedCss, ".shared-dose-recipients");
+		const recipientName = lastBlockFor(sharedCss, ".shared-dose-recipient-name");
+		const actionRecipientName = blockFor(sharedCss, ".shared-action-recipient-name");
+		const hiddenActionRowName = blockFor(
+			sharedCss,
+			".shared-schedule-section :global(.dose-checks.has-recipient-summary:not(.multi-person) .person-name)"
+		);
+		const takeAction = blockFor(sharedCss, ".shared-schedule-section :global(.shared-dose-action-take)");
+		const skipAction = blockFor(sharedCss, ".shared-schedule-section :global(.shared-dose-action-skip)");
+		const journalAction = blockFor(sharedCss, ".shared-schedule-section :global(.shared-dose-action-journal)");
+
+		expect(sharedCss).not.toContain(".shared-timeline");
+		expect(sharedCss).not.toContain(".shared-dose {");
+		expect(sharedCss).not.toContain(".shared-schedule-section :global(.dose-recipients)");
+		expect(sharedCss).not.toMatch(
+			/\.shared-schedule-section\s+\.(timeline|day-block|time-row|time-main|doses-col|dose-item|dose-checks|dose-person)/
+		);
+		expect(doseSummary).toMatch(/grid-column\s*:\s*2/);
+		expect(doseSummary).toMatch(/display\s*:\s*flex/);
+		expect(recipients).toMatch(/display\s*:\s*flex/);
+		expect(recipients).toMatch(/justify-content\s*:\s*flex-end/);
+		expect(recipientName).toMatch(/text-overflow\s*:\s*ellipsis/);
+		expect(hiddenActionRowName).toMatch(/display\s*:\s*none/);
+		expect(actionRecipientName).toMatch(/display\s*:\s*none/);
+		expect(takeAction).toMatch(/grid-column\s*:\s*2/);
+		expect(skipAction).toMatch(/grid-column\s*:\s*3/);
+		expect(journalAction).toMatch(/grid-column\s*:\s*4/);
+	});
 });


### PR DESCRIPTION
## Summary

Closes #852

Fixes the mobile shared schedule intake layout so recipient names stay in the dose summary row beside the dose amount/time instead of appearing visibly to the left of the Take button.

## Changes

- Resolve recipient names from per-intake `takenBy`, falling back to medication-level `takenBy` where needed.
- Render shared recipient names in the dose summary row and hide the old action-row person-name path on mobile.
- Restore shared take/skip/journal action slot classes and remove stale shared schedule CSS hooks.
- Add a UI contract test to keep recipient names in the summary row and prevent obsolete selectors from returning.

## Validation

- `npm --prefix frontend run test:run -- src/test/components/SharedSchedule.test.tsx src/test/ui/dashboard-nowrap-spacing-contract.test.ts` — passed
- `npm --prefix frontend run check` — passed
- `npm --prefix frontend run build` — passed