### PR TITLE
fix: keep mobile tooltip popovers visible

### DIFF
--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -28,6 +28,50 @@ test.describe("Settings Page", () => {
 		await expect(languageSelect.locator("option")).toHaveCount(2);
 	});
 
+	test.describe("mobile tooltip positioning", () => {
+		test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+		test("should keep the timezone info tooltip inside a mobile viewport", async ({ page }) => {
+			await page.setViewportSize({ width: 390, height: 844 });
+			await navigateTo(page, "/settings");
+
+			const timezoneHint = /IANA timezone|IANA-Zeitzone/i;
+			const timezoneInfoIcon = page.getByRole("button", { name: timezoneHint }).first();
+			await expect(timezoneInfoIcon).toBeVisible();
+
+			await timezoneInfoIcon.tap();
+
+			const tooltip = page.getByRole("tooltip").filter({ hasText: timezoneHint }).first();
+			await expect(tooltip).toBeVisible();
+			await expect
+				.poll(async () => {
+					const bounds = await tooltip.boundingBox();
+					if (!bounds) {
+						return "missing";
+					}
+
+					return bounds.x >= 8 && bounds.x + bounds.width <= 390 - 8 && bounds.y >= 0
+						? "inside"
+						: JSON.stringify({
+								left: Math.round(bounds.x),
+								right: Math.round(bounds.x + bounds.width),
+								top: Math.round(bounds.y),
+								width: Math.round(bounds.width),
+							});
+				})
+				.toBe("inside");
+
+			await page.evaluate(() => document.dispatchEvent(new Event("touchmove", { bubbles: true })));
+			await expect(tooltip).toBeHidden();
+
+			await timezoneInfoIcon.tap();
+			await expect(tooltip).toBeVisible();
+
+			await page.evaluate(() => window.scrollBy(0, 240));
+			await expect(tooltip).toBeHidden();
+		});
+	});
+
 	test("should allow switching language", async ({ page }) => {
 		await navigateTo(page, "/settings");
 

--- a/frontend/src/test/components/AppTooltipPrimitives.test.tsx
+++ b/frontend/src/test/components/AppTooltipPrimitives.test.tsx
@@ -2,7 +2,21 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AppCheckbox } from "../../ui/primitives/AppCheckbox";
 import { AppSwitch } from "../../ui/primitives/AppSwitch";
-import { AppTooltipIcon } from "../../ui/primitives/AppTooltip";
+import { AppTooltip, AppTooltipIcon } from "../../ui/primitives/AppTooltip";
+
+function makeRect({ x, y, width, height }: { x: number; y: number; width: number; height: number }): DOMRect {
+	return {
+		bottom: y + height,
+		height,
+		left: x,
+		right: x + width,
+		toJSON: () => ({}),
+		top: y,
+		width,
+		x,
+		y,
+	} as DOMRect;
+}
 
 describe("tooltip-enabled form primitives", () => {
 	it("renders a separate accessible info button for checkbox tooltips", () => {
@@ -33,13 +47,134 @@ describe("tooltip-enabled form primitives", () => {
 		expect(screen.queryByRole("button")).not.toBeInTheDocument();
 	});
 
-	it("opens app tooltip icons from touch input", async () => {
-		render(<AppTooltipIcon label="Mobile help" />);
+	it("opens app tooltip icons from touch input as body portals with aria-describedby", async () => {
+		const { container } = render(<AppTooltipIcon label="Mobile help" />);
 
-		fireEvent.touchStart(screen.getByRole("button", { name: "Mobile help" }));
+		const trigger = screen.getByRole("button", { name: "Mobile help" });
+		fireEvent.touchStart(trigger);
+
+		const tooltip = await screen.findByRole("tooltip");
+		expect(tooltip).toHaveTextContent("Mobile help");
+		expect(tooltip.id).toBeTruthy();
+		expect(trigger).toHaveAttribute("aria-describedby", tooltip.id);
+		expect(tooltip.parentElement).toBe(document.body);
+		expect(container).not.toContainElement(tooltip);
+	});
+
+	it("clamps app tooltips near the left mobile viewport edge", async () => {
+		const originalInnerWidth = window.innerWidth;
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+
+		const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+			this: HTMLElement
+		) {
+			if (this.getAttribute("role") === "tooltip") {
+				const styleLeft = Number.parseFloat(this.style.left || this.style.getPropertyValue("--app-tooltip-left"));
+				const styleTop = Number.parseFloat(this.style.top || this.style.getPropertyValue("--app-tooltip-top"));
+				return makeRect({
+					x: Number.isFinite(styleLeft) ? styleLeft : 0,
+					y: Number.isFinite(styleTop) ? styleTop : 0,
+					width: 240,
+					height: 42,
+				});
+			}
+
+			if (
+				this instanceof HTMLButtonElement ||
+				(this instanceof HTMLElement && this.querySelector("button")?.textContent === "Edge target")
+			) {
+				return makeRect({ x: 2, y: 64, width: 20, height: 20 });
+			}
+
+			return makeRect({ x: 0, y: 0, width: 0, height: 0 });
+		});
+
+		try {
+			render(
+				<AppTooltip label="Edge help">
+					<button type="button">Edge target</button>
+				</AppTooltip>
+			);
+
+			fireEvent.touchStart(screen.getByRole("button", { name: "Edge target" }));
+			const tooltip = await screen.findByRole("tooltip");
+
+			await waitFor(() => {
+				const bounds = tooltip.getBoundingClientRect();
+				expect(bounds.left).toBeGreaterThanOrEqual(8);
+				expect(bounds.right).toBeLessThanOrEqual(window.innerWidth - 8);
+				expect(bounds.top).toBeGreaterThanOrEqual(0);
+			});
+		} finally {
+			rectSpy.mockRestore();
+			Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
+		}
+	});
+
+	it("closes touch-opened app tooltips when the page scrolls or touch moves", async () => {
+		render(<AppTooltipIcon label="Scroll help" />);
+
+		const trigger = screen.getByRole("button", { name: "Scroll help" });
+		fireEvent.touchStart(trigger);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Scroll help");
+
+		fireEvent.touchMove(trigger);
 
 		await waitFor(() => {
-			expect(screen.getByRole("tooltip")).toHaveTextContent("Mobile help");
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		fireEvent.touchStart(trigger);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Scroll help");
+
+		fireEvent.scroll(document);
+
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		fireEvent.touchStart(trigger);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Scroll help");
+
+		fireEvent.pointerMove(trigger, { pointerType: "touch" });
+
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+	});
+
+	it("does not reopen from focus after a touch scroll closes the tooltip", async () => {
+		render(<AppTooltipIcon label="Focus after touch help" />);
+
+		const trigger = screen.getByRole("button", { name: "Focus after touch help" });
+		fireEvent.touchStart(trigger);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Focus after touch help");
+
+		fireEvent.touchMove(trigger);
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		fireEvent.focus(trigger);
+		await new Promise((resolve) => window.setTimeout(resolve, 220));
+
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	it("closes focus-opened app tooltips when the page scrolls", async () => {
+		render(
+			<AppTooltip label="Focused help" openDelay={0}>
+				<button type="button">Focused target</button>
+			</AppTooltip>
+		);
+
+		fireEvent.focus(screen.getByRole("button", { name: "Focused target" }));
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Focused help");
+
+		fireEvent.scroll(document);
+
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/ui/primitives/AppTooltip.module.css
+++ b/frontend/src/ui/primitives/AppTooltip.module.css
@@ -6,12 +6,12 @@
 }
 
 .tooltipBubble {
-	position: absolute;
-	bottom: calc(100% + 0.45rem);
-	left: 50%;
+	position: fixed;
+	top: var(--app-tooltip-top, -9999px);
+	left: var(--app-tooltip-left, -9999px);
 	z-index: 2600;
 	width: max-content;
-	max-width: min(var(--app-tooltip-max-width, 20rem), calc(100vw - 2rem));
+	max-width: min(var(--app-tooltip-max-width, 20rem), var(--app-tooltip-viewport-max-width, calc(100vw - 1rem)));
 	padding: 0.45rem 0.6rem;
 	border: 1px solid var(--mantine-other-border-primary);
 	border-radius: 8px;
@@ -24,13 +24,16 @@
 	text-align: center;
 	white-space: normal;
 	pointer-events: none;
-	transform: translateX(-50%);
+}
+
+.tooltipBubble[data-ready="false"] {
+	visibility: hidden;
 }
 
 .tooltipBubble::after {
 	position: absolute;
 	bottom: -0.32rem;
-	left: 50%;
+	left: var(--app-tooltip-arrow-offset, 50%);
 	width: 0.55rem;
 	height: 0.55rem;
 	border-right: 1px solid var(--mantine-other-border-primary);
@@ -38,6 +41,15 @@
 	background: var(--mantine-other-bg-secondary);
 	content: "";
 	transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltipBubble[data-placement="bottom"]::after {
+	top: -0.32rem;
+	bottom: auto;
+	border-top: 1px solid var(--mantine-other-border-primary);
+	border-right: 0;
+	border-bottom: 0;
+	border-left: 1px solid var(--mantine-other-border-primary);
 }
 
 .tooltipTrigger {

--- a/frontend/src/ui/primitives/AppTooltip.tsx
+++ b/frontend/src/ui/primitives/AppTooltip.tsx
@@ -13,9 +13,11 @@ import {
 	useCallback,
 	useEffect,
 	useId,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
+import { createPortal } from "react-dom";
 import classes from "./AppTooltip.module.css";
 
 type AppTooltipEvents = {
@@ -52,8 +54,30 @@ interface AppTooltipTargetProps {
 	onMouseEnter?: (event: MouseEvent<HTMLElement>) => void;
 	onMouseLeave?: (event: MouseEvent<HTMLElement>) => void;
 	onPointerDown?: (event: PointerEvent<HTMLElement>) => void;
+	onPointerMove?: (event: PointerEvent<HTMLElement>) => void;
 	onTouchStart?: (event: TouchEvent<HTMLElement>) => void;
+	onTouchMove?: (event: TouchEvent<HTMLElement>) => void;
 	"aria-describedby"?: string;
+}
+
+type TooltipPlacement = "top" | "bottom";
+
+interface TooltipPosition {
+	arrowOffset: number;
+	left: number;
+	placement: TooltipPlacement;
+	top: number;
+	viewportMaxWidth: number;
+}
+
+const VIEWPORT_MARGIN = 8;
+const TOOLTIP_GAP = 8;
+const MIN_READABLE_WIDTH = 160;
+const MIN_ARROW_OFFSET = 10;
+const TOUCH_FOCUS_SUPPRESSION_MS = 3000;
+
+function clamp(value: number, min: number, max: number) {
+	return Math.min(Math.max(value, min), max);
 }
 
 export function AppTooltip({
@@ -66,15 +90,20 @@ export function AppTooltip({
 	disabled = false,
 }: AppTooltipProps) {
 	const tooltipId = useId();
+	const rootRef = useRef<HTMLSpanElement | null>(null);
+	const bubbleRef = useRef<HTMLSpanElement | null>(null);
 	const [hoverFocusedOpened, setHoverFocusedOpened] = useState(false);
 	const [touchOpened, setTouchOpened] = useState(false);
+	const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition | null>(null);
 	const openTimerRef = useRef<number | null>(null);
 	const closeTouchTimerRef = useRef<number | null>(null);
+	const lastTouchInteractionRef = useRef(0);
 	const controlled = typeof opened === "boolean";
 	const childProps = (children.props ?? {}) as AppTooltipTargetProps;
 	const touchEnabled = events.touch !== false && !controlled;
 	const isOpen = !disabled && (controlled ? opened : hoverFocusedOpened || touchOpened);
 	const maxWidth = typeof maw === "number" ? `${maw}px` : maw;
+	const canUseDom = typeof document !== "undefined";
 
 	const clearTouchTimer = useCallback(() => {
 		if (closeTouchTimerRef.current) {
@@ -123,6 +152,19 @@ export function AppTooltip({
 		setTouchOpened(false);
 	}, [clearTouchTimer]);
 
+	const closeFromViewportMovement = useCallback(() => {
+		closeFromHoverOrFocus();
+		closeFromTouch();
+	}, [closeFromHoverOrFocus, closeFromTouch]);
+
+	const noteTouchInteraction = useCallback(() => {
+		lastTouchInteractionRef.current = Date.now();
+	}, []);
+
+	const focusFollowsRecentTouch = useCallback(() => {
+		return Date.now() - lastTouchInteractionRef.current < TOUCH_FOCUS_SUPPRESSION_MS;
+	}, []);
+
 	useEffect(
 		() => () => {
 			clearOpenTimer();
@@ -130,6 +172,111 @@ export function AppTooltip({
 		},
 		[clearOpenTimer, clearTouchTimer]
 	);
+
+	useEffect(() => {
+		if (!isOpen || controlled || !canUseDom) return;
+
+		const closeTooltipOnPointerMove = (event: globalThis.PointerEvent) => {
+			if (event.pointerType === "touch") {
+				closeFromViewportMovement();
+			}
+		};
+
+		const visualViewport = window.visualViewport;
+
+		document.addEventListener("pointermove", closeTooltipOnPointerMove, { capture: true, passive: true });
+		document.addEventListener("scroll", closeFromViewportMovement, { capture: true, passive: true });
+		document.addEventListener("touchmove", closeFromViewportMovement, { capture: true, passive: true });
+		document.addEventListener("wheel", closeFromViewportMovement, { capture: true, passive: true });
+		window.addEventListener("scroll", closeFromViewportMovement, { capture: true, passive: true });
+		visualViewport?.addEventListener("resize", closeFromViewportMovement, { passive: true });
+		visualViewport?.addEventListener("scroll", closeFromViewportMovement, { passive: true });
+
+		return () => {
+			document.removeEventListener("pointermove", closeTooltipOnPointerMove, true);
+			document.removeEventListener("scroll", closeFromViewportMovement, true);
+			document.removeEventListener("touchmove", closeFromViewportMovement, true);
+			document.removeEventListener("wheel", closeFromViewportMovement, true);
+			window.removeEventListener("scroll", closeFromViewportMovement, true);
+			visualViewport?.removeEventListener("resize", closeFromViewportMovement);
+			visualViewport?.removeEventListener("scroll", closeFromViewportMovement);
+		};
+	}, [canUseDom, closeFromViewportMovement, controlled, isOpen]);
+
+	const updateTooltipPosition = useCallback(() => {
+		const root = rootRef.current;
+		const bubble = bubbleRef.current;
+		if (!root || !bubble) return;
+
+		const anchorRect = root.getBoundingClientRect();
+		const anchorCenterX = anchorRect.left + anchorRect.width / 2;
+		const viewportWidth = window.innerWidth;
+		const viewportHeight = window.innerHeight;
+		const viewportMaxWidth = Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2);
+		const centeredMaxWidth = Math.max(
+			0,
+			2 * Math.min(anchorCenterX - VIEWPORT_MARGIN, viewportWidth - VIEWPORT_MARGIN - anchorCenterX)
+		);
+		const readableMaxWidth = Math.min(MIN_READABLE_WIDTH, viewportMaxWidth);
+		const effectiveViewportMaxWidth = Math.max(Math.min(viewportMaxWidth, centeredMaxWidth), readableMaxWidth);
+
+		bubble.style.setProperty("--app-tooltip-viewport-max-width", `${effectiveViewportMaxWidth}px`);
+
+		const bubbleRect = bubble.getBoundingClientRect();
+		const bubbleWidth = bubbleRect.width;
+		const bubbleHeight = bubbleRect.height;
+		const left = clamp(
+			anchorCenterX - bubbleWidth / 2,
+			VIEWPORT_MARGIN,
+			Math.max(VIEWPORT_MARGIN, viewportWidth - VIEWPORT_MARGIN - bubbleWidth)
+		);
+		const topCandidate = anchorRect.top - TOOLTIP_GAP - bubbleHeight;
+		const bottomCandidate = anchorRect.bottom + TOOLTIP_GAP;
+		const availableAbove = anchorRect.top - VIEWPORT_MARGIN;
+		const availableBelow = viewportHeight - anchorRect.bottom - VIEWPORT_MARGIN;
+		const placement: TooltipPlacement =
+			topCandidate < VIEWPORT_MARGIN && availableBelow > availableAbove ? "bottom" : "top";
+		const verticalCandidate = placement === "top" ? topCandidate : bottomCandidate;
+		const top = clamp(
+			verticalCandidate,
+			VIEWPORT_MARGIN,
+			Math.max(VIEWPORT_MARGIN, viewportHeight - VIEWPORT_MARGIN - bubbleHeight)
+		);
+		const arrowOffset = clamp(
+			anchorCenterX - left,
+			MIN_ARROW_OFFSET,
+			Math.max(MIN_ARROW_OFFSET, bubbleWidth - MIN_ARROW_OFFSET)
+		);
+
+		setTooltipPosition({
+			arrowOffset,
+			left,
+			placement,
+			top,
+			viewportMaxWidth: effectiveViewportMaxWidth,
+		});
+	}, []);
+
+	useLayoutEffect(() => {
+		if (!isOpen || !canUseDom) {
+			setTooltipPosition(null);
+			return;
+		}
+
+		updateTooltipPosition();
+		let frame = 0;
+		const scheduleUpdate = () => {
+			window.cancelAnimationFrame(frame);
+			frame = window.requestAnimationFrame(updateTooltipPosition);
+		};
+
+		window.addEventListener("resize", scheduleUpdate);
+
+		return () => {
+			window.cancelAnimationFrame(frame);
+			window.removeEventListener("resize", scheduleUpdate);
+		};
+	}, [canUseDom, isOpen, updateTooltipPosition]);
 
 	const target = cloneElement(children as ReactElement<AppTooltipTargetProps>, {
 		"aria-describedby": isOpen ? tooltipId : childProps["aria-describedby"],
@@ -142,7 +289,7 @@ export function AppTooltip({
 		},
 		onFocus: (event: FocusEvent<HTMLElement>) => {
 			childProps.onFocus?.(event);
-			if (events.focus !== false) {
+			if (events.focus !== false && !focusFollowsRecentTouch()) {
 				openFromHoverOrFocus();
 			}
 		},
@@ -168,28 +315,61 @@ export function AppTooltip({
 		onPointerDown: (event: PointerEvent<HTMLElement>) => {
 			childProps.onPointerDown?.(event);
 			if (event.pointerType === "touch") {
+				noteTouchInteraction();
 				openFromTouch();
+			}
+		},
+		onPointerMove: (event: PointerEvent<HTMLElement>) => {
+			childProps.onPointerMove?.(event);
+			if (event.pointerType === "touch") {
+				noteTouchInteraction();
+				closeFromViewportMovement();
 			}
 		},
 		onTouchStart: (event: TouchEvent<HTMLElement>) => {
 			childProps.onTouchStart?.(event);
+			noteTouchInteraction();
 			openFromTouch();
+		},
+		onTouchMove: (event: TouchEvent<HTMLElement>) => {
+			childProps.onTouchMove?.(event);
+			noteTouchInteraction();
+			closeFromViewportMovement();
 		},
 	} satisfies AppTooltipTargetProps);
 
+	const tooltipBubble =
+		isOpen && canUseDom
+			? createPortal(
+					<span
+						className={classes.tooltipBubble}
+						data-placement={tooltipPosition?.placement ?? "top"}
+						data-ready={tooltipPosition ? "true" : "false"}
+						id={tooltipId}
+						ref={bubbleRef}
+						role="tooltip"
+						style={
+							{
+								"--app-tooltip-arrow-offset": tooltipPosition ? `${tooltipPosition.arrowOffset}px` : "50%",
+								"--app-tooltip-left": tooltipPosition ? `${tooltipPosition.left}px` : "-9999px",
+								"--app-tooltip-max-width": maxWidth,
+								"--app-tooltip-top": tooltipPosition ? `${tooltipPosition.top}px` : "-9999px",
+								"--app-tooltip-viewport-max-width": tooltipPosition
+									? `${tooltipPosition.viewportMaxWidth}px`
+									: `calc(100vw - ${VIEWPORT_MARGIN * 2}px)`,
+							} as CSSProperties
+						}
+					>
+						{label}
+					</span>,
+					document.body
+				)
+			: null;
+
 	return (
-		<span className={classes.tooltipRoot}>
+		<span className={classes.tooltipRoot} ref={rootRef}>
 			{target}
-			{isOpen ? (
-				<span
-					className={classes.tooltipBubble}
-					id={tooltipId}
-					role="tooltip"
-					style={{ "--app-tooltip-max-width": maxWidth } as CSSProperties}
-				>
-					{label}
-				</span>
-			) : null}
+			{tooltipBubble}
 		</span>
 	);
 }


### PR DESCRIPTION
Closes #859

## Summary
- Render shared AppTooltip/AppTooltipIcon popovers through a document.body portal so mobile popovers are not clipped by constrained containers.
- Clamp tooltip placement within the viewport and preserve resize-based repositioning for open tooltips.
- Close touch-opened tooltips on mobile viewport movement, including touchmove, touch pointermove, wheel, document/window scroll, and visualViewport movement.
- Prevent focus-triggered reopening immediately after touch interactions and remove the dead scroll-reposition path.

## Validation
- `npx biome check frontend/src/ui/primitives/AppTooltip.tsx frontend/src/ui/primitives/AppTooltip.module.css frontend/src/test/components/AppTooltipPrimitives.test.tsx frontend/e2e/settings.spec.ts`
- `npm --prefix frontend run test:run -- src/test/components/AppTooltipPrimitives.test.tsx` (9 tests passed)
- `PLAYWRIGHT_HTML_OPEN=never PLAYWRIGHT_WORKERS=1 npx playwright test --config=playwright.stable.config.ts e2e/settings.spec.ts --grep "info tooltip"` (auth setup + chromium test passed, 2 passed)
- `npm --prefix frontend run check`
- `npm --prefix frontend run build`