### PR TITLE
fix: align frontend date display formatting

### DIFF
--- a/frontend/src/components/MedDetailModal.tsx
+++ b/frontend/src/components/MedDetailModal.tsx
@@ -22,7 +22,7 @@ import {
 	Pencil,
 	Plus,
 } from "lucide-react";
-import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { Fragment, type MouseEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEscapeKey } from "../hooks/useEscapeKey";
 import type { Coverage, Medication, RefillEntry, StockThresholds } from "../types";
@@ -42,7 +42,15 @@ import { AppButton } from "../ui/primitives/AppButton";
 import { AppTextAction } from "../ui/primitives/AppTextAction";
 import { AppTooltip, AppTooltipTrigger } from "../ui/primitives/AppTooltip";
 import { StatusBadge, type StatusTone } from "../ui/primitives/StatusBadge";
-import { formatNumber, generateICS, getExpiryClass, getSystemLocale } from "../utils";
+import {
+	formatDisplayDate,
+	formatDisplayDateTime,
+	formatExpiryDate,
+	formatNumber,
+	generateICS,
+	getExpiryClass,
+	getSystemLocale,
+} from "../utils";
 import { getIntakeFrequencyText, getMedicationIntakes } from "../utils/intake-schedule";
 import { getLiquidCountUnitLabel } from "../utils/intake-units";
 import { getStockStatus } from "../utils/schedule";
@@ -264,6 +272,7 @@ export function MedDetailModal({
 	]);
 
 	if (!selectedMed) return null;
