### PR TITLE
fix: make Container Smoke a visible PR check

### DIFF
--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -206,11 +206,12 @@ When code changes (features or bug fixes) are complete:
 
 1. Monitor CI status via GitHub MCP until all required checks complete.
    Required checks: all repository-required checks must pass.
-2. If CI fails: analyze the failure, fix it, push again, and re-check.
-3. Once CI is green, **ask the user for merge confirmation**, then merge the PR via GitHub MCP using squash merge and branch deletion.
-4. Re-sync the authoritative local `main` before using it again as a source of truth for any next PR or release step. Do not continue from a previously dirty workspace without another source-of-truth audit.
-5. If the requested end state is a clean local `main`, verify that `git status` is empty and that no task-related stash entry remains as hidden residue.
-6. Switch back to main and pull:
+2. For release-relevant PRs (backend, frontend, shared, package, Docker, or workflow/runtime changes), also require the visible `Container Smoke` PR check to complete successfully. If it is missing, skipped for a smoke-relevant diff, or failed, treat CI as not green even if branch protection would allow a bypass merge.
+3. If CI fails: analyze the failure, fix it, push again, and re-check.
+4. Once CI is green, **ask the user for merge confirmation**, then merge the PR via GitHub MCP using squash merge and branch deletion.
+5. Re-sync the authoritative local `main` before using it again as a source of truth for any next PR or release step. Do not continue from a previously dirty workspace without another source-of-truth audit.
+6. If the requested end state is a clean local `main`, verify that `git status` is empty and that no task-related stash entry remains as hidden residue.
+7. Switch back to main and pull:
 
 ```bash
   git checkout main
@@ -540,7 +541,7 @@ Code complete & validated by testing-manager
 1. Ensure a GitHub issue exists (create if not)
 2. Create feature branch (fix/... or feat/...)
 3. Commit, push, create PR (with "Closes #N" in body, assignee, label, project)
-4. Wait for CI (all required checks)
+4. Wait for CI (all required checks plus visible `Container Smoke` when release-relevant)
 5. Merge PR to main (squash + delete branch)
 6. Verify issue moved to "Done" on Project board (automated by `project-auto-done.yml`; fallback: GraphQL, see Task 6)
         ↓

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -1,9 +1,8 @@
 name: Container Smoke
 
 on:
-  workflow_run:
-    workflows: ['Test', 'E2E Tests']
-    types: [completed]
+  pull_request:
+    branches: [main]
   workflow_call:
     inputs:
       image_source:
@@ -23,73 +22,105 @@ on:
         default: ''
 
 concurrency:
-  group: container-smoke-${{ github.event.workflow_run.head_sha || github.ref }}
+  group: container-smoke-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   checks: read
+  pull-requests: read
 
 jobs:
   gate:
     name: Evaluate CI Gate
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.required_check_gate.outputs.should_run || steps.workflow_call_gate.outputs.should_run || 'false' }}
+      should_run: ${{ steps.pr_required_check_gate.outputs.should_run || steps.workflow_call_gate.outputs.should_run || 'false' }}
     steps:
       - name: Allow smoke when called as reusable workflow
         id: workflow_call_gate
-        if: github.event_name != 'workflow_run'
+        if: github.event_name != 'pull_request'
         run: echo "should_run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure triggering workflow succeeded
-        id: trigger_conclusion
-        if: github.event_name == 'workflow_run'
-        run: |
-          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
-            echo "Triggering workflow conclusion is '${{ github.event.workflow_run.conclusion }}'; skipping smoke."
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Detect PR smoke relevance
+        id: pr_changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            smoke:
+              - 'backend/**'
+              - 'frontend/**'
+              - 'shared/**'
+              - 'package.json'
+              - 'release-policy.json'
+              - 'scripts/**'
+              - 'docker-compose.yml'
+              - 'docker-compose.dev.yml'
+              - '.github/workflows/container-smoke.yml'
+              - '.github/workflows/docker-build.yml'
 
-      - name: Verify required checks for this commit
-        id: required_check_gate
-        if: github.event_name == 'workflow_run' && steps.trigger_conclusion.outputs.should_run == 'true'
+      - name: Wait for required PR checks
+        id: pr_required_check_gate
+        if: github.event_name == 'pull_request' && steps.pr_changes.outputs.smoke == 'true'
         uses: actions/github-script@v9
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const ref = context.payload.workflow_run.head_sha;
+            const ref = context.payload.pull_request.head.sha;
             const requiredChecks = ['Backend Tests', 'Frontend Build', 'Playwright E2E'];
+            const terminalFailures = new Set(['action_required', 'cancelled', 'failure', 'neutral', 'skipped', 'stale', 'startup_failure', 'timed_out']);
+            const maxAttempts = 80;
+            const waitMs = 15000;
 
-            const response = await github.rest.checks.listForRef({
-              owner,
-              repo,
-              ref,
-              per_page: 100,
-            });
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const response = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref,
+                per_page: 100,
+              });
 
-            const checkMap = new Map();
-            for (const run of response.data.check_runs) {
-              checkMap.set(run.name, run.conclusion);
-            }
-
-            let shouldRun = true;
-            for (const checkName of requiredChecks) {
-              const conclusion = checkMap.get(checkName);
-              core.info(`${checkName}: ${conclusion ?? 'missing'}`);
-              if (conclusion !== 'success') {
-                shouldRun = false;
+              const checkMap = new Map();
+              for (const run of response.data.check_runs) {
+                if (!checkMap.has(run.name) || run.completed_at) {
+                  checkMap.set(run.name, {
+                    conclusion: run.conclusion,
+                    status: run.status,
+                  });
+                }
               }
+
+              const waitingFor = [];
+              for (const checkName of requiredChecks) {
+                const check = checkMap.get(checkName);
+                core.info(`${checkName}: ${check?.status ?? 'missing'} / ${check?.conclusion ?? 'pending'}`);
+                if (check?.conclusion === 'success') {
+                  continue;
+                }
+                if (check?.conclusion && terminalFailures.has(check.conclusion)) {
+                  core.info(`${checkName} concluded ${check.conclusion}; skipping Container Smoke because the PR is already blocked.`);
+                  core.setOutput('should_run', 'false');
+                  return;
+                }
+                waitingFor.push(checkName);
+              }
+
+              if (waitingFor.length === 0) {
+                core.setOutput('should_run', 'true');
+                return;
+              }
+
+              core.info(`Waiting for required checks before Container Smoke: ${waitingFor.join(', ')} (attempt ${attempt}/${maxAttempts})`);
+              await new Promise((resolve) => setTimeout(resolve, waitMs));
             }
 
-            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setFailed(`Timed out waiting for required PR checks before Container Smoke on ${ref}.`);
 
       - name: Skip smoke when required checks are not all green
-        if: github.event_name == 'workflow_run' && (steps.trigger_conclusion.outputs.should_run != 'true' || steps.required_check_gate.outputs.should_run != 'true')
-        run: echo "Skipping Container Smoke because required checks are not all successful for this commit."
+        if: github.event_name == 'pull_request' && (steps.pr_changes.outputs.smoke != 'true' || steps.pr_required_check_gate.outputs.should_run != 'true')
+        run: echo "Skipping Container Smoke because this PR is not smoke-relevant or required checks are not all successful."
 
   smoke:
     name: Container Smoke
@@ -109,7 +140,7 @@ jobs:
         if: inputs.image_source != 'published'
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Buildx
         if: inputs.image_source != 'published'
@@ -142,8 +173,8 @@ jobs:
           file: ./backend/Dockerfile
           load: true
           tags: ${{ env.BACKEND_LOCAL_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=container-smoke-backend
+          cache-to: type=gha,mode=max,scope=container-smoke-backend,ignore-error=true
           platforms: linux/amd64
 
       - name: Build frontend image for local smoke
@@ -154,8 +185,8 @@ jobs:
           file: ./frontend/Dockerfile
           load: true
           tags: ${{ env.FRONTEND_LOCAL_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=container-smoke-frontend
+          cache-to: type=gha,mode=max,scope=container-smoke-frontend,ignore-error=true
           platforms: linux/amd64
 
       - name: Pull published images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -140,8 +140,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.image }},ignore-error=true
           platforms: linux/amd64,linux/arm64
           provenance: mode=max
           sbom: true

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -95,18 +95,19 @@ Use the root-level commands for full-stack validation when a change spans backen
 
 ## Release Workflow Safeguards
 
-- PR validation is enforced through `.github/workflows/test.yml` and `.github/workflows/e2e.yml`.
+- PR validation is enforced through `.github/workflows/test.yml`, `.github/workflows/e2e.yml`, and `.github/workflows/container-smoke.yml`.
 - Workflow syntax validation is enforced through `.github/workflows/workflow-validation.yml` with `actionlint` on PRs that change workflow files under `.github/workflows/**`.
 - CodeQL scans both `javascript-typescript` source code and GitHub Actions workflow changes under `.github/workflows/**` / `.github/actions/**`.
 - Within product-relevant PRs, required product checks still emit their stable names and report a no-op success when a backend/frontend lane is not relevant inside that product scope.
 - Workflow-only edits are validated by `Workflow Validation / Actionlint`; they do not trigger backend/frontend/Playwright/container smoke lanes by themselves, but they still run CodeQL for the `actions` language.
-- Release-relevant PRs also run `.github/workflows/container-smoke.yml` as a dedicated container runtime check.
+- Release-relevant PRs also run `.github/workflows/container-smoke.yml` as a dedicated visible `Container Smoke` PR check after `Backend Tests`, `Frontend Build`, and `Playwright E2E` are green.
 - Dependabot auto-merge for safe updates is gated by `.github/workflows/dependabot-automerge.yml` and currently allows `npm`, `npm_and_yarn`, and `github_actions` ecosystems for semver minor/patch updates only.
 - The default-branch ruleset requires the stable CodeQL context `Analyze (javascript-typescript)`, so workflow changes must keep the CodeQL job name aligned with that exact required-check context.
 - Docker publishing is handled by `.github/workflows/docker-build.yml`.
 - The reusable container smoke workflow is used in two places:
   - directly on release-relevant PRs as the visible `Container Smoke` check
   - from `docker-build.yml` before release completion
+- Docker Buildx cache export is allowed to fail in smoke/publish builds (`ignore-error=true`) because cache reservation is an optimization; container build, startup, health, static asset, and proxy checks remain the required signal.
 - Releases also run `npm run release:preflight` in two stages:
   - early static validation of tag, package versions, release policy, compose tags, and release workflow dependencies
   - late validation of generated changelog and `docker-compose.pinned.yml` before GitHub Release creation

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -140,6 +140,49 @@ function validateWorkflowNeeds(workflowPath) {
   }
 }
 
+function validateDockerBuildCachePolicy(workflowPath) {
+  const workflow = readText(workflowPath);
+  const requiredCacheTo = "cache-to: type=gha,mode=max,scope=docker-${{ matrix.image }},ignore-error=true";
+  const requiredCacheFrom = "cache-from: type=gha,scope=docker-${{ matrix.image }}";
+
+  if (!workflow.includes(requiredCacheFrom)) {
+    fail(`${workflowPath} build-and-push cache-from must use a Docker image-specific GitHub Actions cache scope.`);
+  }
+
+  if (!workflow.includes(requiredCacheTo)) {
+    fail(`${workflowPath} build-and-push cache-to must ignore GitHub Actions cache export failures.`);
+  }
+}
+
+function validateContainerSmokeWorkflow(workflowPath) {
+  const workflow = readText(workflowPath);
+
+  if (!/\n\s*pull_request:\s*\n\s*branches:\s*\[main\]/.test(workflow)) {
+    fail(`${workflowPath} must run directly on pull_request for main so Container Smoke is visible as a PR check.`);
+  }
+
+  if (/\n\s*workflow_run:/.test(workflow)) {
+    fail(`${workflowPath} must not use workflow_run; it hides Container Smoke from PR check rollups and creates duplicate post-check runs.`);
+  }
+
+  if (!workflow.includes("Wait for required PR checks")) {
+    fail(`${workflowPath} must wait for Backend Tests, Frontend Build, and Playwright E2E before running smoke on PRs.`);
+  }
+
+  for (const imageName of ["backend", "frontend"]) {
+    const cacheFrom = `cache-from: type=gha,scope=container-smoke-${imageName}`;
+    const cacheTo = `cache-to: type=gha,mode=max,scope=container-smoke-${imageName},ignore-error=true`;
+
+    if (!workflow.includes(cacheFrom)) {
+      fail(`${workflowPath} ${imageName} smoke build must use an image-specific GitHub Actions cache scope.`);
+    }
+
+    if (!workflow.includes(cacheTo)) {
+      fail(`${workflowPath} ${imageName} smoke build must ignore GitHub Actions cache export failures.`);
+    }
+  }
+}
+
 function validatePackageVersion(packageName, packageJsonPath, packageJson, releaseVersion) {
   if (packageJson.version !== releaseVersion) {
     fail(`${packageJsonPath} version must match ${releaseVersion}, found ${packageJson.version}.`);
@@ -335,6 +378,10 @@ function main() {
 
   const workflowPath = String(args.workflow || ".github/workflows/docker-build.yml");
   validateWorkflowNeeds(workflowPath);
+  validateDockerBuildCachePolicy(workflowPath);
+
+  const containerSmokeWorkflowPath = String(args["container-smoke-workflow"] || ".github/workflows/container-smoke.yml");
+  validateContainerSmokeWorkflow(containerSmokeWorkflowPath);
 
   if (args["static-only"]) {
     console.log(`release-preflight: static checks passed for ${tag}`);

--- a/scripts/test-release-preflight.mjs
+++ b/scripts/test-release-preflight.mjs
@@ -28,6 +28,7 @@ function copyFixture() {
     "shared/package.json",
     "shared/package-lock.json",
     ".github/workflows/docker-build.yml",
+    ".github/workflows/container-smoke.yml",
     ".github/workflows/test.yml",
     ".github/workflows/e2e.yml"
   ];
@@ -178,6 +179,59 @@ test("release preflight rejects CI workflow without the domain E2E release gate"
     writeFileSync(workflowPath, workflow);
 
     expectPreflightFailure(fixtureRoot, /\.github\/workflows\/e2e\.yml must run the domain E2E release gate/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects hidden workflow-run container smoke", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/container-smoke.yml");
+    const workflow = readFileSync(workflowPath, "utf8")
+      .replace("pull_request:", "workflow_run:\n    workflows: ['Test', 'E2E Tests']\n    types: [completed]")
+      .replace("    branches: [main]\n", "");
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(fixtureRoot, /\.github\/workflows\/container-smoke\.yml must run directly on pull_request/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects fatal container smoke cache export", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/container-smoke.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      "cache-to: type=gha,mode=max,scope=container-smoke-backend,ignore-error=true",
+      "cache-to: type=gha,mode=max"
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /\.github\/workflows\/container-smoke\.yml backend smoke build must ignore GitHub Actions cache export failures/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects fatal Docker publish cache export", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/docker-build.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      "cache-to: type=gha,mode=max,scope=docker-${{ matrix.image }},ignore-error=true",
+      "cache-to: type=gha,mode=max"
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /\.github\/workflows\/docker-build\.yml build-and-push cache-to must ignore GitHub Actions cache export failures/
+    );
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #865

## Summary

- Run Container Smoke directly on relevant pull requests so it appears in the PR check rollup.
- Gate smoke until Backend Tests, Frontend Build, and Playwright E2E have completed successfully.
- Make Buildx GitHub Actions cache export non-fatal for smoke and publish builds while keeping real container startup and health checks required.
- Add release-preflight guards and documentation so this behavior does not regress.

## Local Validation

- `node scripts/test-release-preflight.mjs`
- `actionlint .github/workflows/container-smoke.yml .github/workflows/docker-build.yml`
- `npm run release:preflight -- --tag v1.28.1 --static-only`
- `npm run check`

## Merge Gate

Do not merge until the visible `Container Smoke` PR check appears and succeeds, in addition to the repository-required checks and workflow validation/CodeQL.