### PR TITLE
chore: upgrade Mantine packages to v9

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,11 @@
       "name": "medassist-ng-frontend",
       "version": "1.28.1",
       "dependencies": {
-        "@mantine/core": "^8.3.18",
-        "@mantine/dates": "^8.3.18",
-        "@mantine/hooks": "^8.3.18",
-        "@mantine/modals": "^8.3.18",
-        "@mantine/notifications": "^8.3.18",
+        "@mantine/core": "^9.4.1",
+        "@mantine/dates": "^9.4.1",
+        "@mantine/hooks": "^9.4.1",
+        "@mantine/modals": "^9.4.1",
+        "@mantine/notifications": "^9.4.1",
         "@medassist/shared": "file:../shared",
         "dayjs": "^1.11.21",
         "i18next": "^26.3.3",
@@ -642,84 +642,83 @@
       }
     },
     "node_modules/@mantine/core": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.18.tgz",
-      "integrity": "sha512-9tph1lTVogKPjTx02eUxDUOdXacPzK62UuSqb4TdGliI54/Xgxftq0Dfqu6XuhCxn9J5MDJaNiLDvL/1KRkYqA==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.4.1.tgz",
+      "integrity": "sha512-lZWEICrum4+vwKxzh/mk4RB1N6BqZ0Cshdl6lhm7OYLiQzmOaxKtOgyaWz+vr65G8mqTXjalZalB+wmMVBYK2Q==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react": "^0.27.16",
+        "@floating-ui/react": "^0.27.19",
         "clsx": "^2.1.1",
-        "react-number-format": "^5.4.4",
-        "react-remove-scroll": "^2.7.1",
-        "react-textarea-autosize": "8.5.9",
-        "type-fest": "^4.41.0"
+        "react-number-format": "^5.4.5",
+        "react-remove-scroll": "^2.7.2",
+        "type-fest": "^5.7.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "8.3.18",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "@mantine/hooks": "9.4.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/dates": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-8.3.18.tgz",
-      "integrity": "sha512-FHx5teJOhupI0gO2o5evtVYQEdqOjayOkLRhEQfB5Nc5DvcysfPfmNILGkc1Nrp9ZQeQWKLT9qr+CkcCXwHOaw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.4.1.tgz",
+      "integrity": "sha512-DoQDvQMAlIw6ohwhUwYuTYQevG9y5AQmYWkhOHUuavABFEZmtBglkwziBoATvxT09I/6I56UMPhproXcS6XUfg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "@mantine/core": "8.3.18",
-        "@mantine/hooks": "8.3.18",
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
         "dayjs": ">=1.0.0",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.18.tgz",
-      "integrity": "sha512-QoWr9+S8gg5050TQ06aTSxtlpGjYOpIllRbjYYXlRvZeTsUqiTbVfvQROLexu4rEaK+yy9Wwriwl9PMRgbLqPw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.4.1.tgz",
+      "integrity": "sha512-eTI8wmzPx3r98zgKIEuvukmoGTHBhmtI6+9E6o2DbTmEU2eM1bCdjE2vFdf0op2AlRO0KEYEcZhNQi4T/SJk0A==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^18.x || ^19.x"
+        "react": "^19.2.0"
       }
     },
     "node_modules/@mantine/modals": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-8.3.18.tgz",
-      "integrity": "sha512-JfPDS4549L314SxFPC1x6CbKwzh82OdnIzwgMxPCVNsWLKV2vEHHUH/fzUYj4Wli6IBrsW4cufjMj9BTj3hm3Q==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.4.1.tgz",
+      "integrity": "sha512-z5G3Biz7/5Ybz5Z8u5Xyvo9UBmFhAX/YXMf6U96ejvtAB11xVnCo8m37R5DJyzeFEqB4D1tvUgWiVVPBb+yadw==",
       "license": "MIT",
       "peerDependencies": {
-        "@mantine/core": "8.3.18",
-        "@mantine/hooks": "8.3.18",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/notifications": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.18.tgz",
-      "integrity": "sha512-IpQ0lmwbigTBbZCR6iSYWqIOKEx1tlcd7PcEJ5M5X1qeVSY/N3mmDQt1eJmObvcyDeL5cTJMbSA9UPqhRqo9jw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.4.1.tgz",
+      "integrity": "sha512-Sm1g8E8RkFmesxpNz9zFvOjkTVxOa7dJJjMGoHNIXH+9/wO0s9kInny4mVnxTbLJJsD6nTqIQlk1v8tq2C4Ftw==",
       "license": "MIT",
       "dependencies": {
-        "@mantine/store": "8.3.18",
+        "@mantine/store": "9.4.1",
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@mantine/core": "8.3.18",
-        "@mantine/hooks": "8.3.18",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/store": {
-      "version": "8.3.18",
-      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.18.tgz",
-      "integrity": "sha512-i+QRTLmZzLldea0egtUVnGALd6UMIu8jd44nrNWBSNIXJU/8B6rMlC6gyX+l4szopZSuOaaNJIXkqRdC1gQsVg==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.4.1.tgz",
+      "integrity": "sha512-/DCZq0aqqIdm03J0RJ7pbzoau2cwY8ndSOjskHOKHhTeWMnOBdCKXA3oMO5aIDldDqJ9T7Io4Boh4Pt461zNQw==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^18.x || ^19.x"
+        "react": "^19.2.0"
       }
     },
     "node_modules/@medassist/shared": {
@@ -2580,23 +2579,6 @@
         }
       }
     },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -2779,6 +2761,18 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2876,12 +2870,15 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2932,51 +2929,6 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-composed-ref": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,11 +34,11 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
