### PR TITLE
chore: align agent memory governance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ If `AGENTS.md` exists in the checkout or is provided in the session context, tre
 
 1. Read this file first.
 2. Apply `AGENTS.md` when available.
-3. Ensure `doku/memory_notes.md` exists, read its current-state/relevant durable notes before meaningful work, and keep it updated with concise continuity notes. It is local-only and must not be staged or committed unless explicitly requested.
+3. Ensure root `MEMORY.md` exists, read its current-state/relevant durable notes before meaningful work, and keep it updated with concise durable context: project decisions, conventions, recurring pitfalls, validation state, and open risks. It is local-only and must not be staged or committed unless explicitly requested.
 4. Identify triggered skills and read only the matching `.github/skills/*/SKILL.md` files before changing code.
 5. Keep work scoped to the user's current objective and existing repository patterns.
 
@@ -54,5 +54,5 @@ shell commands, and other important information, read the current plan.
 
 Do not stage or commit local workspace state unless the user explicitly asks for that exact action:
 
-- `doku/memory_notes.md`
+- `MEMORY.md`
 - local planning, agent, or scratch artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ Thumbs.db
 .roomodes
 .claude/
 AGENTS.md
+MEMORY.md
 docs/TECH_STACK.md
 /doku/
 /plan/


### PR DESCRIPTION
## Summary

- Update the Copilot entrypoint to use root `MEMORY.md` for local agent continuity.
- Add `MEMORY.md` to `.gitignore` so local memory remains untracked.

## Validation

- `npm run check`

Closes #863