+	const displayLocale = getSystemLocale(i18n.language);
 	const isAmountPackage =
 		isTubePackageType(selectedMed.packageType) || isLiquidContainerPackageType(selectedMed.packageType);
 	const getDiscreteUnitLabel = (value: number) => {
@@ -278,6 +287,12 @@ export function MedDetailModal({
 	const stockUnitLabel = isAmountPackage ? amountUnitLabel : null;
 
 	const medCoverage = coverage.all.find((c) => c.name === getMedDisplayName(selectedMed));
+	const runsOutLabel = medCoverage
+		? formatDisplayDate(medCoverage.depletionTime ?? medCoverage.depletionDate, displayLocale, {
+				weekday: true,
+				fallback: medCoverage.depletionDate ?? "—",
+			})
+		: "—";
 	const packageSize = getPackageSize(selectedMed);
 	const stockDisplayCapacity = getStockDisplayCapacity(selectedMed);
 	// Structural max = sealed package capacity only (excludes pre-existing looseTablets).
@@ -856,7 +871,7 @@ export function MedDetailModal({
 						<h3>{t("modal.stockInfo")}</h3>
 						<div className={classes["med-detail-grid"]}>
 							{!isAmountBasedPackageType(selectedMed.packageType) && (
-								<>
+								<Fragment key="discrete-stock-details">
 									<div className={classes["med-detail-item"]}>
 										<span className={classes["med-detail-label"]}>{t("table.fullBlisters")}</span>
 										<span className={cx(classes["med-detail-value"], textClass)}>
@@ -874,7 +889,7 @@ export function MedDetailModal({
 											)}
 										</span>
 									</div>
-								</>
+								</Fragment>
 							)}
 							<div className={cx(classes["med-detail-item"], classes["full-width"])}>
 								<span className={classes["med-detail-label"]}>
@@ -937,7 +952,7 @@ export function MedDetailModal({
 						</h3>
 						<div className={classes["med-detail-grid"]}>
 							{!isAmountBasedPackageType(selectedMed.packageType) ? (
-								<>
+								<Fragment key="blister-package-details">
 									<div className={classes["med-detail-item"]}>
 										<span className={classes["med-detail-label"]}>{t("modal.packs")}</span>
 										<span className={classes["med-detail-value"]}>{selectedMed.packCount}</span>
@@ -950,9 +965,9 @@ export function MedDetailModal({
 										<span className={classes["med-detail-label"]}>{t("modal.pillsPerBlister")}</span>
 										<span className={classes["med-detail-value"]}>{selectedMed.pillsPerBlister}</span>
 									</div>
-								</>
+								</Fragment>
 							) : isLiquidContainerPackageType(selectedMed.packageType) ? (
-								<>
+								<Fragment key="liquid-package-details">
 									<div className={classes["med-detail-item"]}>
 										<span className={classes["med-detail-label"]}>{t("form.bottles")}</span>
 										<span className={classes["med-detail-value"]}>{packageCount}</span>
@@ -969,9 +984,9 @@ export function MedDetailModal({
 											{formatNumber(stockDisplayTotal)} {amountUnitLabel}
 										</span>
 									</div>
-								</>
+								</Fragment>
 							) : isTubePackageType(selectedMed.packageType) ? (
-								<>
+								<Fragment key="tube-package-details">
 									<div className={classes["med-detail-item"]}>
 										<span className={classes["med-detail-label"]}>{t("form.tubes")}</span>
 										<span className={classes["med-detail-value"]}>{packageCount}</span>
@@ -988,7 +1003,7 @@ export function MedDetailModal({
 											{formatNumber(stockDisplayTotal)} {amountUnitLabel}
 										</span>
 									</div>
-								</>
+								</Fragment>
 							) : (
 								<div className={classes["med-detail-item"]}>
 									<span className={classes["med-detail-label"]}>{t("form.totalCapacity")}</span>
@@ -1012,11 +1027,7 @@ export function MedDetailModal({
 											getValueToneClass(getExpiryClass(selectedMed.expiryDate, settings.expiryWarningDays))
 										)}
 									>
-										{new Date(selectedMed.expiryDate).toLocaleDateString(getSystemLocale(i18n.language), {
-											day: "2-digit",
-											month: "short",
-											year: "numeric",
-										})}
+										{formatExpiryDate(selectedMed.expiryDate, displayLocale)}
 									</span>
 								</div>
 							)}
@@ -1104,14 +1115,7 @@ export function MedDetailModal({
 									<span className={classes["med-detail-label"]}>{t("prescription.expiryDate")}</span>
 									<span className={classes["med-detail-value"]}>
 										{selectedMed.prescriptionExpiryDate
-											? new Date(selectedMed.prescriptionExpiryDate).toLocaleDateString(
-													getSystemLocale(i18n.language),
-													{
-														day: "2-digit",
-														month: "short",
-														year: "numeric",
-													}
-												)
+											? formatExpiryDate(selectedMed.prescriptionExpiryDate, displayLocale)
 											: "—"}
 									</span>
 								</div>
@@ -1137,7 +1141,7 @@ export function MedDetailModal({
 								</div>
 								<div className={classes["med-detail-item"]}>
 									<span className={classes["med-detail-label"]}>{t("modal.runsOut")}</span>
-									<span className={classes["med-detail-value"]}>{medCoverage.depletionDate ?? "—"}</span>
+									<span className={classes["med-detail-value"]}>{runsOutLabel}</span>
 								</div>
 							</div>
 						</div>
@@ -1174,16 +1178,7 @@ export function MedDetailModal({
 									{refillHistory.map((entry) => (
 										<div key={entry.id} className={classes["refill-history-item"]}>
 											<span className={classes["refill-date"]}>
-												{new Date(entry.refillDate).toLocaleDateString(getSystemLocale(i18n.language), {
-													day: "2-digit",
-													month: "short",
-													year: "numeric",
-												})}
-												,{" "}
-												{new Date(entry.refillDate).toLocaleTimeString(getSystemLocale(i18n.language), {
-													hour: "2-digit",
-													minute: "2-digit",
-												})}
+												{formatDisplayDateTime(entry.refillDate, displayLocale)}
 											</span>
 											<span className={classes["refill-amount"]}>
 												{(() => {

--- a/frontend/src/components/MobileEditModal.tsx
+++ b/frontend/src/components/MobileEditModal.tsx
@@ -629,8 +629,8 @@ export function MobileEditModal({
 											</label>
 										)}
 										{form.medicationEndDate && (
-											<label className="full">
-												{t("form.autoMarkObsoleteAfterEndDate")}
+											<label className={`full ${formClasses.inlineToggleField}`}>
+												<span className={formClasses.inlineToggleText}>{t("form.autoMarkObsoleteAfterEndDate")}</span>
 												<span className="toggle-switch small">
 													<input
 														type="checkbox"

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -12,6 +12,7 @@ import type { ActiveShareLink } from "../hooks/useShare";
 import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
 import { AppButton } from "../ui/primitives/AppButton";
 import { AppTooltip } from "../ui/primitives/AppTooltip";
+import { formatDisplayDate, getSystemLocale } from "../utils/formatters";
 import { ConfirmModal } from "./ConfirmModal";
 import classes from "./ShareDialog.module.css";
 
@@ -72,10 +73,11 @@ export function ShareDialog({
 	onRegenerateShareLink,
 	onCopyShareLink,
 }: ShareDialogProps) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const [manageLinksOpen, setManageLinksOpen] = useState(false);
 	const [shareToRevoke, setShareToRevoke] = useState<ActiveShareLink | null>(null);
 	const [shareToRegenerate, setShareToRegenerate] = useState<ActiveShareLink | null>(null);
+	const displayLocale = getSystemLocale(i18n.language);
 	const closeLabel = t("common.close");
 	const copyLabel = shareCopied ? t("share.copied") : t("share.copyLink");
 	const getPersonLabel = (person: string) => (person === "all" ? t("share.allPeople") : person);
@@ -117,9 +119,9 @@ export function ShareDialog({
 			<ul className={classes.activeList}>
 				{activeShareLinks.map((share) => {
 					const personLabel = getPersonLabel(share.takenBy);
-					const createdAtLabel = new Date(share.createdAt).toLocaleDateString();
-					const expiresAtLabel = share.expiresAt ? new Date(share.expiresAt).toLocaleDateString() : null;
-					const lastUsedAtLabel = share.lastUsedAt ? new Date(share.lastUsedAt).toLocaleDateString() : null;
+					const createdAtLabel = formatDisplayDate(share.createdAt, displayLocale);
+					const expiresAtLabel = share.expiresAt ? formatDisplayDate(share.expiresAt, displayLocale) : null;
+					const lastUsedAtLabel = share.lastUsedAt ? formatDisplayDate(share.lastUsedAt, displayLocale) : null;
 					let expiryLabel = t("share.expiryNever");
 					if (share.legacyNeverExpires) {
 						expiryLabel = t("share.activeLinkLegacyExpiry");

--- a/frontend/src/components/SharedMedicationOverviewSection.tsx
+++ b/frontend/src/components/SharedMedicationOverviewSection.tsx
@@ -5,7 +5,7 @@ import {
 	isTubePackageType,
 	type SharedMedicationOverviewItem,
 } from "../types";
-import { formatDate } from "../utils/formatters";
+import { formatDisplayDate, getSystemLocale } from "../utils/formatters";
 import { MedicationAvatar } from "./MedicationAvatar";
 import sharedClasses from "./SharedSchedule.module.css";
 
@@ -77,7 +77,8 @@ export function SharedMedicationOverviewSection({
 	onMedicationImageClick,
 	imageSrcResolver,
 }: SharedMedicationOverviewSectionProps) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const displayLocale = getSystemLocale(i18n.language);
 	const cx = (...classNames: Array<string | false | null | undefined>) => classNames.filter(Boolean).join(" ");
 	const renderMedicationAvatar = (name: string, imageUrl: string | null) => {
 		const isClickable = Boolean(imageUrl && onMedicationImageClick);
@@ -160,7 +161,7 @@ export function SharedMedicationOverviewSection({
 											<td>{medication.daysLeft === null ? "-" : medication.daysLeft}</td>
 											<td>
 												<span className={sharedClasses["shared-overview-date-value"]}>
-													{formatDate(medication.depletionDate)}
+													{formatDisplayDate(medication.depletionDate, displayLocale, { weekday: true })}
 												</span>
 											</td>
 											<td>
@@ -224,7 +225,7 @@ export function SharedMedicationOverviewSection({
 										<span>{t("sharedOverview.columns.depletion")}</span>
 										<strong>
 											<span className={sharedClasses["shared-overview-date-value"]}>
-												{formatDate(medication.depletionDate)}
+												{formatDisplayDate(medication.depletionDate, displayLocale, { weekday: true })}
 											</span>
 										</strong>
 									</div>

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -28,7 +28,7 @@ import {
 } from "../types";
 import { AppButton } from "../ui/primitives/AppButton";
 import { AppTooltip, AppTooltipTrigger } from "../ui/primitives/AppTooltip";
-import { getSystemLocale } from "../utils/formatters";
+import { formatDisplayDate, getSystemLocale } from "../utils/formatters";
 import { getIntakeDailyRate, getMedicationIntakes, iterateIntakeOccurrences } from "../utils/intake-schedule";
 import { convertLiquidUsageToMl } from "../utils/intake-units";
 import { getStockStatus, isDoseDismissed, parseLocalDateTime } from "../utils/schedule";
@@ -860,11 +860,7 @@ export function SharedSchedule() {
 						isPast,
 						takenBy: intake.takenBy, // Per-intake takenBy (string | null)
 						timeStr: d.toLocaleTimeString(getSystemLocale(i18n.language), { hour: "2-digit", minute: "2-digit" }),
-						dateStr: d.toLocaleDateString(getSystemLocale(i18n.language), {
-							weekday: "short",
-							day: "2-digit",
-							month: "short",
-						}),
+						dateStr: formatDisplayDate(d, getSystemLocale(i18n.language), { weekday: true }),
 					});
 				});
 			});
@@ -926,11 +922,7 @@ export function SharedSchedule() {
 	// Separate today from future days
 	const { todayDay, futureDays } = useMemo(() => {
 		const today = new Date();
-		const todayStr = today.toLocaleDateString(getSystemLocale(i18n.language), {
-			weekday: "short",
-			day: "2-digit",
-			month: "short",
-		});
+		const todayStr = formatDisplayDate(today, getSystemLocale(i18n.language), { weekday: true });
 		const nonPastDays = schedule.filter((d) => !d.isPast).slice(0, data?.scheduleDays ?? 30);
 
 		const todayEntry = nonPastDays.find((d) => d.dateStr === todayStr);
@@ -1160,7 +1152,7 @@ export function SharedSchedule() {
 					</p>
 					<p className={sharedClasses["expired-date"]}>
 						{t("share.expired.expiredOn", {
-							date: new Date(expiredData.expiredAt).toLocaleDateString(getSystemLocale(i18n.language)),
+							date: formatDisplayDate(expiredData.expiredAt, getSystemLocale(i18n.language)),
 						})}
 					</p>
 				</div>

--- a/frontend/src/components/medications/MedicationForm.module.css
+++ b/frontend/src/components/medications/MedicationForm.module.css
@@ -21,6 +21,26 @@
 	align-self: end;
 }
 
+.category .inlineToggleField {
+	display: inline-flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 0.65rem;
+	width: fit-content;
+	max-width: 100%;
+	min-width: 0;
+	justify-self: start;
+}
+
+.category .inlineToggleText {
+	min-width: 0;
+}
+
+.category .inlineToggleField :global(.toggle-switch.small) {
+	flex: 0 0 auto;
+}
+
 .categoryTitle {
 	grid-column: 1 / -1;
 	margin: 0;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -33,7 +33,13 @@ import { AppTextAction } from "../ui/primitives/AppTextAction";
 import { AppTooltip, AppTooltipTrigger } from "../ui/primitives/AppTooltip";
 import { DataTable, type DataTableColumn } from "../ui/primitives/DataTable";
 import { StatusBadge, type StatusTone } from "../ui/primitives/StatusBadge";
-import { formatNumber, getExpiryClass, getSystemLocale } from "../utils/formatters";
+import {
+	formatDisplayDate,
+	formatExpiryDate,
+	formatNumber,
+	getExpiryClass,
+	getSystemLocale,
+} from "../utils/formatters";
 import { getIntakeDailyRate, getMedicationIntakes } from "../utils/intake-schedule";
 import { convertLiquidUsageToMl, getLiquidCountUnitLabel, type UnitLabelVariant } from "../utils/intake-units";
 import { buildClearMissedPayload, expandDoseIds, getStockStatus, isDoseDismissed } from "../utils/schedule";
@@ -1082,22 +1088,21 @@ export function DashboardPage() {
 			render: (row) => {
 				const med = getMedByName(row.name);
 				const expiryClass = getExpiryClass(med?.expiryDate, settings.expiryWarningDays);
+				const displayLocale = getSystemLocale(i18n.language);
+				const runsOutValue = formatDisplayDate(row.depletionTime ?? row.depletionDate, displayLocale, {
+					weekday: true,
+					fallback: row.depletionDate ?? "-",
+				});
 				return (
 					<span className="date-pair-stack">
 						<span className="date-pair-entry">
 							<span className="date-pair-label">{t("table.runsOut")}</span>
-							<span className="date-pair-value">{row.depletionDate ?? "-"}</span>
+							<span className="date-pair-value">{runsOutValue}</span>
 						</span>
 						<span className="date-pair-entry">
 							<span className="date-pair-label">{t("table.expiry")}</span>
 							<span className={`date-pair-value ${expiryClass}`}>
-								{med?.expiryDate
-									? new Date(med.expiryDate).toLocaleDateString(getSystemLocale(i18n.language), {
-											day: "2-digit",
-											month: "short",
-											year: "2-digit",
-										})
-									: "-"}
+								{med?.expiryDate ? formatExpiryDate(med.expiryDate, displayLocale) : "-"}
 							</span>
 						</span>
 					</span>

--- a/frontend/src/pages/MedicationsPage.tsx
+++ b/frontend/src/pages/MedicationsPage.tsx
@@ -1723,16 +1723,16 @@ export function MedicationsPage() {
 								</label>
 							)}
 							{form.medicationEndDate && (
-								<label className="full">
-									{t("form.autoMarkObsoleteAfterEndDate")}
-									<label className="toggle-switch small">
+								<label className={`full ${formClasses.inlineToggleField}`}>
+									<span className={formClasses.inlineToggleText}>{t("form.autoMarkObsoleteAfterEndDate")}</span>
+									<span className="toggle-switch small">
 										<input
 											type="checkbox"
 											checked={form.autoMarkObsoleteAfterEndDate}
 											onChange={(e) => handleValueChange("autoMarkObsoleteAfterEndDate", e.target.checked)}
 										/>
 										<span className="toggle-slider"></span>
-									</label>
+									</span>
 								</label>
 							)}
 							<label className={`full ${fieldErrors.takenBy ? "has-error" : ""}`}>

--- a/frontend/src/pages/dashboard-helpers.ts
+++ b/frontend/src/pages/dashboard-helpers.ts
@@ -1,6 +1,6 @@
 import type { Coverage, Medication, PackageType } from "../types";
 import { getMedTotal as getMedTotalFromTypes, isLiquidContainerPackageType, isTubePackageType } from "../types";
-import { withFormattingTimezone } from "../utils/formatters";
+import { formatDisplayDateTime } from "../utils/formatters";
 import { splitCurrentBlisterStock } from "../utils/stock";
 
 export function userStorageKey(userId: number | undefined, key: string): string {
@@ -132,36 +132,16 @@ export function getReminderStatusData(
 
 	let lastStockSent: { date: string; medNames: string | null } | null = null;
 	if (lastStockReminderSent) {
-		const sentDate = new Date(lastStockReminderSent);
-		const formattedDate = sentDate.toLocaleDateString(
-			locale,
-			withFormattingTimezone({
-				day: "2-digit",
-				month: "short",
-				hour: "2-digit",
-				minute: "2-digit",
-			})
-		);
 		lastStockSent = {
-			date: formattedDate,
+			date: formatDisplayDateTime(lastStockReminderSent, locale),
 			medNames: lastStockReminderMedNames,
 		};
 	}
 
 	let lastIntakeSent: { date: string; medName: string | null; takenBy: string | null } | null = null;
 	if (lastAutoEmailSent) {
-		const sentDate = new Date(lastAutoEmailSent);
-		const formattedDate = sentDate.toLocaleDateString(
-			locale,
-			withFormattingTimezone({
-				day: "2-digit",
-				month: "short",
-				hour: "2-digit",
-				minute: "2-digit",
-			})
-		);
 		lastIntakeSent = {
-			date: formattedDate,
+			date: formatDisplayDateTime(lastAutoEmailSent, locale),
 			medName: lastReminderMedName,
 			takenBy: lastReminderTakenBy,
 		};

--- a/frontend/src/test/components/MedDetailModal.test.tsx
+++ b/frontend/src/test/components/MedDetailModal.test.tsx
@@ -203,22 +203,44 @@ describe("MedDetailModal", () => {
 	});
 
 	it("shows prescription details section when prescription is enabled", () => {
-		const med: Medication = {
-			...mockMedication,
-			prescriptionEnabled: true,
-			prescriptionAuthorizedRefills: 5,
-			prescriptionRemainingRefills: 2,
-			prescriptionLowRefillThreshold: 1,
-			prescriptionExpiryDate: "2026-12-31",
-		};
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 6, 1, 12, 0, 0));
 
-		render(<MedDetailModal {...defaultProps} selectedMed={med} />);
+		try {
+			const med: Medication = {
+				...mockMedication,
+				expiryDate: "2026-07-14",
+				prescriptionEnabled: true,
+				prescriptionAuthorizedRefills: 5,
+				prescriptionRemainingRefills: 2,
+				prescriptionLowRefillThreshold: 1,
+				prescriptionExpiryDate: "2027-05-01",
+			};
 
-		expect(screen.getByText(/form\.sections\.prescription/i)).toBeInTheDocument();
-		expect(screen.getByText(/prescription\.authorizedRefills/i)).toBeInTheDocument();
-		expect(screen.getByText(/prescription\.remainingRefills/i)).toBeInTheDocument();
-		expect(screen.getByText(/prescription\.lowThreshold/i)).toBeInTheDocument();
-		expect(screen.getByText(/prescription\.expiryDate/i)).toBeInTheDocument();
+			render(<MedDetailModal {...defaultProps} selectedMed={med} />);
+
+			expect(screen.getByText(/form\.sections\.prescription/i)).toBeInTheDocument();
+			expect(screen.getByText(/prescription\.authorizedRefills/i)).toBeInTheDocument();
+			expect(screen.getByText(/prescription\.remainingRefills/i)).toBeInTheDocument();
+			expect(screen.getByText(/prescription\.lowThreshold/i)).toBeInTheDocument();
+			expect(screen.getByText(/prescription\.expiryDate/i)).toBeInTheDocument();
+
+			const medicationExpiry = getDetailValue(/modal\.expiryDate/i);
+			expect(medicationExpiry).toHaveTextContent(/Jul/i);
+			expect(medicationExpiry).toHaveTextContent(/26/);
+			expect(medicationExpiry).not.toHaveTextContent(/Tue/i);
+			expect(medicationExpiry).not.toHaveTextContent(/14/);
+			expect(medicationExpiry).not.toHaveTextContent(/2026/);
+
+			const prescriptionExpiry = getDetailValue(/prescription\.expiryDate/i);
+			expect(prescriptionExpiry).toHaveTextContent(/May/i);
+			expect(prescriptionExpiry).toHaveTextContent(/27/);
+			expect(prescriptionExpiry).not.toHaveTextContent(/Sat/i);
+			expect(prescriptionExpiry).not.toHaveTextContent(/01/);
+			expect(prescriptionExpiry).not.toHaveTextContent(/2027/);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("does not show prescription details section when prescription is disabled", () => {

--- a/frontend/src/test/components/ShareDialog.test.tsx
+++ b/frontend/src/test/components/ShareDialog.test.tsx
@@ -176,6 +176,9 @@ describe("ShareDialog", () => {
 	});
 
 	it("shows active share expiry status for expiring and legacy permanent links", () => {
+		const currentYear = new Date().getFullYear();
+		const nextYear = currentYear + 1;
+
 		render(
 			<ShareDialog
 				{...defaultProps}
@@ -184,8 +187,8 @@ describe("ShareDialog", () => {
 						token: "abcdef0123456789",
 						takenBy: "Alice",
 						scheduleDays: 30,
-						createdAt: "2026-05-17T12:00:00.000Z",
-						expiresAt: "2026-08-15T12:00:00.000Z",
+						createdAt: `${currentYear}-07-14T12:00:00.000Z`,
+						expiresAt: `${nextYear}-05-01T12:00:00.000Z`,
 						lastUsedAt: null,
 						allowJournalNotes: false,
 						allowMarkTaken: false,
@@ -214,6 +217,17 @@ describe("ShareDialog", () => {
 		expect(screen.getAllByText(/share\.activeLinkExpiresLabel/i).length).toBeGreaterThan(0);
 		expect(screen.getAllByText(/share\.activeLinkDays_30/i).length).toBeGreaterThan(0);
 		expect(screen.getByText(/share\.activeLinkLegacyExpiry/i)).toBeInTheDocument();
+
+		const createdLabels = screen.getAllByText(/share\.activeLinkCreatedLabel/i);
+		const createdValue = createdLabels[0].parentElement?.querySelector("dd")?.textContent ?? "";
+		expect(createdValue).toMatch(/14/);
+		expect(createdValue).toMatch(/Jul/i);
+		expect(createdValue).not.toContain(String(currentYear));
+
+		const expiryLabels = screen.getAllByText(/share\.activeLinkExpiresLabel/i);
+		const expiringValue = expiryLabels[0].parentElement?.querySelector("dd")?.textContent ?? "";
+		expect(expiringValue).toMatch(/May/i);
+		expect(expiringValue).toContain(String(nextYear));
 	});
 
 	it("uses an in-app confirm modal before revoking an active share link", async () => {

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -595,10 +595,13 @@ describe("SharedSchedule", () => {
 
 	it("renders the embedded medication overview on the shared page when enabled", async () => {
 		const sharedData = createSharedDataWithEmbeddedOverview();
+		const currentYear = new Date().getFullYear();
+		sharedData.medicationOverview[0].depletionDate = `${currentYear}-07-14`;
+		sharedData.medicationOverview[1].depletionDate = `${currentYear + 1}-05-01`;
 
 		mockSharedScheduleRead(sharedData);
 
-		renderSharedSchedule("/share/token-123");
+		const { container } = renderSharedSchedule("/share/token-123");
 
 		await waitFor(() => {
 			expect(screen.getAllByText("Aspirin").length).toBeGreaterThan(0);
@@ -610,6 +613,14 @@ describe("SharedSchedule", () => {
 		expect(screen.getAllByText("2 x 40 form.packageAmountUnitG").length).toBeGreaterThan(0);
 		expect(screen.getAllByText("3 x 150 form.packageAmountUnitMl").length).toBeGreaterThan(0);
 		expect(screen.getByText("share.noSchedule")).toBeInTheDocument();
+
+		const dateValues = Array.from(container.querySelectorAll('[class*="shared-overview-date-value"]')).map(
+			(element) => element.textContent ?? ""
+		);
+		expect(
+			dateValues.some((value) => /14/.test(value) && /Jul/i.test(value) && !value.includes(String(currentYear)))
+		).toBe(true);
+		expect(dateValues.some((value) => /May/i.test(value) && value.includes(String(currentYear + 1)))).toBe(true);
 	});
 
 	it("skips a neutral shared dose via the skip endpoint", async () => {

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -600,30 +600,55 @@ describe("DashboardPage", () => {
 	});
 
 	it("renders runs-out and expiry as a stacked date pair in overview rows", () => {
-		mockContextValue = createMockAppContext({
-			meds: mockMeds,
-			coverage: mockCoverage,
-		});
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 6, 1, 12, 0, 0));
 
-		render(
-			<MemoryRouter>
-				<DashboardPage />
-			</MemoryRouter>
-		);
+		try {
+			mockContextValue = createMockAppContext({
+				meds: [{ ...mockMeds[0], expiryDate: "2027-05-01" }, mockMeds[1]],
+				coverage: {
+					...mockCoverage,
+					all: [
+						{
+							...mockCoverage.all[0],
+							depletionDate: "2026-07-14",
+							depletionTime: new Date(2026, 6, 14, 12, 0, 0).getTime(),
+						},
+						mockCoverage.all[1],
+					],
+				},
+			});
 
-		const headerPair = document.querySelector(".date-pair-stack-header");
-		expect(headerPair).toBeInTheDocument();
-		expect(headerPair).toHaveTextContent("table.runsOut");
-		expect(headerPair).toHaveTextContent("table.expiry");
+			render(
+				<MemoryRouter>
+					<DashboardPage />
+				</MemoryRouter>
+			);
 
-		const rowPair = screen.getAllByTestId("dashboard-overview-row")[0].querySelector(".date-pair-stack");
-		expect(rowPair).toBeInTheDocument();
+			const headerPair = document.querySelector(".date-pair-stack-header");
+			expect(headerPair).toBeInTheDocument();
+			expect(headerPair).toHaveTextContent("table.runsOut");
+			expect(headerPair).toHaveTextContent("table.expiry");
 
-		const rowEntries = Array.from(rowPair?.querySelectorAll(".date-pair-entry") ?? []);
-		expect(rowEntries).toHaveLength(2);
-		expect(rowEntries[0]).toHaveTextContent("table.runsOut");
-		expect(rowEntries[0]).toHaveTextContent("2025-02-15");
-		expect(rowEntries[1]).toHaveTextContent("table.expiry");
+			const rowPair = screen.getAllByTestId("dashboard-overview-row")[0].querySelector(".date-pair-stack");
+			expect(rowPair).toBeInTheDocument();
+
+			const rowEntries = Array.from(rowPair?.querySelectorAll(".date-pair-entry") ?? []);
+			expect(rowEntries).toHaveLength(2);
+			expect(rowEntries[0]).toHaveTextContent("table.runsOut");
+			expect(rowEntries[0]).toHaveTextContent(/Tue/i);
+			expect(rowEntries[0]).toHaveTextContent(/14/);
+			expect(rowEntries[0]).toHaveTextContent(/Jul/i);
+			expect(rowEntries[0]).not.toHaveTextContent(/2026/);
+			expect(rowEntries[1]).toHaveTextContent("table.expiry");
+			expect(rowEntries[1]).toHaveTextContent(/May/i);
+			expect(rowEntries[1]).toHaveTextContent(/27/);
+			expect(rowEntries[1]).not.toHaveTextContent(/Sat/i);
+			expect(rowEntries[1]).not.toHaveTextContent(/01/);
+			expect(rowEntries[1]).not.toHaveTextContent(/2027/);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("renders multiple cards", () => {

--- a/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
@@ -33,7 +33,7 @@ function lastBlockFor(css: string, selector: string) {
 }
 
 describe("dashboard and shared mobile polish contract", () => {
-	it("keeps overview table headers readable and mobile date values right aligned", () => {
+	it("keeps overview table headers readable and mobile date values left aligned", () => {
 		const css = readSource("ui/primitives/DataTable.module.css");
 		const headCell = blockFor(css, ".headCell");
 		const mobileCell = lastBlockFor(css, ".bodyCell");
@@ -44,8 +44,8 @@ describe("dashboard and shared mobile polish contract", () => {
 		expect(headCell).toMatch(/font-weight\s*:\s*750/);
 		expect(mobileCell).toMatch(/align-items\s*:\s*center/);
 		expect(mobileLabel).toMatch(/font-size\s*:\s*0\.82rem/);
-		expect(mobileDateValue).toMatch(/justify-self\s*:\s*end/);
-		expect(mobileDateValue).toMatch(/text-align\s*:\s*right/);
+		expect(mobileDateValue).toMatch(/justify-self\s*:\s*start/);
+		expect(mobileDateValue).toMatch(/text-align\s*:\s*left/);
 	});
 
 	it("keeps shared medication generic names and mobile dose actions in stable slots", () => {

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -66,15 +66,18 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 	});
 
 	it("keeps mobile runs-out and expiry dates in the same value column as other overview values", () => {
-		const css = readSource("AppSurfaces.css");
-		const desktopDatePairEntry = blockFor(css, ".date-pair-entry");
-		const mobileDatePairEntry = lastBlockFor(css, ".date-pair-entry");
+		const surfacesCss = readSource("AppSurfaces.css");
+		const tableCss = readSource("ui/primitives/DataTable.module.css");
+		const desktopDatePairEntry = blockFor(surfacesCss, ".date-pair-entry");
+		const mobileDatePairEntry = lastBlockFor(surfacesCss, ".date-pair-entry");
+		const overviewDatePairEntry = blockFor(tableCss, '.bodyCell[data-column-key="datePair"] :global(.date-pair-entry)');
 
 		expect(desktopDatePairEntry).toMatch(/display\s*:\s*flex/);
 		expect(desktopDatePairEntry).toMatch(/flex-direction\s*:\s*column/);
 		expect(mobileDatePairEntry).toMatch(/display\s*:\s*grid/);
 		expect(mobileDatePairEntry).toMatch(/grid-template-columns\s*:\s*minmax\(11rem, 48%\) minmax\(0, 1fr\)/);
 		expect(mobileDatePairEntry).toMatch(/align-items\s*:\s*baseline/);
+		expect(overviewDatePairEntry).toMatch(/grid-template-columns\s*:\s*minmax\(11rem, 48%\) minmax\(0, 1fr\)/);
 	});
 
 	it("keeps reminder label/value spacing close to a single typed space", () => {

--- a/frontend/src/test/ui/medication-edit-layout-contract.test.ts
+++ b/frontend/src/test/ui/medication-edit-layout-contract.test.ts
@@ -31,4 +31,18 @@ describe("desktop medication edit layout contract", () => {
 		expect(cssBlock(coordinatorCss, ".formActions")).toMatch(/background\s*:\s*var\(--desktop-editor-panel-bg\)/);
 		expect(cssBlock(formCss, ".tabs")).toMatch(/border-radius\s*:\s*10px 10px 0 0/);
 	});
+
+	it("keeps the obsolete-after-end-date toggle inline with its label on desktop and mobile", () => {
+		const formCss = readSource("components/medications/MedicationForm.module.css");
+		const pageSource = readSource("pages/MedicationsPage.tsx");
+		const mobileSource = readSource("components/MobileEditModal.tsx");
+		const inlineToggleField = cssBlock(formCss, ".category .inlineToggleField");
+
+		expect(inlineToggleField).toMatch(/display\s*:\s*inline-flex/);
+		expect(inlineToggleField).toMatch(/flex-direction\s*:\s*row/);
+		expect(inlineToggleField).toMatch(/align-items\s*:\s*center/);
+		expect(inlineToggleField).toMatch(/width\s*:\s*fit-content/);
+		expect(pageSource).toContain("formClasses.inlineToggleField");
+		expect(mobileSource).toContain("formClasses.inlineToggleField");
+	});
 });

--- a/frontend/src/test/utils/formatters.test.ts
+++ b/frontend/src/test/utils/formatters.test.ts
@@ -5,6 +5,9 @@ import {
 	compareSemver,
 	deriveTotal,
 	formatDateTime,
+	formatDisplayDate,
+	formatDisplayDateTime,
+	formatExpiryDate,
 	formatNumber,
 	getBlisterStock,
 	getExpiryClass,
@@ -62,6 +65,60 @@ describe("formatDateTime", () => {
 		const result = formatDateTime("2024-03-15T10:30:00Z", "en-US");
 		expect(result).toMatch(/\d{2}\/\d{2}\/\d{4}/); // Contains date in some format
 		expect(result).toMatch(/\d{1,2}:\d{2}/); // Contains time
+	});
+});
+
+describe("formatDisplayDate", () => {
+	const currentYear = new Date(2026, 6, 1, 12, 0, 0);
+
+	it("formats same-year deadline dates with weekday and no year", () => {
+		expect(formatDisplayDate("2026-07-14", "en-DE", { weekday: true, now: currentYear })).toBe("Tue, 14 Jul");
+	});
+
+	it("adds the year for deadline dates outside the current year", () => {
+		expect(formatDisplayDate("2027-05-01", "en-DE", { weekday: true, now: currentYear })).toBe("Sat, 01 May 2027");
+	});
+
+	it("formats metadata dates without weekday using the same conditional-year rule", () => {
+		expect(formatDisplayDate("2026-07-14", "en-DE", { now: currentYear })).toBe("14 Jul");
+		expect(formatDisplayDate("2027-05-01", "en-DE", { now: currentYear })).toBe("01 May 2027");
+	});
+
+	it("uses the configured fallback for missing and invalid values", () => {
+		expect(formatDisplayDate(null, "en-DE", { fallback: "—", now: currentYear })).toBe("—");
+		expect(formatDisplayDate("not-a-date", "en-DE", { fallback: "—", now: currentYear })).toBe("—");
+	});
+
+	it("keeps date-only strings on their calendar day", () => {
+		expect(formatDisplayDate("2027-01-01", "en-DE", { weekday: true, now: new Date(2027, 0, 1) })).toBe("Fri, 01 Jan");
+	});
+});
+
+describe("formatDisplayDateTime", () => {
+	const currentYear = new Date(2026, 6, 1, 12, 0, 0);
+
+	it("formats visible date-time metadata without weekday by default", () => {
+		expect(formatDisplayDateTime("2026-07-14T20:30:00", "en-DE", { now: currentYear })).toBe("14 Jul, 20:30");
+	});
+
+	it("adds the year to date-time metadata outside the current year", () => {
+		expect(formatDisplayDateTime("2027-05-01T20:30:00", "en-DE", { now: currentYear })).toBe("01 May 2027, 20:30");
+	});
+});
+
+describe("formatExpiryDate", () => {
+	it("formats medication expiry dates as month and 2-digit year only", () => {
+		expect(formatExpiryDate("2028-09-03", "en-DE")).toBe("Sept 28");
+		expect(formatExpiryDate("2027-05-01", "en-DE")).toBe("May 27");
+	});
+
+	it("keeps date-only expiry strings on their calendar month", () => {
+		expect(formatExpiryDate("2027-01-01", "en-DE")).toBe("Jan 27");
+	});
+
+	it("uses the configured fallback for missing and invalid values", () => {
+		expect(formatExpiryDate(null, "en-DE", { fallback: "—" })).toBe("—");
+		expect(formatExpiryDate("not-a-date", "en-DE", { fallback: "—" })).toBe("—");
 	});
 });
 

--- a/frontend/src/ui/modal/AppModal.tsx
+++ b/frontend/src/ui/modal/AppModal.tsx
@@ -34,7 +34,7 @@ function splitModalChildren(children: ReactNode): { content: ReactNode[]; footer
 	const content: ReactNode[] = [];
 	const footers: ReactNode[] = [];
 
-	Children.forEach(children, (child) => {
+	Children.toArray(children).forEach((child) => {
 		if (isAppModalFooterElement(child)) {
 			footers.push(child);
 			return;
@@ -44,7 +44,7 @@ function splitModalChildren(children: ReactNode): { content: ReactNode[]; footer
 			const nested = splitModalChildren((child.props as { children?: ReactNode }).children);
 			footers.push(...nested.footers);
 			if (nested.content.length > 0) {
-				content.push(cloneElement(child as ElementWithChildren, undefined, nested.content));
+				content.push(cloneElement(child as ElementWithChildren, undefined, Children.toArray(nested.content)));
 			}
 			return;
 		}
@@ -81,6 +81,8 @@ export function AppModal({
 	const resolvedLockScroll = manageScrollLock ? false : (lockScroll ?? true);
 	const providedClassNames = typeof classNames === "function" ? undefined : classNames;
 	const { content, footers } = splitModalChildren(children);
+	const modalContent = Children.toArray(content);
+	const modalFooters = Children.toArray(footers);
 	const hasFooterSlot = footers.length > 0;
 
 	return (
@@ -110,9 +112,9 @@ export function AppModal({
 			{hasFooterSlot ? (
 				<>
 					<div className={classes.scrollArea} data-testid="app-modal-scroll-area">
-						{content}
+						{modalContent}
 					</div>
-					{footers}
+					{modalFooters}
 				</>
 			) : (
 				children

--- a/frontend/src/ui/primitives/DataTable.module.css
+++ b/frontend/src/ui/primitives/DataTable.module.css
@@ -71,8 +71,8 @@
 }
 
 .bodyCell[data-column-key="datePair"] :global(.date-pair-value) {
-	justify-self: end;
-	text-align: right;
+	justify-self: start;
+	text-align: left;
 	white-space: nowrap;
 }
 
@@ -182,14 +182,14 @@
 
 	.bodyCell[data-column-key="datePair"] :global(.date-pair-entry) {
 		display: grid;
-		grid-template-columns: minmax(6rem, 38%) minmax(0, 1fr);
+		grid-template-columns: minmax(11rem, 48%) minmax(0, 1fr);
 		align-items: center;
 		gap: 0.75rem;
 	}
 
 	.bodyCell[data-column-key="datePair"] :global(.date-pair-value) {
-		justify-self: end;
-		text-align: right;
+		justify-self: start;
+		text-align: left;
 	}
 
 	.bodyCell :global(.hide-on-card) {

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -190,6 +190,121 @@ export function formatDate(dateStr: string | null | undefined, locale?: string):
 	return d.toLocaleDateString(effectiveLocale, { year: "numeric", month: "2-digit", day: "2-digit" });
 }
 
+type DisplayDateValue = Date | number | string | null | undefined;
+type DisplayDateYearPolicy = "auto" | "always" | "never";
+
+interface DisplayDateOptions {
+	weekday?: boolean;
+	year?: DisplayDateYearPolicy;
+	fallback?: string;
+	now?: Date | number | string;
+}
+
+function parseDisplayDateValue(value: DisplayDateValue): Date | null {
+	if (value === null || value === undefined || value === "") return null;
+
+	if (value instanceof Date) {
+		return Number.isNaN(value.getTime()) ? null : new Date(value.getTime());
+	}
+
+	if (typeof value === "number") {
+		const date = new Date(value);
+		return Number.isNaN(date.getTime()) ? null : date;
+	}
+
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+
+	const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (dateOnlyMatch) {
+		const [, year, month, day] = dateOnlyMatch;
+		const date = new Date(Number(year), Number(month) - 1, Number(day));
+		return Number.isNaN(date.getTime()) ? null : date;
+	}
+
+	const localDateTimeMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,3})?)?$/);
+	if (localDateTimeMatch) {
+		const [, year, month, day, hour, minute, second = "0"] = localDateTimeMatch;
+		const date = new Date(Number(year), Number(month) - 1, Number(day), Number(hour), Number(minute), Number(second));
+		return Number.isNaN(date.getTime()) ? null : date;
+	}
+
+	const parsed = new Date(trimmed);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function shouldIncludeDisplayYear(date: Date, policy: DisplayDateYearPolicy, now: Date): boolean {
+	if (policy === "always") return true;
+	if (policy === "never") return false;
+	return date.getFullYear() !== now.getFullYear();
+}
+
+function getDisplayDateOptions(date: Date, options: DisplayDateOptions): Intl.DateTimeFormatOptions {
+	const yearPolicy = options.year ?? "auto";
+	const now = parseDisplayDateValue(options.now) ?? new Date();
+	const dateOptions: Intl.DateTimeFormatOptions = {
+		day: "2-digit",
+		month: "short",
+	};
+
+	if (options.weekday === true) {
+		dateOptions.weekday = "short";
+	}
+
+	if (shouldIncludeDisplayYear(date, yearPolicy, now)) {
+		dateOptions.year = "numeric";
+	}
+
+	return dateOptions;
+}
+
+/**
+ * Format visible app dates with contextual year display.
+ * Date-only strings are treated as local calendar dates to prevent timezone day shifts.
+ */
+export function formatDisplayDate(value: DisplayDateValue, locale?: string, options: DisplayDateOptions = {}): string {
+	const date = parseDisplayDateValue(value);
+	if (!date) return options.fallback ?? "-";
+	const effectiveLocale = locale ?? getSystemLocale();
+	return date.toLocaleDateString(effectiveLocale, getDisplayDateOptions(date, options));
+}
+
+/**
+ * Format medication expiry dates as month + 2-digit year.
+ * Medication package expiries are month-accurate, not day-accurate.
+ */
+export function formatExpiryDate(
+	value: DisplayDateValue,
+	locale?: string,
+	options: Pick<DisplayDateOptions, "fallback"> = {}
+): string {
+	const date = parseDisplayDateValue(value);
+	if (!date) return options.fallback ?? "-";
+	const effectiveLocale = locale ?? getSystemLocale();
+	return date.toLocaleDateString(effectiveLocale, {
+		month: "short",
+		year: "2-digit",
+	});
+}
+
+/**
+ * Format visible app date+time metadata with contextual year display.
+ */
+export function formatDisplayDateTime(
+	value: DisplayDateValue,
+	locale?: string,
+	options: DisplayDateOptions = {}
+): string {
+	const date = parseDisplayDateValue(value);
+	if (!date) return options.fallback ?? "-";
+	const effectiveLocale = locale ?? getSystemLocale();
+	return date.toLocaleString(effectiveLocale, {
+		...getDisplayDateOptions(date, options),
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
 /**
  * Pad a number to 2 digits with leading zero
  */

--- a/frontend/src/utils/schedule.ts
+++ b/frontend/src/utils/schedule.ts
@@ -5,6 +5,7 @@
 import { parseLocalDateTime } from "@medassist/shared";
 import type { Coverage, Intake, Medication, PackageType, ScheduleEvent, StockStatus, StockThresholds } from "../types";
 import { getMedDisplayName, getMedTotal, isLiquidContainerPackageType, isTubePackageType } from "../types";
+import { formatDisplayDate, formatDisplayDateTime } from "./formatters";
 import { getIntakeDailyRate, getMedicationIntakes, iterateIntakeOccurrences } from "./intake-schedule";
 import { convertLiquidUsageToMl } from "./intake-units";
 
@@ -58,7 +59,7 @@ export function buildSchedulePreview(
 					when: whenMs,
 					isPast,
 					timeStr: d.toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" }),
-					dateStr: d.toLocaleDateString(locale, { weekday: "short", day: "2-digit", month: "short" }),
+					dateStr: formatDisplayDate(d, locale, { weekday: true }),
 					intakeRemindersEnabled: intake.intakeRemindersEnabled,
 				});
 			});
@@ -235,10 +236,7 @@ export function calculateCoverage(
 		const rawDaysLeft = dailyRate > 0 ? medsLeft / dailyRate : null;
 		const daysLeft = rawDaysLeft !== null ? Math.max(0, Math.floor(rawDaysLeft)) : null;
 		const depletionMs = daysLeft !== null ? now + daysLeft * MS_PER_DAY : null;
-		const depletionDate =
-			depletionMs !== null
-				? new Date(depletionMs).toLocaleDateString(locale, { weekday: "short", day: "2-digit", month: "short" })
-				: null;
+		const depletionDate = depletionMs !== null ? formatDisplayDate(depletionMs, locale, { weekday: true }) : null;
 		const displayName = getMedDisplayName(m);
 		const nextEvent = events.find((e) => e.medName === displayName);
 
@@ -248,15 +246,7 @@ export function calculateCoverage(
 			daysLeft,
 			depletionDate,
 			depletionTime: depletionMs,
-			nextDose: nextEvent
-				? new Date(nextEvent.when).toLocaleString(locale, {
-						weekday: "short",
-						day: "2-digit",
-						month: "short",
-						hour: "2-digit",
-						minute: "2-digit",
-					})
-				: null,
+			nextDose: nextEvent ? formatDisplayDateTime(nextEvent.when, locale, { weekday: true }) : null,
 		};
 	});
 
@@ -337,10 +327,7 @@ export function getNextReminderForMed(med: Coverage, reminderDaysBefore: number,
 		return "Due now";
 	}
 
-	return new Date(reminderTime).toLocaleDateString(locale, {
-		day: "2-digit",
-		month: "short",
-	});
+	return formatDisplayDate(reminderTime, locale, { weekday: true });
 }
 
 /**
@@ -366,8 +353,7 @@ export function getReminderStatusText(
 	);
 
 	const formatLastSent = (iso: string) => {
-		const date = new Date(iso);
-		return date.toLocaleDateString(locale, { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" });
+		return formatDisplayDateTime(iso, locale);
 	};
 
 	const getTypeLabel = () =>


### PR DESCRIPTION
Closes #857

## Summary

- Centralized display-date helpers in `frontend/src/utils/formatters.ts` for contextual UI dates and date-time metadata.
- Kept existing numeric/full-year date formatters for forms, reports, exports, and document output.
- Migrated dashboard, schedule/shared schedule, medication detail, shared overview, and share dialog display-date call sites.
- Updated expiry displays to use month plus two-digit year, matching the month/year granularity of the source data.
- Aligned dashboard Runs out/Expiry date values and mobile overview-card value columns.
- Fixed the AppModal child key warning observed during detail-modal verification.
- Kept the obsolete-after-end-date checkbox/toggle inline after its label in desktop and mobile medication edit forms.

## Validation

Testing-manager completed the local quality gate before release handoff:

- `npm --prefix frontend run test:run -- src/test/utils/formatters.test.ts src/test/utils/schedule.test.ts src/test/pages/DashboardPage.test.tsx src/test/components/MedDetailModal.test.tsx src/test/components/SharedSchedule.test.tsx src/test/components/ShareDialog.test.tsx`
- `npm --prefix frontend run test:run -- src/test/ui/dashboard-mobile-polish-contract.test.ts src/test/ui/dashboard-nowrap-spacing-contract.test.ts src/test/pages/DashboardPage.test.tsx`
- `npm --prefix frontend run test:run -- src/test/ui/medication-edit-layout-contract.test.ts src/test/pages/MedicationsPage.test.tsx src/test/components/MobileEditModal.test.tsx`
- `npm --prefix frontend run check`
- `npm --prefix frontend run build`
- Authenticated browser probes for dashboard/detail date rendering, date-column alignment, and inline checkbox layout on desktop/mobile