### PR TITLE
test: isolate Playwright runtime from dev stack

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,6 +34,16 @@ docker compose -p medassist-dev -f docker-compose.dev.yml -f docker-compose.medt
 - OpenAPI JSON: `http://localhost:3000/docs/json` when docs are enabled
 - Docs are open in no-auth local development; authenticated setups protect docs by default unless `DOCS_AUTH_REQUIRED=false` is set.
 
+## Playwright Runtime Isolation
+
+Local Playwright runs start their own backend and frontend servers instead of reusing the always-on development stack:
+
+- Frontend: `http://localhost:4174`
+- Backend: `http://localhost:4175`
+- Backend data: `frontend/test-results/e2e-data`
+
+This keeps `npm --prefix frontend run test:e2e` from colliding with the Docker dev stack on `3000`/`5173` or mutating the normal local SQLite data. Override these defaults with `PLAYWRIGHT_BASE_URL`, `PLAYWRIGHT_API_BASE_URL`, `PLAYWRIGHT_FRONTEND_PORT`, or `PLAYWRIGHT_DATA_DIR` when an E2E run must target a specific external server.
+
 ## Frontend Dev Server Behind a Proxy
 
 If the frontend dev server runs behind a reverse proxy or on a remote host, set these frontend-only environment variables before starting Vite:

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -139,13 +139,26 @@ async function syncResponseCookiesToBrowserContext(page: Page, baseURL: string, 
 setup("authenticate", async ({ page }) => {
 	setup.setTimeout(120000);
 	await applyVideoSafetyMode(page);
-	const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:5173";
+	const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:4174";
+	const apiBaseURL = process.env.PLAYWRIGHT_API_BASE_URL || "http://localhost:4175";
+	const waitForApiReady = async () => {
+		for (let attempt = 0; attempt < 30; attempt += 1) {
+			const response = await page.request.get(`${apiBaseURL}/health`).catch(() => null);
+			if (response?.ok()) {
+				return;
+			}
+			await page.waitForTimeout(1000);
+		}
+		throw new Error(`Playwright backend did not become ready at ${apiBaseURL}`);
+	};
 
 	// Create .auth directory if it doesn't exist
 	const authDir = path.dirname(authFile);
 	if (!fs.existsSync(authDir)) {
 		fs.mkdirSync(authDir, { recursive: true });
 	}
+
+	await waitForApiReady();
 
 	// ---- 1. Try to reuse an existing auth file (offline check only) ----
 	if (fs.existsSync(authFile)) {
@@ -160,7 +173,7 @@ setup("authenticate", async ({ page }) => {
 
 			if (accessCookie?.value && isTokenValid(accessCookie.value)) {
 				const hasSavedSession = await page.request
-					.get(`${baseURL}/api/auth/me`)
+					.get(`${apiBaseURL}/auth/me`)
 					.then((response) => response.ok())
 					.catch(() => false);
 
@@ -171,12 +184,12 @@ setup("authenticate", async ({ page }) => {
 			}
 
 			if (refreshCookie?.value) {
-				const refreshResponse = await page.request.post(`${baseURL}/api/auth/refresh`).catch(() => null);
+				const refreshResponse = await page.request.post(`${apiBaseURL}/auth/refresh`).catch(() => null);
 				if (refreshResponse?.ok()) {
 					await syncResponseCookiesToBrowserContext(page, baseURL, refreshResponse);
 
 					const refreshedSession = await page.request
-						.get(`${baseURL}/api/auth/me`)
+						.get(`${apiBaseURL}/auth/me`)
 						.then((response) => response.ok())
 						.catch(() => false);
 
@@ -198,7 +211,7 @@ setup("authenticate", async ({ page }) => {
 	let oidcEnabled = false;
 	let registrationEnabled = true;
 	try {
-		const stateRes = await page.request.get(`${baseURL}/api/auth/state`);
+		const stateRes = await page.request.get(`${apiBaseURL}/auth/state`);
 		if (stateRes.ok()) {
 			const state = await stateRes.json();
 			authEnabled = state.authEnabled === true;
@@ -226,7 +239,7 @@ setup("authenticate", async ({ page }) => {
 	}
 
 	const hasAuthenticatedSession = await page.request
-		.get(`${baseURL}/api/auth/me`)
+		.get(`${apiBaseURL}/auth/me`)
 		.then((response) => response.ok())
 		.catch(() => false);
 	if (hasAuthenticatedSession) {
@@ -258,7 +271,7 @@ setup("authenticate", async ({ page }) => {
 	}
 
 	const loginWithApi = async () => {
-		const res = await page.request.post(`${baseURL}/api/auth/login`, {
+		const res = await page.request.post(`${apiBaseURL}/auth/login`, {
 			data: { username: TEST_USER.username, password: TEST_USER.password, rememberMe: false },
 		});
 
@@ -295,7 +308,7 @@ setup("authenticate", async ({ page }) => {
 
 	const registerWithApi = async () => {
 		await page.request
-			.post(`${baseURL}/api/auth/register`, {
+			.post(`${apiBaseURL}/auth/register`, {
 				data: { username: TEST_USER.username, password: TEST_USER.password },
 			})
 			.catch(() => {});
@@ -308,7 +321,7 @@ setup("authenticate", async ({ page }) => {
 			.catch(() => false);
 		if (hasHeader) return true;
 
-		const meRes = await page.request.get(`${baseURL}/api/auth/me`).catch(() => null);
+		const meRes = await page.request.get(`${apiBaseURL}/auth/me`).catch(() => null);
 		return Boolean(meRes?.ok());
 	};
 

--- a/frontend/e2e/domain-safety.spec.ts
+++ b/frontend/e2e/domain-safety.spec.ts
@@ -45,7 +45,7 @@ function normalizeText(value: string | null | undefined): string {
 async function calculatePlanner(page: Page): Promise<void> {
 	await page.waitForLoadState("networkidle");
 	await page.locator('form.planner button[type="submit"]').click();
-	await expect(page.locator(".table")).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId("planner-results-table")).toBeVisible({ timeout: 15000 });
 }
 
 async function calculatePlannerWithRequest(page: Page): Promise<PlannerUsageRequest> {
@@ -56,7 +56,7 @@ async function calculatePlannerWithRequest(page: Page): Promise<PlannerUsageRequ
 	await page.locator('form.planner button[type="submit"]').click();
 	const response = await responsePromise;
 	expect(response.ok()).toBe(true);
-	await expect(page.locator(".table")).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId("planner-results-table")).toBeVisible({ timeout: 15000 });
 
 	return JSON.parse(response.request().postData() ?? "{}") as PlannerUsageRequest;
 }
@@ -98,7 +98,7 @@ async function expectPlannerStartDisplay(page: Page, start: string, locale: stri
 }
 
 async function getPlannerUsage(page: Page, medicationName: string): Promise<string> {
-	const row = page.locator(".table-row", { hasText: medicationName });
+	const row = page.getByTestId("planner-result-row").filter({ hasText: medicationName });
 	await expect(row).toBeVisible({ timeout: 15000 });
 	const usage = await row.locator("[data-label] strong").first().textContent();
 	expect(usage).toBeTruthy();
@@ -106,7 +106,7 @@ async function getPlannerUsage(page: Page, medicationName: string): Promise<stri
 }
 
 async function getPlannerRowSnapshot(page: Page, medicationName: string): Promise<string[]> {
-	const row = page.locator(".table-row", { hasText: medicationName });
+	const row = page.getByTestId("planner-result-row").filter({ hasText: medicationName });
 	await expect(row).toBeVisible({ timeout: 15000 });
 	const cells = await row.locator("[data-label]").allTextContents();
 	expect(cells.length).toBeGreaterThanOrEqual(6);

--- a/frontend/e2e/export-import.spec.ts
+++ b/frontend/e2e/export-import.spec.ts
@@ -55,11 +55,22 @@ async function downloadExportFromSettings(page: Page, options: { includeSensitiv
 
 async function exportDataViaAPI(page: Page): Promise<ExportPayload> {
 	return page.evaluate(async () => {
-		const response = await fetch("/api/export?includeSensitive=false&includeImages=false", { credentials: "include" });
-		if (!response.ok) {
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			const response = await fetch("/api/export?includeSensitive=false&includeImages=false", {
+				credentials: "include",
+			});
+			if (response.ok) {
+				return response.json();
+			}
+			if (response.status === 429 && attempt < 4) {
+				const retryAfterSeconds = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
+				const delayMs = Number.isFinite(retryAfterSeconds) ? retryAfterSeconds * 1000 : 3000 * (attempt + 1);
+				await new Promise((resolve) => setTimeout(resolve, delayMs));
+				continue;
+			}
 			throw new Error(`Export failed: ${response.status} ${await response.text()}`);
 		}
-		return response.json();
+		throw new Error("Export failed after retries");
 	});
 }
 

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -202,10 +202,10 @@ export async function signOut(page: Page): Promise<void> {
 // Re-export expect for convenience
 export { expect };
 
-const APP_BASE = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:5173";
+const APP_BASE = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:4174";
 // Seed helpers talk to the backend directly so Vite proxy readiness does not consume
 // the 30s beforeAll budget for API-created test data.
-const API_BASE = process.env.PLAYWRIGHT_API_BASE_URL || "http://localhost:3000";
+const API_BASE = process.env.PLAYWRIGHT_API_BASE_URL || "http://localhost:4175";
 
 let cachedAuthEnabled: boolean | null = null;
 
@@ -258,6 +258,12 @@ function extractCookieValue(setCookieHeaders: string[], name: string): string | 
 		if (value) return value;
 	}
 	return null;
+}
+
+async function waitForRetryAfter(response: Response, attempt: number): Promise<void> {
+	const retryAfterSeconds = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
+	const delayMs = Number.isFinite(retryAfterSeconds) ? retryAfterSeconds * 1000 : 3000 * (attempt + 1);
+	await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 async function refreshAuthCookieViaLogin(): Promise<string | null> {
@@ -408,8 +414,7 @@ export async function createMedicationViaAPI(data: {
 			if (token) continue;
 		}
 		if (res.status === 429) {
-			// Rate limited — exponential backoff: 3s, 6s, 9s, 12s, 15s
-			await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+			await waitForRetryAfter(res, attempt);
 			continue;
 		}
 		if (!res.ok) {
@@ -438,7 +443,7 @@ export async function deleteMedicationViaAPI(id: number): Promise<void> {
 			if (token) continue;
 		}
 		if (res.status === 429) {
-			await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+			await waitForRetryAfter(res, attempt);
 			continue;
 		}
 		return;
@@ -461,7 +466,7 @@ export async function deleteAllMedicationsViaAPI(): Promise<void> {
 			if (token) continue;
 		}
 		if (res.status === 429) {
-			await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+			await waitForRetryAfter(res, attempt);
 			continue;
 		}
 		if (!res.ok) return;
@@ -477,7 +482,7 @@ export async function deleteAllMedicationsViaAPI(): Promise<void> {
 					if (token) continue;
 				}
 				if (delRes.status === 429) {
-					await new Promise((r) => setTimeout(r, 3000));
+					await waitForRetryAfter(delRes, delAttempt);
 					continue;
 				}
 				break;
@@ -518,7 +523,7 @@ export async function createShareTokenViaAPI(
 			if (token) continue;
 		}
 		if (res.status === 429) {
-			await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+			await waitForRetryAfter(res, attempt);
 			continue;
 		}
 		if (res.status === 400) {
@@ -555,7 +560,7 @@ export async function updateSettingsViaAPI(settings: Record<string, unknown>): P
 			if (token) continue;
 		}
 		if (currentRes.status === 429) {
-			await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+			await waitForRetryAfter(currentRes, attempt);
 			continue;
 		}
 		const current = currentRes.ok ? ((await currentRes.json()) as Record<string, unknown>) : {};
@@ -602,7 +607,7 @@ export async function updateSettingsViaAPI(settings: Record<string, unknown>): P
 			if (token) continue;
 		}
 		if (res.status === 429) {
-			await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+			await waitForRetryAfter(res, attempt);
 			continue;
 		}
 		if (res.ok) return;

--- a/frontend/e2e/mobile-modal-history.spec.ts
+++ b/frontend/e2e/mobile-modal-history.spec.ts
@@ -110,14 +110,17 @@ test.describe("Mobile modal browser back", () => {
 
 		const doseItem = page.locator(".dose-item").first();
 		await expect(doseItem).toBeVisible({ timeout: 15000 });
-		await doseItem.locator(".dose-btn.take").click();
+		await doseItem.getByRole("button", { name: /Take|Nehmen/i }).click();
 
 		const collapsedTodayDivider = page.locator(".day-block.today.collapsed .day-divider.clickable").first();
 		if (await collapsedTodayDivider.isVisible().catch(() => false)) {
 			await collapsedTodayDivider.click();
 		}
 
-		const noteButton = page.locator(".dose-item").first().locator(".dose-btn.journal");
+		const noteButton = page
+			.locator(".dose-item")
+			.first()
+			.getByRole("button", { name: /Note|Notiz/i });
 		await expect(noteButton).toBeEnabled({ timeout: 10000 });
 		await noteButton.click();
 

--- a/frontend/playwright.base.config.ts
+++ b/frontend/playwright.base.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices, type PlaywrightTestConfig } from "@playwright/test";
 
+const DEFAULT_E2E_BASE_URL = "http://localhost:4174";
+const DEFAULT_E2E_API_BASE_URL = "http://localhost:4175";
+const DEFAULT_E2E_DATA_DIR = "../frontend/test-results/e2e-data";
+
 function parseOptionalPort(value: string | undefined) {
 	if (!value) {
 		return undefined;
@@ -9,18 +13,32 @@ function parseOptionalPort(value: string | undefined) {
 	return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function shellQuote(value: string) {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 export function buildPlaywrightConfig(runAllBrowsers: boolean) {
 	const env =
 		typeof globalThis === "object" && "process" in globalThis
 			? ((globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {})
 			: {};
-	const baseURL = env.PLAYWRIGHT_BASE_URL || "http://localhost:5173";
-	const apiBaseURL = env.PLAYWRIGHT_API_BASE_URL || "http://localhost:3000";
-	const frontendPort = parseOptionalPort(env.PLAYWRIGHT_FRONTEND_PORT) ?? parseOptionalPort(new URL(baseURL).port) ?? 5173;
+	const baseURL = env.PLAYWRIGHT_BASE_URL || DEFAULT_E2E_BASE_URL;
+	const apiBaseURL = env.PLAYWRIGHT_API_BASE_URL || DEFAULT_E2E_API_BASE_URL;
+	const frontendPort = parseOptionalPort(env.PLAYWRIGHT_FRONTEND_PORT) ?? parseOptionalPort(new URL(baseURL).port) ?? 4174;
+	const backendPort = parseOptionalPort(new URL(apiBaseURL).port) ?? 4175;
+	const dataDir = env.PLAYWRIGHT_DATA_DIR || DEFAULT_E2E_DATA_DIR;
 	const parsedWorkers = Number.parseInt(env.PLAYWRIGHT_WORKERS ?? "", 10);
 	// Default to single-worker execution to keep API-seeded E2E suites deterministic.
 	// Still allow explicit local overrides via PLAYWRIGHT_WORKERS.
 	const workers = Number.isFinite(parsedWorkers) && parsedWorkers > 0 ? parsedWorkers : 1;
+	const backendEnv = [
+		["PORT", String(backendPort)],
+		["DATA_DIR", dataDir],
+		["DOTENV_PATH", "/tmp/medassist-playwright-empty.env"],
+		["CORS_ORIGINS", baseURL],
+		["RATE_LIMIT_MAX", env.PLAYWRIGHT_RATE_LIMIT_MAX || "100000"],
+	];
+	const frontendEnv = [["BACKEND_URL", apiBaseURL]];
 
 	const projects: NonNullable<PlaywrightTestConfig["projects"]> = [
 		{
@@ -96,13 +114,15 @@ export function buildPlaywrightConfig(runAllBrowsers: boolean) {
 		outputDir: "test-results/",
 		webServer: [
 			{
-				command: "cd ../backend && npm run dev",
+				command: `cd ../backend && ${backendEnv
+					.map(([key, value]) => `${key}=${shellQuote(value)}`)
+					.join(" ")} npm run dev`,
 				url: `${apiBaseURL}/health`,
 				reuseExistingServer: !env.CI,
 				timeout: 120 * 1000,
 			},
 			{
-				command: `npm run dev -- --host 127.0.0.1 --port ${frontendPort} --strictPort`,
+				command: `${frontendEnv.map(([key, value]) => `${key}=${shellQuote(value)}`).join(" ")} npm run dev -- --host 127.0.0.1 --port ${frontendPort} --strictPort`,
 				url: baseURL,
 				reuseExistingServer: !env.CI,
 				timeout: 120 * 1000,


### PR DESCRIPTION
## Summary

- Isolate Playwright-managed frontend/backend servers from the always-running dev stack by defaulting E2E to ports 4174/4175 and a dedicated test data directory.
- Inject Playwright backend runtime env, including high test-only rate limits and CORS origin alignment.
- Make auth setup use the backend API directly after `/health` readiness instead of racing through the Vite proxy.
- Update stale planner/shared-journal E2E selectors and make API helper retries respect `Retry-After`.

## Validation

- `npm --prefix frontend run check`
- `PLAYWRIGHT_HTML_OPEN=never PLAYWRIGHT_WORKERS=1 CI=true npm --prefix frontend run test:e2e -- e2e/domain-safety.spec.ts e2e/export-import.spec.ts e2e/mobile-modal-history.spec.ts`
- Earlier app-shell smoke passed while the Docker dev stack was still listening on 3000/5173.

Closes #855