### PR TITLE
fix: correct journal taken-at timezone display

### DIFF
--- a/frontend/src/components/intake-journal/journal-display.ts
+++ b/frontend/src/components/intake-journal/journal-display.ts
@@ -1,14 +1,52 @@
 import type { IntakeJournalEntry } from "../../hooks/useIntakeJournal";
-import { formatDateTime, getNumericLocale } from "../../utils/formatters";
+import { formatDateTime, getNumericLocale, withFormattingTimezone } from "../../utils/formatters";
 
 type Translate = (key: string) => string;
+
+const EXPLICIT_TIMEZONE_SUFFIX = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+function hasExplicitTimezone(value: string): boolean {
+	return EXPLICIT_TIMEZONE_SUFFIX.test(value.trim());
+}
+
+function formatAbsoluteJournalDateTime(value: string, locale: string): string | null {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	const dateLabel = date.toLocaleDateString(
+		locale,
+		withFormattingTimezone({
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		})
+	);
+	const timeLabel = date.toLocaleTimeString(
+		locale,
+		withFormattingTimezone({
+			hour: "2-digit",
+			minute: "2-digit",
+		})
+	);
+
+	return `${dateLabel} ${timeLabel}`;
+}
 
 export function formatJournalDisplayDateTime(value: string | null): string | null {
 	if (!value) {
 		return null;
 	}
 
-	return formatDateTime(value, getNumericLocale());
+	const trimmed = value.trim();
+	const locale = getNumericLocale();
+
+	if (hasExplicitTimezone(trimmed)) {
+		return formatAbsoluteJournalDateTime(trimmed, locale) ?? formatDateTime(trimmed, locale);
+	}
+
+	return formatDateTime(trimmed, locale);
 }
 
 export function getJournalSourceLabel(entry: IntakeJournalEntry, t: Translate): string {

--- a/frontend/src/test/components/IntakeJournalModal.test.tsx
+++ b/frontend/src/test/components/IntakeJournalModal.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { IntakeJournalModal } from "../../components/intake-journal/IntakeJournalModal";
 import type { IntakeJournalEntry } from "../../hooks/useIntakeJournal";
+import { setDefaultFormattingTimezone } from "../../utils/formatters";
 
 vi.mock("react-i18next", () => ({
 	useTranslation: () => ({
@@ -12,6 +13,10 @@ vi.mock("react-i18next", () => ({
 vi.mock("../../components/MedicationAvatar", () => ({
 	MedicationAvatar: ({ name }: { name: string }) => <div>{name}</div>,
 }));
+
+afterEach(() => {
+	setDefaultFormattingTimezone(null);
+});
 
 function buildEntry(overrides: Partial<IntakeJournalEntry> = {}): IntakeJournalEntry {
 	return {
@@ -32,6 +37,56 @@ function buildEntry(overrides: Partial<IntakeJournalEntry> = {}): IntakeJournalE
 }
 
 describe("IntakeJournalModal", () => {
+	it("displays taken-at instants in the configured local timezone", () => {
+		setDefaultFormattingTimezone("Europe/Berlin");
+		const entry = buildEntry({
+			scheduledFor: "2026-07-03T07:00:00.000+02:00",
+			takenAt: "2026-07-03T04:47:00.000Z",
+		});
+
+		render(
+			<IntakeJournalModal
+				isOpen
+				entry={entry}
+				isLoading={false}
+				isSaving={false}
+				isDeleting={false}
+				error={null}
+				onClose={vi.fn()}
+				onSave={vi.fn()}
+				onDelete={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByText("03.07.2026 07:00")).toBeInTheDocument();
+		expect(screen.getByText("03.07.2026 06:47")).toBeInTheDocument();
+	});
+
+	it("keeps no-offset journal timestamps as local wall time", () => {
+		setDefaultFormattingTimezone("Europe/Berlin");
+		const entry = buildEntry({
+			scheduledFor: "2026-07-03T07:00:00.000",
+			takenAt: "2026-07-03T04:47:00.000",
+		});
+
+		render(
+			<IntakeJournalModal
+				isOpen
+				entry={entry}
+				isLoading={false}
+				isSaving={false}
+				isDeleting={false}
+				error={null}
+				onClose={vi.fn()}
+				onSave={vi.fn()}
+				onDelete={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByText("03.07.2026 07:00")).toBeInTheDocument();
+		expect(screen.getByText("03.07.2026 04:47")).toBeInTheDocument();
+	});
+
 	it("closes after a successful save", async () => {
 		const onSave = vi.fn(async () => true);
 		const onClose = vi.fn();


### PR DESCRIPTION
## Summary

- Render journal `takenAt` instants with `Z` or an explicit offset through the configured formatting timezone.
- Preserve direct wall-time formatting for no-offset local timestamp strings.
- Add Berlin timezone coverage for absolute, offset, and no-offset journal timestamps.

## Validation

- `npm --prefix frontend run test:run -- src/test/components/IntakeJournalModal.test.tsx`
- `npm --prefix frontend run check`
- testing-manager reported focused Vitest, scoped Biome, and frontend TypeScript checks passed.

Closes #861