-    "@mantine/core": "^8.3.18",
-    "@mantine/dates": "^8.3.18",
-    "@mantine/hooks": "^8.3.18",
-    "@mantine/modals": "^8.3.18",
-    "@mantine/notifications": "^8.3.18",
+    "@mantine/core": "^9.4.1",
+    "@mantine/dates": "^9.4.1",
+    "@mantine/hooks": "^9.4.1",
+    "@mantine/modals": "^9.4.1",
+    "@mantine/notifications": "^9.4.1",
     "@medassist/shared": "file:../shared",
     "dayjs": "^1.11.21",
     "i18next": "^26.3.3",

--- a/frontend/src/test/ui/mantine-v9-upgrade-contract.test.tsx
+++ b/frontend/src/test/ui/mantine-v9-upgrade-contract.test.tsx
@@ -1,0 +1,248 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	DEFAULT_THEME,
+	mergeMantineTheme,
+	useMantineCssVariablesResolver,
+	useMantineTheme,
+	v8CssVariablesResolver,
+} from "@mantine/core";
+import { useHeadroom } from "@mantine/hooks";
+import { modals } from "@mantine/modals";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppShellLayout } from "../../ui/layout/AppShellLayout";
+import { AppUiProvider } from "../../ui/providers/AppUiProvider";
+import { cssVariablesResolver, mantineTheme } from "../../ui/theme/mantineTheme";
+
+const headroomState = vi.hoisted(() => ({
+	value: { pinned: true, scrollProgress: 1 },
+}));
+
+const notificationProps = vi.hoisted(() => ({
+	latest: undefined as
+		| undefined
+		| {
+				autoClose?: unknown;
+				pauseResetOnHover?: unknown;
+				position?: unknown;
+		  },
+}));
+
+vi.mock("@mantine/hooks", async () => {
+	const actual = await vi.importActual<typeof import("@mantine/hooks")>("@mantine/hooks");
+
+	return {
+		...actual,
+		useHeadroom: vi.fn(() => headroomState.value),
+	};
+});
+
+vi.mock("@mantine/notifications", () => ({
+	Notifications: (props: typeof notificationProps.latest) => {
+		notificationProps.latest = props;
+		return <div data-testid="notifications-root" />;
+	},
+}));
+
+vi.mock("../../components/AppHeader", () => ({
+	AppHeader: ({ onOpenAbout, onOpenProfile }: { onOpenAbout: () => void; onOpenProfile: () => void }) => (
+		<header data-testid="mock-app-header">
+			<button type="button" onClick={onOpenProfile}>
+				open profile
+			</button>
+			<button type="button" onClick={onOpenAbout}>
+				open about
+			</button>
+		</header>
+	),
+}));
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const collapsedHeaderTransformPattern =
+	/--app-shell-header-transform:translateY\(calc\(var\(--app-shell-header-height\) \* -1\)\)/;
+
+function setHeadroomPinned(pinned: boolean) {
+	headroomState.value = { pinned, scrollProgress: pinned ? 1 : 0 };
+}
+
+function renderAppShell(currentPath = "/dashboard") {
+	render(
+		<AppShellLayout
+			currentPath={currentPath}
+			onNavigate={vi.fn().mockResolvedValue(undefined)}
+			onOpenAbout={vi.fn()}
+			onOpenProfile={vi.fn()}
+		>
+			<div>Shell content</div>
+		</AppShellLayout>
+	);
+}
+
+function getInlineStyleText() {
+	return Array.from(document.querySelectorAll<HTMLStyleElement>('style[data-mantine-styles="inline"]'))
+		.map((style) => style.textContent ?? "")
+		.join("\n");
+}
+
+function readCssVariable(section: object, key: string) {
+	return (section as Record<string, string | undefined>)[key];
+}
+
+describe("Mantine v9 upgrade contract", () => {
+	beforeEach(() => {
+		setHeadroomPinned(true);
+		notificationProps.latest = undefined;
+		document.documentElement.removeAttribute("data-theme");
+	});
+
+	afterEach(() => {
+		modals.closeAll();
+	});
+
+	it("keeps Mantine packages on one coordinated v9 version range", () => {
+		const packageJson = JSON.parse(readFileSync(resolve(frontendRoot, "package.json"), "utf8")) as {
+			dependencies: Record<string, string>;
+		};
+		const mantinePackages = [
+			"@mantine/core",
+			"@mantine/dates",
+			"@mantine/hooks",
+			"@mantine/modals",
+			"@mantine/notifications",
+		];
+		const versions = mantinePackages.map((packageName) => packageJson.dependencies[packageName]);
+
+		expect(new Set(versions).size).toBe(1);
+		expect(versions[0]).toMatch(/^\^9\./);
+	});
+
+	it("collapses the app header when the v9 headroom object reports unpinned", () => {
+		setHeadroomPinned(false);
+
+		renderAppShell();
+
+		expect(useHeadroom).toHaveBeenCalledWith({ fixedAt: 60 });
+		expect(screen.getByTestId("mock-app-header")).toBeInTheDocument();
+		expect(getInlineStyleText()).toMatch(collapsedHeaderTransformPattern);
+	});
+
+	it("keeps the app header pinned when the v9 headroom object reports pinned", () => {
+		setHeadroomPinned(true);
+
+		renderAppShell();
+
+		expect(getInlineStyleText()).not.toMatch(collapsedHeaderTransformPattern);
+	});
+
+	it("keeps the medication edit header visible even when headroom reports unpinned", () => {
+		setHeadroomPinned(false);
+
+		renderAppShell("/medications?editMedId=42");
+
+		expect(getInlineStyleText()).not.toMatch(collapsedHeaderTransformPattern);
+	});
+
+	it("mounts Mantine providers and preserves notification hover pause behavior", () => {
+		let providerSnapshot:
+			| {
+					primaryColor: string;
+					usesClinicalResolver: boolean;
+			  }
+			| undefined;
+
+		function ProviderProbe() {
+			const theme = useMantineTheme();
+			const resolver = useMantineCssVariablesResolver();
+			providerSnapshot = {
+				primaryColor: theme.primaryColor,
+				usesClinicalResolver: resolver === cssVariablesResolver,
+			};
+
+			return <div data-testid="provider-child">provider child</div>;
+		}
+
+		render(
+			<AppUiProvider>
+				<ProviderProbe />
+			</AppUiProvider>
+		);
+
+		expect(screen.getByTestId("provider-child")).toBeInTheDocument();
+		expect(screen.getByTestId("notifications-root")).toBeInTheDocument();
+		expect(providerSnapshot).toEqual({
+			primaryColor: "brand",
+			usesClinicalResolver: true,
+		});
+		expect(notificationProps.latest).toMatchObject({
+			autoClose: 4000,
+			pauseResetOnHover: "notification",
+			position: "top-right",
+		});
+	});
+
+	it("keeps the modal provider capable of rendering opened modals", async () => {
+		function ModalTrigger() {
+			return (
+				<button
+					type="button"
+					onClick={() =>
+						modals.open({
+							children: <div>Provider modal body</div>,
+							title: "Provider modal",
+						})
+					}
+				>
+					open modal
+				</button>
+			);
+		}
+
+		render(
+			<AppUiProvider>
+				<ModalTrigger />
+			</AppUiProvider>
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "open modal" }));
+
+		expect(await screen.findByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByText("Provider modal body")).toBeInTheDocument();
+	});
+
+	it("composes v8 variant variables with the clinical theme resolver", () => {
+		const resolvedTheme = mergeMantineTheme(DEFAULT_THEME, mantineTheme);
+		const v8Variables = v8CssVariablesResolver(resolvedTheme);
+		const clinicalVariables = cssVariablesResolver(resolvedTheme);
+		const primaryVariantKeys = [
+			"--mantine-primary-color-filled",
+			"--mantine-primary-color-filled-hover",
+			"--mantine-primary-color-light",
+			"--mantine-primary-color-light-hover",
+			"--mantine-primary-color-light-color",
+		];
+		const colorVariantSuffixes = ["light", "light-hover", "light-color"];
+		const clinicalColors = ["blue", "brand", "green", "red", "yellow"];
+
+		for (const key of primaryVariantKeys) {
+			expect(readCssVariable(clinicalVariables.variables, key)).toBe(readCssVariable(v8Variables.variables, key));
+		}
+
+		for (const color of clinicalColors) {
+			for (const scheme of ["light", "dark"] as const) {
+				for (const suffix of colorVariantSuffixes) {
+					const key = `--mantine-color-${color}-${suffix}`;
+					expect(readCssVariable(clinicalVariables[scheme], key)).toBe(readCssVariable(v8Variables[scheme], key));
+				}
+			}
+		}
+
+		expect(clinicalVariables.dark["--mantine-color-body"]).toBe("#101314");
+		expect(clinicalVariables.light["--mantine-color-body"]).toBe("#f6f6f4");
+		expect(clinicalVariables.dark["--bg-primary"]).toBe("#101314");
+		expect(clinicalVariables.light["--bg-primary"]).toBe("#f6f6f4");
+	});
+});

--- a/frontend/src/ui/layout/AppShellLayout.tsx
+++ b/frontend/src/ui/layout/AppShellLayout.tsx
@@ -19,7 +19,7 @@ export function AppShellLayout({
 	onOpenProfile,
 	onOpenAbout,
 }: AppShellLayoutProps) {
-	const pinned = useHeadroom({ fixedAt: 60 });
+	const { pinned } = useHeadroom({ fixedAt: 60 });
 	const keepHeaderVisible = currentPath.startsWith("/medications") && currentPath.includes("editMedId=");
 
 	return (

--- a/frontend/src/ui/providers/AppUiProvider.tsx
+++ b/frontend/src/ui/providers/AppUiProvider.tsx
@@ -47,7 +47,7 @@ export function AppUiProvider({ children }: { children: ReactNode }) {
 		>
 			<ModalsProvider>
 				{children}
-				<Notifications autoClose={4000} position="top-right" />
+				<Notifications autoClose={4000} pauseResetOnHover="notification" position="top-right" />
 			</ModalsProvider>
 		</MantineProvider>
 	);

--- a/frontend/src/ui/theme/mantineTheme.ts
+++ b/frontend/src/ui/theme/mantineTheme.ts
@@ -7,6 +7,7 @@ import {
 	Menu,
 	Popover,
 	Tooltip,
+	v8CssVariablesResolver,
 } from "@mantine/core";
 
 /**
@@ -283,7 +284,8 @@ const legacyVarMap: Record<string, string> = {
 	buttonObsoleteShadow: "--button-obsolete-shadow",
 };
 
-export const cssVariablesResolver: CSSVariablesResolver = () => {
+export const cssVariablesResolver: CSSVariablesResolver = (theme) => {
+	const v8VariantVars = v8CssVariablesResolver(theme);
 	// Map Mantine core component variables onto the clinical palette so built-in
 	// components (Menu, Modal, Paper, inputs) match the app surfaces automatically.
 	const darkVars: Record<string, string> = {
@@ -319,7 +321,11 @@ export const cssVariablesResolver: CSSVariablesResolver = () => {
 			lightVars[legacyName] = lightTokens[key];
 		}
 	}
-	return { variables: {}, dark: darkVars, light: lightVars };
+	return {
+		variables: { ...v8VariantVars.variables },
+		dark: { ...v8VariantVars.dark, ...darkVars },
+		light: { ...v8VariantVars.light, ...lightVars },
+	};
 };
 
 export const mantineTheme = createTheme({


### PR DESCRIPTION
Closes #853

## Summary
- Upgrade `@mantine/core`, `@mantine/hooks`, `@mantine/dates`, `@mantine/modals`, and `@mantine/notifications` together to `^9.4.1`.
- Replace the closed isolated Dependabot PRs #843, #844, #845, #846, and #847; these Mantine packages must be upgraded together because their peer dependencies are locked to the same release line.
- Update the app shell headroom integration for Mantine v9, preserve notification hover pause behavior, and compose Mantine v8 variant CSS variables into the clinical theme resolver.
- Add a focused Mantine v9 upgrade contract test covering package coordination, app shell header behavior, providers, notifications, modals, and theme variable composition.

## Validation
- `npm --prefix frontend install @mantine/core@9.4.1 @mantine/hooks@9.4.1 @mantine/dates@9.4.1 @mantine/modals@9.4.1 @mantine/notifications@9.4.1`
- `npm --prefix frontend run check`
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:run -- src/test/ui/mantine-v9-upgrade-contract.test.tsx`
- `npm --prefix frontend run test:run`
- Focused UI pack: button-height-theme-contract, app-shell-blur-contract, AppHeader, ConfirmModal, ShareDialog

Note: the Playwright app-shell default-port issue was traced to a local dev-stack port collision and is handled separately on `fix/e2e-isolated-local-runtime`; it is intentionally not included here.