### PR TITLE
feat: add intake journal mood tracking

### DIFF
--- a/backend/drizzle/0019_add_intake_journal_mood.sql
+++ b/backend/drizzle/0019_add_intake_journal_mood.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `intake_journal` ADD `mood` text(20) DEFAULT '' NOT NULL;

--- a/backend/drizzle/meta/0019_snapshot.json
+++ b/backend/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1615 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "989c80c7-156e-4c24-a9c1-b64fc1f448ff",
+  "prevId": "e1c55413-5bca-44ce-a7ca-8645fa3f33d5",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'write'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dose_tracking": {
+      "name": "dose_tracking",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dose_id": {
+          "name": "dose_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s','now'))"
+        },
+        "marked_by": {
+          "name": "marked_by",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "taken_source": {
+          "name": "taken_source",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dose_tracking_user_id_dose_id_unique": {
+          "name": "dose_tracking_user_id_dose_id_unique",
+          "columns": [
+            "user_id",
+            "dose_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "dose_tracking_user_id_users_id_fk": {
+          "name": "dose_tracking_user_id_users_id_fk",
+          "tableFrom": "dose_tracking",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "intake_journal": {
+      "name": "intake_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dose_tracking_id": {
+          "name": "dose_tracking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "intake_journal_dose_tracking_id_unique": {
+          "name": "intake_journal_dose_tracking_id_unique",
+          "columns": [
+            "dose_tracking_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "intake_journal_user_id_users_id_fk": {
+          "name": "intake_journal_user_id_users_id_fk",
+          "tableFrom": "intake_journal",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_journal_dose_tracking_id_dose_tracking_id_fk": {
+          "name": "intake_journal_dose_tracking_id_dose_tracking_id_fk",
+          "tableFrom": "intake_journal",
+          "tableTo": "dose_tracking",
+          "columnsFrom": [
+            "dose_tracking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_journal_medication_id_medications_id_fk": {
+          "name": "intake_journal_medication_id_medications_id_fk",
+          "tableFrom": "intake_journal",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "medications": {
+      "name": "medications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generic_name": {
+          "name": "generic_name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "taken_by_json": {
+          "name": "taken_by_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "package_type": {
+          "name": "package_type",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'blister'"
+        },
+        "medication_form": {
+          "name": "medication_form",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'tablet'"
+        },
+        "pill_form": {
+          "name": "pill_form",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifecycle_category": {
+          "name": "lifecycle_category",
+          "type": "text(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'refill_when_empty'"
+        },
+        "package_amount_value": {
+          "name": "package_amount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "package_amount_unit": {
+          "name": "package_amount_unit",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ml'"
+        },
+        "pack_count": {
+          "name": "pack_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "blisters_per_pack": {
+          "name": "blisters_per_pack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "pills_per_blister": {
+          "name": "pills_per_blister",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_pills": {
+          "name": "total_pills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "loose_tablets": {
+          "name": "loose_tablets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_adjustment": {
+          "name": "stock_adjustment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_stock_correction_at": {
+          "name": "last_stock_correction_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pill_weight_mg": {
+          "name": "pill_weight_mg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dose_unit": {
+          "name": "dose_unit",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'mg'"
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "every_json": {
+          "name": "every_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "start_json": {
+          "name": "start_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "intakes_json": {
+          "name": "intakes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intake_reminders_enabled": {
+          "name": "intake_reminders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "medication_start_date": {
+          "name": "medication_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "medication_end_date": {
+          "name": "medication_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_mark_obsolete_after_end_date": {
+          "name": "auto_mark_obsolete_after_end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_obsolete": {
+          "name": "is_obsolete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "obsolete_at": {
+          "name": "obsolete_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prescription_enabled": {
+          "name": "prescription_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prescription_authorized_refills": {
+          "name": "prescription_authorized_refills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prescription_remaining_refills": {
+          "name": "prescription_remaining_refills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prescription_low_refill_threshold": {
+          "name": "prescription_low_refill_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "prescription_expiry_date": {
+          "name": "prescription_expiry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissed_until": {
+          "name": "dismissed_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medications_user_id_users_id_fk": {
+          "name": "medications_user_id_users_id_fk",
+          "tableFrom": "medications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_action_groups": {
+      "name": "notification_action_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ntfy_original_message_id": {
+          "name": "ntfy_original_message_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "dose_ids_json": {
+          "name": "dose_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_action": {
+          "name": "resolved_action",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "notification_action_groups_group_key_unique": {
+          "name": "notification_action_groups_group_key_unique",
+          "columns": [
+            "group_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_action_groups_user_id_users_id_fk": {
+          "name": "notification_action_groups_user_id_users_id_fk",
+          "tableFrom": "notification_action_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_action_tokens": {
+      "name": "notification_action_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "notification_action_tokens_token_hash_unique": {
+          "name": "notification_action_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_action_tokens_group_id_notification_action_groups_id_fk": {
+          "name": "notification_action_tokens_group_id_notification_action_groups_id_fk",
+          "tableFrom": "notification_action_tokens",
+          "tableTo": "notification_action_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refill_history": {
+      "name": "refill_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "packs_added": {
+          "name": "packs_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "loose_pills_added": {
+          "name": "loose_pills_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used_prescription": {
+          "name": "used_prescription",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "refill_date": {
+          "name": "refill_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s','now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refill_history_medication_id_medications_id_fk": {
+          "name": "refill_history_medication_id_medications_id_fk",
+          "tableFrom": "refill_history",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refill_history_user_id_users_id_fk": {
+          "name": "refill_history_user_id_users_id_fk",
+          "tableFrom": "refill_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_id_unique": {
+          "name": "refresh_tokens_token_id_unique",
+          "columns": [
+            "token_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_tokens": {
+      "name": "share_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taken_by": {
+          "name": "taken_by",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_days": {
+          "name": "schedule_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "allow_journal_notes": {
+          "name": "allow_journal_notes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_mark_taken": {
+          "name": "allow_mark_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_tokens_token_unique": {
+          "name": "share_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_tokens_user_id_users_id_fk": {
+          "name": "share_tokens_user_id_users_id_fk",
+          "tableFrom": "share_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_stock_reminders": {
+          "name": "email_stock_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_intake_reminders": {
+          "name": "email_intake_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_prescription_reminders": {
+          "name": "email_prescription_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "shoutrrr_enabled": {
+          "name": "shoutrrr_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "shoutrrr_url": {
+          "name": "shoutrrr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shoutrrr_stock_reminders": {
+          "name": "shoutrrr_stock_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "shoutrrr_intake_reminders": {
+          "name": "shoutrrr_intake_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "shoutrrr_prescription_reminders": {
+          "name": "shoutrrr_prescription_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reminder_days_before": {
+          "name": "reminder_days_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 7
+        },
+        "repeat_daily_reminders": {
+          "name": "repeat_daily_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_reminders_for_taken_doses": {
+          "name": "skip_reminders_for_taken_doses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "repeat_reminders_enabled": {
+          "name": "repeat_reminders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reminder_repeat_interval_minutes": {
+          "name": "reminder_repeat_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "max_nagging_reminders": {
+          "name": "max_nagging_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "low_stock_days": {
+          "name": "low_stock_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "normal_stock_days": {
+          "name": "normal_stock_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 90
+        },
+        "high_stock_days": {
+          "name": "high_stock_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 180
+        },
+        "expiry_warning_days": {
+          "name": "expiry_warning_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 90
+        },
+        "language": {
+          "name": "language",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "stock_calculation_mode": {
+          "name": "stock_calculation_mode",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'automatic'"
+        },
+        "share_stock_status": {
+          "name": "share_stock_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "share_medication_overview": {
+          "name": "share_medication_overview",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "upcoming_today_only": {
+          "name": "upcoming_today_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "share_schedule_today_only": {
+          "name": "share_schedule_today_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "swap_dashboard_main_sections": {
+          "name": "swap_dashboard_main_sections",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_auto_email_sent": {
+          "name": "last_auto_email_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_notification_type": {
+          "name": "last_notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_notification_channel": {
+          "name": "last_notification_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminder_med_name": {
+          "name": "last_reminder_med_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminder_taken_by": {
+          "name": "last_reminder_taken_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stock_reminder_sent": {
+          "name": "last_stock_reminder_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stock_reminder_channel": {
+          "name": "last_stock_reminder_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stock_reminder_med_names": {
+          "name": "last_stock_reminder_med_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_prescription_reminder_sent": {
+          "name": "last_prescription_reminder_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_prescription_reminder_channel": {
+          "name": "last_prescription_reminder_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_prescription_reminder_med_names": {
+          "name": "last_prescription_reminder_med_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1779816583288,
       "tag": "0018_add_dose_tracking_unique_index",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1783107344203,
+      "tag": "0019_add_intake_journal_mood",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/migration-utils.ts
+++ b/backend/src/db/migration-utils.ts
@@ -125,6 +125,7 @@ export async function runAlterMigrations(client: Client): Promise<{ success: boo
 		`ALTER TABLE share_tokens ADD COLUMN allow_mark_taken integer NOT NULL DEFAULT 1`,
 		`ALTER TABLE share_tokens ADD COLUMN last_used_at integer`,
 		`ALTER TABLE share_tokens ADD COLUMN revoked_at integer`,
+		`ALTER TABLE intake_journal ADD COLUMN mood text NOT NULL DEFAULT ''`,
 	];
 
 	for (const sql of alterMigrations) {
@@ -152,6 +153,7 @@ export async function runAlterMigrations(client: Client): Promise<{ success: boo
 			dose_tracking_id INTEGER NOT NULL REFERENCES dose_tracking(id) ON DELETE CASCADE,
 			medication_id INTEGER NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
 			scheduled_for INTEGER NOT NULL,
+			mood TEXT NOT NULL DEFAULT '',
 			note TEXT NOT NULL,
 			created_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -260,6 +260,7 @@ export const intakeJournal = sqliteTable("intake_journal", {
 		.notNull()
 		.references(() => medications.id, { onDelete: "cascade" }),
 	scheduledFor: integer("scheduled_for", { mode: "timestamp" }).notNull(),
+	mood: text("mood", { length: 20 }).notNull().default(""),
 	note: text("note").notNull(),
 	createdAt: integer("created_at", { mode: "timestamp" }).notNull().default(sql`CURRENT_TIMESTAMP`),
 	updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().default(sql`CURRENT_TIMESTAMP`),

--- a/backend/src/routes/doses.ts
+++ b/backend/src/routes/doses.ts
@@ -1,3 +1,4 @@
+import { INTAKE_MOODS, normalizeIntakeMood } from "@medassist/shared";
 import { and, eq, inArray, like, or } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
@@ -43,6 +44,7 @@ const shareDoseSchema = z.object({
 
 const shareJournalUpsertSchema = z.object({
 	note: z.string().max(4000),
+	mood: z.enum(INTAKE_MOODS).nullable().optional(),
 });
 
 const dismissDosesSchema = z.object({
@@ -98,6 +100,7 @@ const shareJournalEntrySchema = {
 		"scheduledFor",
 		"dismissed",
 		"takenSource",
+		"mood",
 		"note",
 		"updatedAt",
 	],
@@ -109,8 +112,9 @@ const shareJournalEntrySchema = {
 		scheduledFor: { type: "string", format: "date-time" },
 		takenAt: { type: ["string", "null"], format: "date-time" },
 		dismissed: { type: "boolean" },
-		takenSource: { type: "string", enum: ["manual", "automatic"] },
+		takenSource: { type: "string", enum: ["manual", "automatic", "notification"] },
 		markedBy: { type: ["string", "null"] },
+		mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
 		note: { type: ["string", "null"] },
 		updatedAt: { type: ["string", "null"], format: "date-time" },
 		createdAt: { type: ["string", "null"], format: "date-time" },
@@ -385,6 +389,7 @@ function buildSharedJournalEntryDto(input: {
 		dismissed: event.dismissed,
 		takenSource: event.takenSource,
 		markedBy: event.markedBy,
+		mood: normalizeIntakeMood(journalEntry?.mood),
 		note: journalEntry?.note ?? null,
 		updatedAt: journalEntry?.updatedAt?.toISOString() ?? null,
 		createdAt: journalEntry?.createdAt?.toISOString() ?? null,
@@ -892,6 +897,7 @@ export async function doseRoutes(app: FastifyInstance) {
 					required: ["note"],
 					properties: {
 						note: { type: "string", maxLength: 4000 },
+						mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
 					},
 					additionalProperties: false,
 				},
@@ -913,7 +919,8 @@ export async function doseRoutes(app: FastifyInstance) {
 			}
 
 			const normalizedNote = parsed.data.note.trim();
-			if (normalizedNote.length === 0) {
+			const normalizedMood = parsed.data.mood ?? null;
+			if (normalizedNote.length === 0 && normalizedMood === null) {
 				return reply.status(400).send({ error: "Journal note cannot be empty", code: "EMPTY_NOTE" });
 			}
 
@@ -948,6 +955,7 @@ export async function doseRoutes(app: FastifyInstance) {
 				userId: share.userId,
 				doseId,
 				note: normalizedNote,
+				mood: normalizedMood,
 			});
 
 			return { entry: buildSharedJournalEntryDto({ event, journalEntry }) };

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { extname, isAbsolute, relative, resolve } from "node:path";
+import { INTAKE_MOODS, normalizeIntakeMood } from "@medassist/shared";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
@@ -34,7 +35,7 @@ const IMAGES_DIR = resolve(getDataDir(), "images");
 // =============================================================================
 // Export Format Version (bump this when format changes)
 // =============================================================================
-const EXPORT_VERSION = "1.7";
+const EXPORT_VERSION = "1.8";
 
 const currentExportVersion = parseExportVersion(EXPORT_VERSION);
 
@@ -128,6 +129,7 @@ const doseHistorySchema = z.object({
 	dismissed: z.boolean().default(false),
 	takenByPerson: z.string().nullable().optional(), // Person suffix from dose ID (e.g., "Daniel")
 	journalNote: z.string().nullable().optional(),
+	journalMood: z.enum(INTAKE_MOODS).nullable().optional(),
 	journalCreatedAt: nullableDateLikeStringSchema,
 	journalUpdatedAt: nullableDateLikeStringSchema,
 });
@@ -273,6 +275,7 @@ const importBodyOpenApiSchema = {
 				dismissed: false,
 				takenByPerson: "Daniel",
 				journalNote: "Took after breakfast.",
+				journalMood: "good",
 				journalUpdatedAt: "2026-03-11T08:05:00.000Z",
 			},
 		],
@@ -482,7 +485,9 @@ function buildImportPreview(
 	}
 ) {
 	const journalEntries = importData.doseHistory.filter(
-		(dose) => typeof dose.journalNote === "string" && dose.journalNote.trim()
+		(dose) =>
+			(typeof dose.journalNote === "string" && dose.journalNote.trim()) ||
+			normalizeIntakeMood(dose.journalMood) !== null
 	).length;
 	const imageCount = importData.medications.filter(
 		(med) => typeof med.image === "string" && med.image.startsWith("data:")
@@ -1097,6 +1102,7 @@ export async function exportRoutes(app: FastifyInstance) {
 							medicationId: newMedId,
 							scheduledFor,
 							journalNote: dose.journalNote,
+							journalMood: normalizeIntakeMood(dose.journalMood),
 							journalCreatedAt: dose.journalCreatedAt,
 							journalUpdatedAt: dose.journalUpdatedAt,
 							database: tx,

--- a/backend/src/routes/intake-journal.ts
+++ b/backend/src/routes/intake-journal.ts
@@ -1,3 +1,4 @@
+import { INTAKE_MOODS, normalizeIntakeMood } from "@medassist/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
@@ -41,6 +42,7 @@ const intakeJournalEntrySchema = {
 		"scheduledFor",
 		"dismissed",
 		"takenSource",
+		"mood",
 		"note",
 		"updatedAt",
 	],
@@ -52,8 +54,9 @@ const intakeJournalEntrySchema = {
 		scheduledFor: { type: "string", format: "date-time" },
 		takenAt: { type: ["string", "null"], format: "date-time" },
 		dismissed: { type: "boolean" },
-		takenSource: { type: "string", enum: ["manual", "automatic"] },
+		takenSource: { type: "string", enum: ["manual", "automatic", "notification"] },
 		markedBy: { type: ["string", "null"] },
+		mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
 		note: { type: ["string", "null"] },
 		updatedAt: { type: ["string", "null"], format: "date-time" },
 		createdAt: { type: ["string", "null"], format: "date-time" },
@@ -91,6 +94,7 @@ const intakeJournalHistoryQuerySchema = z.object({
 
 const intakeJournalUpsertSchema = z.object({
 	note: z.string().max(4000),
+	mood: z.enum(INTAKE_MOODS).nullable().optional(),
 });
 
 function getValidationErrorMessage(error: z.ZodError): string {
@@ -143,6 +147,7 @@ function buildJournalEntryDto(input: {
 		dismissed: event.dismissed,
 		takenSource: event.takenSource,
 		markedBy: event.markedBy,
+		mood: normalizeIntakeMood(journalEntry?.mood),
 		note: journalEntry?.note ?? null,
 		updatedAt: journalEntry?.updatedAt?.toISOString() ?? null,
 		createdAt: journalEntry?.createdAt?.toISOString() ?? null,
@@ -231,6 +236,7 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 					dismissed: entry.dismissed,
 					takenSource: entry.takenSource,
 					markedBy: entry.markedBy,
+					mood: entry.mood,
 					note: entry.note,
 					updatedAt: entry.updatedAt.toISOString(),
 					createdAt: entry.createdAt.toISOString(),
@@ -288,6 +294,7 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 					required: ["note"],
 					properties: {
 						note: { type: "string", maxLength: 4000 },
+						mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
 					},
 					additionalProperties: false,
 				},
@@ -323,6 +330,7 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 				userId,
 				doseId,
 				note: parsed.data.note,
+				mood: parsed.data.mood ?? null,
 			});
 
 			return { entry: buildJournalEntryDto({ event, journalEntry }) };

--- a/backend/src/routes/report.ts
+++ b/backend/src/routes/report.ts
@@ -1,8 +1,9 @@
-import { and, eq, gte, lt } from "drizzle-orm";
+import { INTAKE_MOODS, type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
+import { and, eq, gte, inArray, lt } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db } from "../db/client.js";
-import { doseTracking, medications, refillHistory } from "../db/schema.js";
+import { doseTracking, intakeJournal, medications, refillHistory } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
 import type { AuthUser } from "../types/fastify.js";
@@ -95,6 +96,12 @@ function matchesTakenByFilter(doseId: string, takenByFilter: Set<string> | null)
 	return takenByFilter.has(getPersonTagKey(takenBy));
 }
 
+function getDoseTakenByPerson(doseId: string): string | null {
+	const match = trackedDoseIdPattern.exec(doseId);
+	const takenBy = match?.[4]?.trim();
+	return takenBy && takenBy.length > 0 ? takenBy : null;
+}
+
 function getDoseScheduledAtMs(doseId: string): number | null {
 	const match = trackedDoseIdPattern.exec(doseId);
 	if (!match) {
@@ -127,6 +134,26 @@ const reportDataResponseSchema = {
 			dosesSkipped: { type: "integer" },
 			firstDoseAt: { type: "string" },
 			lastDoseAt: { type: "string" },
+			moodSummary: {
+				type: "object",
+				properties: Object.fromEntries(INTAKE_MOODS.map((mood) => [mood, { type: "integer" }])),
+				additionalProperties: false,
+			},
+			journalEntries: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: {
+						scheduledFor: { type: "string", format: "date-time" },
+						takenAt: { type: ["string", "null"], format: "date-time" },
+						dismissed: { type: "boolean" },
+						takenSource: { type: "string" },
+						takenByPerson: { type: ["string", "null"] },
+						mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
+						note: { type: ["string", "null"] },
+					},
+				},
+			},
 			refills: {
 				type: "array",
 				items: {
@@ -214,6 +241,7 @@ export async function reportRoutes(app: FastifyInstance) {
 			// doseId format: "{medicationId}-{blisterIndex}-{dateMs}" or "{medicationId}-{blisterIndex}-{dateMs}-{takenBy}"
 			const allDoses = await db
 				.select({
+					id: doseTracking.id,
 					doseId: doseTracking.doseId,
 					takenAt: doseTracking.takenAt,
 					dismissed: doseTracking.dismissed,
@@ -223,18 +251,57 @@ export async function reportRoutes(app: FastifyInstance) {
 				.where(eq(doseTracking.userId, userId));
 
 			// Group doses by medication ID
-			const dosesByMed = new Map<number, { takenAt: Date; dismissed: boolean; takenSource: string }[]>();
+			const dosesByMed = new Map<
+				number,
+				{
+					id: number;
+					doseId: string;
+					scheduledAtMs: number | null;
+					takenAt: Date;
+					dismissed: boolean;
+					takenSource: string;
+					takenByPerson: string | null;
+				}[]
+			>();
+			const filteredDoseTrackingIds: number[] = [];
 			for (const dose of allDoses) {
 				const medId = Number.parseInt(dose.doseId.split("-")[0], 10);
 				if (Number.isNaN(medId) || !medicationIds.includes(medId)) continue;
 				if (!matchesTakenByFilter(dose.doseId, normalizedTakenByFilter)) continue;
-				if (!isWithinDateRange(getDoseScheduledAtMs(dose.doseId), dateRange)) continue;
+				const scheduledAtMs = getDoseScheduledAtMs(dose.doseId);
+				if (!isWithinDateRange(scheduledAtMs, dateRange)) continue;
 				if (!dosesByMed.has(medId)) dosesByMed.set(medId, []);
+				filteredDoseTrackingIds.push(dose.id);
 				dosesByMed.get(medId)!.push({
+					id: dose.id,
+					doseId: dose.doseId,
+					scheduledAtMs,
 					takenAt: dose.takenAt,
 					dismissed: dose.dismissed,
 					takenSource: dose.takenSource ?? "manual",
+					takenByPerson: getDoseTakenByPerson(dose.doseId),
 				});
+			}
+
+			const journalByDoseTrackingId = new Map<number, { scheduledFor: Date; mood: IntakeMood | null; note: string }>();
+			if (filteredDoseTrackingIds.length > 0) {
+				const journalRows = await db
+					.select({
+						doseTrackingId: intakeJournal.doseTrackingId,
+						scheduledFor: intakeJournal.scheduledFor,
+						mood: intakeJournal.mood,
+						note: intakeJournal.note,
+					})
+					.from(intakeJournal)
+					.where(and(eq(intakeJournal.userId, userId), inArray(intakeJournal.doseTrackingId, filteredDoseTrackingIds)));
+
+				for (const row of journalRows) {
+					journalByDoseTrackingId.set(row.doseTrackingId, {
+						scheduledFor: row.scheduledFor,
+						mood: normalizeIntakeMood(row.mood),
+						note: row.note,
+					});
+				}
 			}
 
 			// Fetch refill history for requested medications
@@ -246,6 +313,16 @@ export async function reportRoutes(app: FastifyInstance) {
 					dosesSkipped: number;
 					firstDoseAt: string | null;
 					lastDoseAt: string | null;
+					moodSummary: Record<IntakeMood, number>;
+					journalEntries: {
+						scheduledFor: string;
+						takenAt: string | null;
+						dismissed: boolean;
+						takenSource: string;
+						takenByPerson: string | null;
+						mood: IntakeMood | null;
+						note: string | null;
+					}[];
 					refills: {
 						packsAdded: number;
 						loosePillsAdded: number;
@@ -263,6 +340,38 @@ export async function reportRoutes(app: FastifyInstance) {
 				const skippedDoses = doses.filter((d) => d.dismissed);
 
 				const sortedTaken = takenDoses.map((d) => d.takenAt.getTime()).sort((a, b) => a - b);
+				const moodSummary = Object.fromEntries(INTAKE_MOODS.map((mood) => [mood, 0])) as Record<IntakeMood, number>;
+				const journalEntries = doses
+					.map((dose) => {
+						const journal = journalByDoseTrackingId.get(dose.id);
+						if (!journal) {
+							return null;
+						}
+
+						const mood = journal.mood;
+						if (mood) {
+							moodSummary[mood] += 1;
+						}
+
+						const scheduledFor =
+							journal.scheduledFor instanceof Date && !Number.isNaN(journal.scheduledFor.getTime())
+								? journal.scheduledFor
+								: new Date(dose.scheduledAtMs ?? dose.takenAt.getTime());
+						const hasRecordedTakenAt =
+							dose.takenAt instanceof Date && !Number.isNaN(dose.takenAt.getTime()) && dose.takenAt.getTime() > 0;
+
+						return {
+							scheduledFor: scheduledFor.toISOString(),
+							takenAt: hasRecordedTakenAt ? dose.takenAt.toISOString() : null,
+							dismissed: dose.dismissed,
+							takenSource: dose.takenSource,
+							takenByPerson: dose.takenByPerson,
+							mood,
+							note: journal.note.trim().length > 0 ? journal.note : null,
+						};
+					})
+					.filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+					.sort((a, b) => new Date(a.scheduledFor).getTime() - new Date(b.scheduledFor).getTime());
 				const medication = medMap.get(medId);
 				const pillsPerPack = Math.max(1, (medication?.blistersPerPack ?? 1) * (medication?.pillsPerBlister ?? 1));
 				const isAmountBased = medication?.packageType === "liquid_container" || medication?.packageType === "tube";
@@ -284,6 +393,8 @@ export async function reportRoutes(app: FastifyInstance) {
 					dosesSkipped: skippedDoses.length,
 					firstDoseAt: sortedTaken.length > 0 ? new Date(sortedTaken[0]).toISOString() : null,
 					lastDoseAt: sortedTaken.length > 0 ? new Date(sortedTaken[sortedTaken.length - 1]).toISOString() : null,
+					moodSummary,
+					journalEntries,
 					refills: refills.map((r) => ({
 						packsAdded: r.packsAdded,
 						loosePillsAdded: r.loosePillsAdded,

--- a/backend/src/services/intake-journal-export.ts
+++ b/backend/src/services/intake-journal-export.ts
@@ -1,3 +1,4 @@
+import { type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
 import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { intakeJournal } from "../db/schema.js";
@@ -6,6 +7,7 @@ type IntakeJournalWriteDatabase = Pick<typeof db, "insert">;
 
 export type IntakeJournalExportPayload = {
 	journalNote: string;
+	journalMood?: IntakeMood | null;
 	journalCreatedAt?: string | null;
 	journalUpdatedAt?: string | null;
 };
@@ -50,6 +52,7 @@ export async function listIntakeJournalExportPayloadsForUser(
 			row.doseTrackingId,
 			{
 				journalNote: row.note,
+				journalMood: normalizeIntakeMood(row.mood),
 				journalCreatedAt: toIsoStringOrNull(row.createdAt),
 				journalUpdatedAt: toIsoStringOrNull(row.updatedAt),
 			},
@@ -63,12 +66,14 @@ export async function restoreIntakeJournalForImportedDose(input: {
 	medicationId: number;
 	scheduledFor: Date;
 	journalNote?: string | null;
+	journalMood?: IntakeMood | null;
 	journalCreatedAt?: string | null;
 	journalUpdatedAt?: string | null;
 	database?: IntakeJournalWriteDatabase;
 }): Promise<boolean> {
 	const normalizedNote = input.journalNote?.trim() ?? "";
-	if (normalizedNote.length === 0) {
+	const normalizedMood = input.journalMood ?? null;
+	if (normalizedNote.length === 0 && normalizedMood === null) {
 		return false;
 	}
 
@@ -81,6 +86,7 @@ export async function restoreIntakeJournalForImportedDose(input: {
 		doseTrackingId: input.doseTrackingId,
 		medicationId: input.medicationId,
 		scheduledFor: input.scheduledFor,
+		mood: normalizedMood ?? "",
 		note: normalizedNote,
 		createdAt,
 		updatedAt,

--- a/backend/src/services/intake-journal-service.ts
+++ b/backend/src/services/intake-journal-service.ts
@@ -1,3 +1,4 @@
+import { type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
 import { and, desc, eq, gte, lte } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { doseTracking, intakeJournal, medications } from "../db/schema.js";
@@ -43,6 +44,7 @@ export type IntakeJournalHistoryEntry = {
 	markedBy: string | null;
 	takenSource: DoseTrackingSource;
 	dismissed: boolean;
+	mood: IntakeMood | null;
 	note: string;
 	createdAt: Date;
 	updatedAt: Date;
@@ -175,9 +177,11 @@ export async function upsertIntakeJournalForDoseEvent(input: {
 	userId: number;
 	doseId: string;
 	note: string;
+	mood?: IntakeMood | null;
 }): Promise<IntakeJournalEntry | null> {
 	const normalizedNote = input.note.trim();
-	if (normalizedNote.length === 0) {
+	const normalizedMood = input.mood ?? null;
+	if (normalizedNote.length === 0 && normalizedMood === null) {
 		await deleteIntakeJournalForDoseEvent({ userId: input.userId, doseId: input.doseId });
 		return null;
 	}
@@ -196,6 +200,7 @@ export async function upsertIntakeJournalForDoseEvent(input: {
 			doseTrackingId: event.doseTrackingId,
 			medicationId: event.medicationId,
 			scheduledFor: event.scheduledFor,
+			mood: normalizedMood ?? "",
 			note: normalizedNote,
 			createdAt: now,
 			updatedAt: now,
@@ -205,6 +210,7 @@ export async function upsertIntakeJournalForDoseEvent(input: {
 			set: {
 				userId: input.userId,
 				medicationId: event.medicationId,
+				mood: normalizedMood ?? "",
 				note: normalizedNote,
 				updatedAt: now,
 			},
@@ -260,6 +266,7 @@ export async function listIntakeJournalEntriesForUser(input: {
 			markedBy: doseTracking.markedBy,
 			takenSource: doseTracking.takenSource,
 			dismissed: doseTracking.dismissed,
+			mood: intakeJournal.mood,
 			note: intakeJournal.note,
 			createdAt: intakeJournal.createdAt,
 			updatedAt: intakeJournal.updatedAt,
@@ -286,6 +293,7 @@ export async function listIntakeJournalEntriesForUser(input: {
 		markedBy: row.markedBy,
 		takenSource: row.takenSource as DoseTrackingSource,
 		dismissed: row.dismissed ?? false,
+		mood: normalizeIntakeMood(row.mood),
 		note: row.note,
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt,

--- a/backend/src/test/database.test.ts
+++ b/backend/src/test/database.test.ts
@@ -480,6 +480,14 @@ describe("Database Client", () => {
 			expect(columnNames).toContain("packs_added");
 			expect(columnNames).toContain("loose_pills_added");
 		});
+
+		it("should have intake_journal mood column with an empty default", async () => {
+			const columns = await client.execute("PRAGMA table_info(intake_journal)");
+			const moodColumn = columns.rows.find((r) => r.name === "mood");
+
+			expect(moodColumn).toBeDefined();
+			expect(moodColumn).toEqual(expect.objectContaining({ notnull: 1, dflt_value: "''" }));
+		});
 	});
 
 	describe("Default Values", () => {

--- a/backend/src/test/domain-safety.test.ts
+++ b/backend/src/test/domain-safety.test.ts
@@ -663,13 +663,14 @@ describe("Domain safety corpus: real route and service flows", () => {
 			markedBy: "Alice",
 		});
 		await testClient.execute({
-			sql: `INSERT INTO intake_journal (user_id, dose_tracking_id, medication_id, scheduled_for, note, created_at, updated_at)
-			      VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			sql: `INSERT INTO intake_journal (user_id, dose_tracking_id, medication_id, scheduled_for, mood, note, created_at, updated_at)
+			      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			args: [
 				1,
 				doseTrackingId,
 				medication.id,
 				Math.floor(new Date("2026-06-01T00:00:00.000Z").getTime() / 1000),
+				"good",
 				"Took after breakfast",
 				Math.floor(new Date("2026-06-01T08:05:00.000Z").getTime() / 1000),
 				Math.floor(new Date("2026-06-01T08:06:00.000Z").getTime() / 1000),
@@ -736,6 +737,7 @@ describe("Domain safety corpus: real route and service flows", () => {
 				markedBy: dose.markedBy,
 				takenByPerson: dose.takenByPerson,
 				journalNote: dose.journalNote,
+				journalMood: dose.journalMood,
 			})),
 			refillHistory: payload.refillHistory.map((refill: Record<string, unknown>) => ({
 				packsAdded: refill.packsAdded,

--- a/backend/src/test/doses.test.ts
+++ b/backend/src/test/doses.test.ts
@@ -672,6 +672,7 @@ describe("Dose Tracking API", () => {
 				expect.objectContaining({
 					doseId,
 					markedBy: "Max",
+					mood: null,
 					note: null,
 				})
 			);
@@ -692,13 +693,14 @@ describe("Dose Tracking API", () => {
 			const saveResponse = await app.inject({
 				method: "PUT",
 				url: `/share/cccccccccccccccc/journal/event/${encodeURIComponent(doseId)}`,
-				payload: { note: "Shared note from Max" },
+				payload: { note: "Shared note from Max", mood: "very_good" },
 			});
 
 			expect(saveResponse.statusCode).toBe(200);
 			expect(saveResponse.json().entry).toEqual(
 				expect.objectContaining({
 					doseId,
+					mood: "very_good",
 					note: "Shared note from Max",
 				})
 			);
@@ -715,6 +717,21 @@ describe("Dose Tracking API", () => {
 					hasJournalNote: true,
 				}),
 			]);
+
+			const moodOnlySaveResponse = await app.inject({
+				method: "PUT",
+				url: `/share/cccccccccccccccc/journal/event/${encodeURIComponent(doseId)}`,
+				payload: { note: "   ", mood: "bad" },
+			});
+
+			expect(moodOnlySaveResponse.statusCode).toBe(200);
+			expect(moodOnlySaveResponse.json().entry).toEqual(
+				expect.objectContaining({
+					doseId,
+					mood: "bad",
+					note: "",
+				})
+			);
 
 			const blankSaveResponse = await app.inject({
 				method: "PUT",
@@ -740,12 +757,13 @@ describe("Dose Tracking API", () => {
 			});
 
 			const journalRows = await testClient.execute({
-				sql: "SELECT note FROM intake_journal WHERE user_id = ? AND medication_id = ?",
+				sql: "SELECT note, mood FROM intake_journal WHERE user_id = ? AND medication_id = ?",
 				args: [userId, 8],
 			});
 
 			expect(journalRows.rows).toHaveLength(1);
-			expect(journalRows.rows[0].note).toBe("Shared note from Max");
+			expect(journalRows.rows[0].note).toBe("");
+			expect(journalRows.rows[0].mood).toBe("bad");
 		});
 	});
 });

--- a/backend/src/test/e2e-routes.test.ts
+++ b/backend/src/test/e2e-routes.test.ts
@@ -200,6 +200,7 @@ async function createSchema(client: Client) {
       dose_tracking_id integer NOT NULL UNIQUE,
       medication_id integer NOT NULL,
       scheduled_for integer NOT NULL,
+      mood text NOT NULL DEFAULT '',
       note text NOT NULL,
       created_at integer NOT NULL DEFAULT (strftime('%s','now')),
       updated_at integer NOT NULL DEFAULT (strftime('%s','now')),

--- a/backend/src/test/intake-journal-routes.test.ts
+++ b/backend/src/test/intake-journal-routes.test.ts
@@ -199,7 +199,7 @@ describe("Intake journal routes", () => {
 			method: "PUT",
 			url: `/intake-journal/event/${encodeURIComponent(ownerDoseId)}`,
 			headers: { cookie: ownerCookie },
-			payload: { note: "Took after breakfast." },
+			payload: { note: "Took after breakfast.", mood: "good" },
 		});
 
 		expect(ownerPutResponse.statusCode).toBe(200);
@@ -208,6 +208,7 @@ describe("Intake journal routes", () => {
 				doseId: ownerDoseId,
 				medicationId: ownerMedicationId,
 				scheduledFor: expect.stringContaining("T08:00:00"),
+				mood: "good",
 				note: "Took after breakfast.",
 			})
 		);
@@ -232,10 +233,36 @@ describe("Intake journal routes", () => {
 			expect.objectContaining({
 				doseId: ownerDoseId,
 				medicationId: ownerMedicationId,
+				mood: "good",
 				note: "Took after breakfast.",
 				markedBy: "Daniel",
 			}),
 		]);
+
+		const moodOnlyResponse = await app.inject({
+			method: "PUT",
+			url: `/intake-journal/event/${encodeURIComponent(ownerDoseId)}`,
+			headers: { cookie: ownerCookie },
+			payload: { note: "   ", mood: "neutral" },
+		});
+
+		expect(moodOnlyResponse.statusCode).toBe(200);
+		expect(moodOnlyResponse.json().entry).toEqual(
+			expect.objectContaining({
+				doseId: ownerDoseId,
+				mood: "neutral",
+				note: "",
+			})
+		);
+
+		const invalidMoodResponse = await app.inject({
+			method: "PUT",
+			url: `/intake-journal/event/${encodeURIComponent(ownerDoseId)}`,
+			headers: { cookie: ownerCookie },
+			payload: { note: "Took after breakfast.", mood: "excellent" },
+		});
+
+		expect(invalidMoodResponse.statusCode).toBe(400);
 
 		const otherEventResponse = await app.inject({
 			method: "GET",
@@ -287,13 +314,14 @@ describe("Intake journal routes", () => {
 		const updatedAt = new Date("2026-02-03T07:50:00.000Z");
 		await testClient.execute({
 			sql: `INSERT INTO intake_journal (
-			  user_id, dose_tracking_id, medication_id, scheduled_for, note, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			  user_id, dose_tracking_id, medication_id, scheduled_for, mood, note, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			args: [
 				userId,
 				doseTrackingId,
 				medicationId,
 				Math.floor(new Date(start).getTime() / 1000),
+				"good",
 				"Roundtrip journal note",
 				Math.floor(createdAt.getTime() / 1000),
 				Math.floor(updatedAt.getTime() / 1000),
@@ -314,6 +342,7 @@ describe("Intake journal routes", () => {
 				scheduleIndex: 0,
 				takenByPerson: "Daniel-Volz",
 				journalNote: "Roundtrip journal note",
+				journalMood: "good",
 				journalCreatedAt: createdAt.toISOString(),
 				journalUpdatedAt: updatedAt.toISOString(),
 			})
@@ -340,18 +369,20 @@ describe("Intake journal routes", () => {
 				scheduleIndex: 0,
 				takenByPerson: "Daniel-Volz",
 				journalNote: "Roundtrip journal note",
+				journalMood: "good",
 				journalCreatedAt: createdAt.toISOString(),
 				journalUpdatedAt: updatedAt.toISOString(),
 			}),
 		]);
 
 		const restoredJournalRows = await testClient.execute({
-			sql: "SELECT note FROM intake_journal WHERE user_id = ?",
+			sql: "SELECT note, mood FROM intake_journal WHERE user_id = ?",
 			args: [userId],
 		});
 
 		expect(restoredJournalRows.rows).toHaveLength(1);
 		expect(restoredJournalRows.rows[0].note).toBe("Roundtrip journal note");
+		expect(restoredJournalRows.rows[0].mood).toBe("good");
 	});
 
 	it("preserves the shared journal-note permission through authenticated export and import", async () => {

--- a/backend/src/test/routes-real.test.ts
+++ b/backend/src/test/routes-real.test.ts
@@ -816,6 +816,70 @@ describe("Real route coverage: settings/export/report", () => {
 		});
 	});
 
+	it("POST /medications/report-data includes filtered mood and journal entries", async () => {
+		const medId = await seedMedication("Report Mood Med");
+		const windowStart = "2026-01-10T00:00:00.000Z";
+		const windowEnd = "2026-01-20T00:00:00.000Z";
+
+		const inWindowDose = await testClient.execute({
+			sql: "INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed) VALUES (?, ?, ?, ?) RETURNING id",
+			args: [
+				1,
+				`${medId}-0-${Date.parse("2026-01-15T09:00:00.000Z")}-Alice`,
+				Math.floor(Date.parse("2026-01-15T09:05:00.000Z") / 1000),
+				0,
+			],
+		});
+		const outOfFilterDose = await testClient.execute({
+			sql: "INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed) VALUES (?, ?, ?, ?) RETURNING id",
+			args: [
+				1,
+				`${medId}-0-${Date.parse("2026-01-16T09:00:00.000Z")}-Bob`,
+				Math.floor(Date.parse("2026-01-16T09:05:00.000Z") / 1000),
+				0,
+			],
+		});
+
+		await testClient.execute({
+			sql: `INSERT INTO intake_journal (user_id, dose_tracking_id, medication_id, scheduled_for, mood, note)
+			      VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)`,
+			args: [
+				1,
+				Number(inWindowDose.rows[0].id),
+				medId,
+				Math.floor(Date.parse("2026-01-15T09:00:00.000Z") / 1000),
+				"good",
+				"Felt steady",
+				1,
+				Number(outOfFilterDose.rows[0].id),
+				medId,
+				Math.floor(Date.parse("2026-01-16T09:00:00.000Z") / 1000),
+				"bad",
+				"Filtered out",
+			],
+		});
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/medications/report-data",
+			payload: { medicationIds: [medId], startDate: windowStart, endDate: windowEnd, takenByFilter: ["Alice"] },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body[medId].moodSummary).toMatchObject({
+			good: 1,
+			bad: 0,
+		});
+		expect(body[medId].journalEntries).toEqual([
+			expect.objectContaining({
+				mood: "good",
+				note: "Felt steady",
+				takenByPerson: "Alice",
+			}),
+		]);
+	});
+
 	it("GET /export includes medications, settings, doseHistory and refillHistory", async () => {
 		const medId = await seedMedication("Export Med");
 		await testClient.execute({

--- a/frontend/e2e/export-import.spec.ts
+++ b/frontend/e2e/export-import.spec.ts
@@ -130,7 +130,7 @@ test.describe("Export/import E2E", () => {
 		});
 
 		const nonSensitive = await downloadExportFromSettings(page, { includeSensitive: false });
-		expect(nonSensitive.version).toBe("1.7");
+		expect(nonSensitive.version).toBe("1.8");
 		expect(nonSensitive.includeSensitiveData).toBe(false);
 		expect(nonSensitive.settings?.timezone).toBe("Europe/Berlin");
 		expect(nonSensitive.settings?.upcomingTodayOnly).toBe(true);

--- a/frontend/src/components/ReportModal.tsx
+++ b/frontend/src/components/ReportModal.tsx
@@ -13,6 +13,7 @@ import {
 import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
 import { AppButton } from "../ui/primitives/AppButton";
 import { formatDate, formatDateTime, toInputValue } from "../utils/formatters";
+import { getIntakeMoodDisplay, INTAKE_MOODS, type IntakeMood } from "../utils/intake-mood";
 import { getIntakeFrequencyText, getMedicationIntakes } from "../utils/intake-schedule";
 import { mergePersonTags, personTagsMatch } from "../utils/person-tags";
 import { useAuth } from "./Auth";
@@ -36,6 +37,8 @@ type ReportData = Record<
 		dosesSkipped: number;
 		firstDoseAt: string | null;
 		lastDoseAt: string | null;
+		moodSummary?: Partial<Record<IntakeMood, number>>;
+		journalEntries?: ReportJournalEntry[];
 		refills: {
 			packsAdded: number;
 			loosePillsAdded?: number;
@@ -45,6 +48,16 @@ type ReportData = Record<
 		}[];
 	}
 >;
+
+type ReportJournalEntry = {
+	scheduledFor: string;
+	takenAt: string | null;
+	dismissed: boolean;
+	takenSource: string;
+	takenByPerson: string | null;
+	mood: IntakeMood | null;
+	note: string | null;
+};
 
 type ReportDateRange = {
 	startDate: string;
@@ -458,6 +471,31 @@ function getReportPackageTypeLabel(med: Medication, t: TFn): string {
 	return t("report.docBlister");
 }
 
+function getMoodSummaryItems(summary: Partial<Record<IntakeMood, number>> | undefined, t: TFn): string[] {
+	return INTAKE_MOODS.map((mood) => {
+		const count = summary?.[mood] ?? 0;
+		return count > 0 ? `${getIntakeMoodDisplay(mood, t)}: ${count}` : null;
+	}).filter((item): item is string => item !== null);
+}
+
+function formatJournalReportEntry(entry: ReportJournalEntry, t: TFn): string {
+	const mood = entry.mood ? getIntakeMoodDisplay(entry.mood, t) : t("report.docJournalNoMood");
+	const status = entry.dismissed ? t("report.docJournalStatusSkipped") : t("report.docJournalStatusTaken");
+	const parts = [
+		`${t("report.docJournalScheduledFor")}: ${formatDateTime(entry.scheduledFor)}`,
+		`${t("report.docJournalTakenAt")}: ${entry.takenAt ? formatDateTime(entry.takenAt) : "-"}`,
+		`${t("report.docStatus")}: ${status}`,
+		`${t("report.docJournalMood")}: ${mood}`,
+	];
+	if (entry.takenByPerson) {
+		parts.push(`${t("report.docTakenBy")}: ${entry.takenByPerson}`);
+	}
+	if (entry.note) {
+		parts.push(`${t("report.docJournalNote")}: ${entry.note}`);
+	}
+	return parts.join("; ");
+}
+
 function generateTextReport(
 	meds: Medication[],
 	reportData: ReportData,
@@ -562,6 +600,28 @@ function generateTextReport(
 				lines.push(fmt === "md" ? `- ${t("report.docNoDoses")}` : `  ${t("report.docNoDoses")}`);
 			}
 			lines.push("");
+
+			const moodSummaryItems = getMoodSummaryItems(data.moodSummary, t);
+			const journalEntries = data.journalEntries ?? [];
+			if (moodSummaryItems.length > 0 || journalEntries.length > 0) {
+				lines.push(h3(t("report.docJournal")));
+				if (moodSummaryItems.length > 0) {
+					lines.push(item(t("report.docJournalMoodSummary"), moodSummaryItems.join(", ")));
+				}
+				if (journalEntries.length > 0) {
+					lines.push(
+						fmt === "md" ? `- ${bold(t("report.docJournalEntries"))}:` : `  ${t("report.docJournalEntries")}:`
+					);
+					for (const entry of journalEntries) {
+						lines.push(
+							fmt === "md" ? `  - ${formatJournalReportEntry(entry, t)}` : `    • ${formatJournalReportEntry(entry, t)}`
+						);
+					}
+				} else {
+					lines.push(fmt === "md" ? `- ${t("report.docJournalNoEntries")}` : `  ${t("report.docJournalNoEntries")}`);
+				}
+				lines.push("");
+			}
 
 			// Refill history
 			if (data.refills.length > 0) {
@@ -772,6 +832,24 @@ function buildPrintHtml(
 				s += `</tbody></table>`;
 			} else {
 				s += `<p class="no-data">${escHtml(t("report.docNoDoses"))}</p>`;
+			}
+
+			const moodSummaryItems = getMoodSummaryItems(data.moodSummary, t);
+			const journalEntries = data.journalEntries ?? [];
+			if (moodSummaryItems.length > 0 || journalEntries.length > 0) {
+				s += `<h3>${escHtml(t("report.docJournal"))}</h3>`;
+				if (moodSummaryItems.length > 0) {
+					s += `<table><tbody><tr><td class="label">${escHtml(t("report.docJournalMoodSummary"))}</td><td>${escHtml(moodSummaryItems.join(", "))}</td></tr></tbody></table>`;
+				}
+				if (journalEntries.length > 0) {
+					s += `<ul>`;
+					for (const entry of journalEntries) {
+						s += `<li>${escHtml(formatJournalReportEntry(entry, t))}</li>`;
+					}
+					s += `</ul>`;
+				} else {
+					s += `<p class="no-data">${escHtml(t("report.docJournalNoEntries"))}</p>`;
+				}
 			}
 
 			// Refill history

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -237,7 +237,7 @@ export function SharedSchedule() {
 				setSharedJournalEntry(payload.entry);
 				setSharedJournalDoseIdsWithNotes((current) => {
 					const next = new Set(current);
-					if (payload.entry.note?.trim()) {
+					if (payload.entry.note?.trim() || payload.entry.mood) {
 						next.add(payload.entry.doseId);
 					} else {
 						next.delete(payload.entry.doseId);
@@ -255,13 +255,13 @@ export function SharedSchedule() {
 	);
 
 	const saveSharedJournalNote = useCallback(
-		async (note: string) => {
+		async (note: string, mood: IntakeJournalEntry["mood"]) => {
 			if (!token || !sharedJournalDoseId) {
 				setSharedJournalError(t("journal.errors.noEventSelected"));
 				return false;
 			}
 
-			if (note.trim().length === 0) {
+			if (note.trim().length === 0 && mood === null) {
 				setSharedJournalError(t("journal.errors.emptySharedNote"));
 				return false;
 			}
@@ -273,7 +273,7 @@ export function SharedSchedule() {
 				const response = await fetch(`/api/share/${token}/journal/event/${encodeURIComponent(sharedJournalDoseId)}`, {
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ note }),
+					body: JSON.stringify({ note, mood }),
 				});
 
 				if (!response.ok) {
@@ -285,7 +285,7 @@ export function SharedSchedule() {
 				setSharedJournalEntry(payload.entry);
 				setSharedJournalDoseIdsWithNotes((current) => {
 					const next = new Set(current);
-					if (payload.entry.note?.trim()) {
+					if (payload.entry.note?.trim() || payload.entry.mood) {
 						next.add(payload.entry.doseId);
 					} else {
 						next.delete(payload.entry.doseId);

--- a/frontend/src/components/intake-journal/IntakeJournalHistoryModal.tsx
+++ b/frontend/src/components/intake-journal/IntakeJournalHistoryModal.tsx
@@ -4,6 +4,7 @@ import type { Medication } from "../../types";
 import { AppModal, AppModalFooter } from "../../ui/modal/AppModal";
 import { AppButton } from "../../ui/primitives/AppButton";
 import { AppSelect } from "../../ui/primitives/AppSelect";
+import { getIntakeMoodDisplay } from "../../utils/intake-mood";
 import { DateTimeInput } from "../DateTimeInput";
 import { MedicationAvatar } from "../MedicationAvatar";
 import classes from "./IntakeJournalModal.module.css";
@@ -70,6 +71,7 @@ export function IntakeJournalHistoryModal({
 							</div>
 							<div className={classes.noteBlock}>
 								<span className={classes.noteLabel}>{t("journal.actions.note")}</span>
+								{entry.mood ? <span className={classes.moodBadge}>{getIntakeMoodDisplay(entry.mood, t)}</span> : null}
 								<p className={classes.entryNote}>{entry.note ?? t("journal.history.noNote")}</p>
 							</div>
 							<dl className={classes.entryMetaGrid}>

--- a/frontend/src/components/intake-journal/IntakeJournalModal.module.css
+++ b/frontend/src/components/intake-journal/IntakeJournalModal.module.css
@@ -85,11 +85,84 @@
 	margin-bottom: 1rem;
 }
 
+.moodField {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-bottom: 1rem;
+	padding: 0;
+	border: 0;
+}
+
+.moodHeader {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.75rem;
+}
+
 .fieldLabel {
 	margin-bottom: 0.35rem;
 	color: var(--text-secondary);
 	font-size: 0.82rem;
 	font-weight: 600;
+}
+
+.moodHeader .fieldLabel {
+	margin-bottom: 0;
+}
+
+.moodOptions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: 0.45rem;
+}
+
+.moodOption {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	padding: 0;
+	border: 1px solid var(--border-primary);
+	border-radius: 8px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	line-height: 1;
+	cursor: pointer;
+	transition:
+		border-color 0.16s ease,
+		background 0.16s ease,
+		box-shadow 0.16s ease,
+		transform 0.16s ease;
+}
+
+.moodOption svg {
+	width: 1.2rem;
+	height: 1.2rem;
+	stroke-width: 2.15;
+}
+
+.moodOption:hover {
+	border-color: color-mix(in srgb, var(--accent) 45%, var(--border-primary));
+	background: color-mix(in srgb, var(--accent-bg) 50%, var(--bg-primary));
+	color: var(--accent);
+	transform: translateY(-1px);
+}
+
+.moodOption:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.moodOptionSelected {
+	border-color: color-mix(in srgb, var(--accent) 70%, var(--border-primary));
+	background: color-mix(in srgb, var(--accent-bg) 75%, var(--bg-primary));
+	box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+	color: var(--accent);
 }
 
 .noteInput {
@@ -201,6 +274,21 @@
 	flex-direction: column;
 	gap: 0.3rem;
 	min-width: 0;
+}
+
+.moodBadge {
+	display: inline-flex;
+	align-items: center;
+	width: fit-content;
+	min-height: 1.55rem;
+	padding: 0.18rem 0.55rem;
+	border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--accent-bg) 70%, transparent);
+	color: var(--text-primary);
+	font-size: 0.8rem;
+	font-weight: 700;
+	line-height: 1.15;
 }
 
 .noteLabel {

--- a/frontend/src/components/intake-journal/IntakeJournalModal.tsx
+++ b/frontend/src/components/intake-journal/IntakeJournalModal.tsx
@@ -1,12 +1,23 @@
+import { Angry, Frown, Laugh, type LucideIcon, Meh, Smile } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { IntakeJournalEntry } from "../../hooks/useIntakeJournal";
 import { AppModal, AppModalFooter } from "../../ui/modal/AppModal";
 import { AppButton } from "../../ui/primitives/AppButton";
 import { AppTextarea } from "../../ui/primitives/AppTextarea";
+import { AppTooltip } from "../../ui/primitives/AppTooltip";
+import { getIntakeMoodLabel, INTAKE_MOODS, type IntakeMood } from "../../utils/intake-mood";
 import { MedicationAvatar } from "../MedicationAvatar";
 import classes from "./IntakeJournalModal.module.css";
 import { formatJournalDisplayDateTime, getJournalSourceLabel } from "./journal-display";
+
+const INTAKE_MOOD_ICONS: Record<IntakeMood, LucideIcon> = {
+	very_bad: Angry,
+	bad: Frown,
+	neutral: Meh,
+	good: Smile,
+	very_good: Laugh,
+};
 
 interface IntakeJournalModalProps {
 	isOpen: boolean;
@@ -16,7 +27,7 @@ interface IntakeJournalModalProps {
 	isDeleting: boolean;
 	error: string | null;
 	onClose: () => void;
-	onSave: (note: string) => Promise<boolean> | boolean;
+	onSave: (note: string, mood: IntakeMood | null) => Promise<boolean> | boolean;
 	onDelete: () => Promise<void> | void;
 	allowDelete?: boolean;
 }
@@ -35,6 +46,7 @@ export function IntakeJournalModal({
 }: IntakeJournalModalProps) {
 	const { t } = useTranslation();
 	const [note, setNote] = useState("");
+	const [mood, setMood] = useState<IntakeMood | null>(null);
 	const [showSavedState, setShowSavedState] = useState(false);
 	const activeDoseTrackingIdRef = useRef<number | null>(null);
 	const wasSavingRef = useRef(false);
@@ -42,6 +54,7 @@ export function IntakeJournalModal({
 	useEffect(() => {
 		if (!isOpen) {
 			setNote("");
+			setMood(null);
 			setShowSavedState(false);
 			activeDoseTrackingIdRef.current = null;
 			wasSavingRef.current = false;
@@ -53,6 +66,7 @@ export function IntakeJournalModal({
 		}
 
 		setNote(entry.note ?? "");
+		setMood(entry.mood ?? null);
 		if (activeDoseTrackingIdRef.current !== entry.doseTrackingId) {
 			activeDoseTrackingIdRef.current = entry.doseTrackingId;
 			setShowSavedState(false);
@@ -73,18 +87,18 @@ export function IntakeJournalModal({
 
 		if (wasSavingRef.current) {
 			wasSavingRef.current = false;
-			if (entry && !error && note === (entry.note ?? "")) {
+			if (entry && !error && note === (entry.note ?? "") && mood === (entry.mood ?? null)) {
 				setShowSavedState(true);
 			}
 		}
-	}, [entry, error, isOpen, isSaving, note]);
+	}, [entry, error, isOpen, isSaving, mood, note]);
 
 	if (!isOpen) {
 		return null;
 	}
 
 	const handleSave = async () => {
-		const saved = await onSave(note);
+		const saved = await onSave(note, mood);
 		if (saved) {
 			onClose();
 		}
@@ -92,7 +106,7 @@ export function IntakeJournalModal({
 
 	const scheduledForLabel = formatJournalDisplayDateTime(entry?.scheduledFor ?? null);
 	const takenAtLabel = formatJournalDisplayDateTime(entry?.takenAt ?? null);
-	const title = entry?.note ? t("journal.editor.editTitle") : t("journal.editor.addTitle");
+	const title = entry?.note || entry?.mood ? t("journal.editor.editTitle") : t("journal.editor.addTitle");
 	const saveLabel = showSavedState ? t("common.saved") : t("common.save");
 	let bodyContent: React.ReactNode;
 
@@ -128,6 +142,48 @@ export function IntakeJournalModal({
 						</div>
 					</div>
 				</div>
+
+				<fieldset className={classes.moodField}>
+					<legend className={classes.fieldLabel}>{t("journal.mood.label")}</legend>
+					{mood ? (
+						<div className={classes.moodHeader}>
+							<AppButton
+								type="button"
+								size="xs"
+								tone="ghost"
+								onClick={() => {
+									setMood(null);
+									setShowSavedState(false);
+								}}
+							>
+								{t("journal.mood.clear")}
+							</AppButton>
+						</div>
+					) : null}
+					<div className={classes.moodOptions}>
+						{INTAKE_MOODS.map((option) => {
+							const selected = mood === option;
+							const MoodIcon = INTAKE_MOOD_ICONS[option];
+							const label = getIntakeMoodLabel(option, t);
+							return (
+								<AppTooltip key={option} label={label} maw={160}>
+									<button
+										type="button"
+										aria-label={label}
+										aria-pressed={selected}
+										className={`${classes.moodOption} ${selected ? classes.moodOptionSelected : ""}`}
+										onClick={() => {
+											setMood(selected ? null : option);
+											setShowSavedState(false);
+										}}
+									>
+										<MoodIcon aria-hidden="true" />
+									</button>
+								</AppTooltip>
+							);
+						})}
+					</div>
+				</fieldset>
 
 				<AppTextarea
 					id="journal-note-input"
@@ -180,7 +236,7 @@ export function IntakeJournalModal({
 							type="button"
 							tone="ghost"
 							onClick={() => void onDelete()}
-							disabled={isLoading || isSaving || isDeleting || !entry?.note}
+							disabled={isLoading || isSaving || isDeleting || (!entry?.note && !entry?.mood)}
 						>
 							{isDeleting ? t("journal.editor.deleting") : t("common.delete")}
 						</AppButton>

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -113,7 +113,7 @@ export interface AppContextValue {
 	journalHistoryError: string | null;
 	openJournalEditor: (doseId: string) => Promise<void>;
 	closeJournalEditor: () => void;
-	saveJournalNote: (note: string) => Promise<boolean>;
+	saveJournalNote: ReturnType<typeof useIntakeJournal>["saveJournalNote"];
 	deleteJournalNote: () => Promise<boolean>;
 	openJournalHistory: () => void;
 	closeJournalHistory: () => void;

--- a/frontend/src/hooks/useIntakeJournal.ts
+++ b/frontend/src/hooks/useIntakeJournal.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
+import type { IntakeMood } from "../utils/intake-mood";
 import { useModalHistory } from "./useModalHistory";
 
 export type IntakeJournalEntry = {
@@ -11,8 +12,9 @@ export type IntakeJournalEntry = {
 	scheduledFor: string;
 	takenAt: string | null;
 	dismissed: boolean;
-	takenSource: "manual" | "automatic";
+	takenSource: "manual" | "automatic" | "notification";
 	markedBy: string | null;
+	mood: IntakeMood | null;
 	note: string | null;
 	updatedAt: string | null;
 	createdAt: string | null;
@@ -41,7 +43,7 @@ export interface UseIntakeJournalReturn {
 	resetJournalState: () => void;
 	openJournalEditor: (doseId: string) => Promise<void>;
 	closeJournalEditor: () => void;
-	saveJournalNote: (note: string) => Promise<boolean>;
+	saveJournalNote: (note: string, mood?: IntakeMood | null) => Promise<boolean>;
 	deleteJournalNote: () => Promise<boolean>;
 	openJournalHistory: () => void;
 	closeJournalHistory: () => void;
@@ -206,7 +208,7 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 	}, []);
 
 	const saveJournalNote = useCallback(
-		async (note: string) => {
+		async (note: string, mood: IntakeMood | null = null) => {
 			if (!journalTargetDoseId) {
 				setJournalEventError(t("journal.errors.noEventSelected"));
 				return false;
@@ -219,7 +221,7 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 				const response = await authFetch(`/api/intake-journal/event/${encodeURIComponent(journalTargetDoseId)}`, {
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ note }),
+					body: JSON.stringify({ note, mood }),
 				});
 
 				if (!response.ok) {
@@ -265,7 +267,7 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 			}
 
 			setJournalEvent((previous) =>
-				previous ? { ...previous, note: null, updatedAt: null, createdAt: null } : previous
+				previous ? { ...previous, mood: null, note: null, updatedAt: null, createdAt: null } : previous
 			);
 			if (journalHistoryOpen) {
 				void loadJournalHistory(journalHistoryFilters);

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -119,6 +119,17 @@
       "saving": "Speichern...",
       "deleting": "Löschen..."
     },
+    "mood": {
+      "label": "Stimmung",
+      "clear": "Stimmung löschen",
+      "values": {
+        "very_bad": "Sehr schlecht",
+        "bad": "Schlecht",
+        "neutral": "Neutral",
+        "good": "Gut",
+        "very_good": "Sehr gut"
+      }
+    },
     "history": {
       "title": "Journal-Verlauf",
       "description": "Durchsuche gespeicherte Einnahme-Notizen nach Medikament oder Zeitraum und öffne einen Eintrag erneut im Bearbeitungsmodus.",
@@ -1034,6 +1045,17 @@
     "docDosesSkipped": "Übersprungene Dosen",
     "docFirstDose": "Erste Dosis",
     "docLastDose": "Letzte Dosis",
+    "docJournal": "Journal und Stimmung",
+    "docJournalMoodSummary": "Stimmungsübersicht",
+    "docJournalMood": "Stimmung",
+    "docJournalEntries": "Journal-Einträge",
+    "docJournalScheduledFor": "Geplant für",
+    "docJournalTakenAt": "Eingenommen um",
+    "docJournalStatusTaken": "Eingenommen",
+    "docJournalStatusSkipped": "Übersprungen",
+    "docJournalNote": "Notiz",
+    "docJournalNoMood": "Keine Stimmung",
+    "docJournalNoEntries": "Keine Journal-Einträge erfasst",
     "docRefillHistory": "Nachfüll-Verlauf",
     "docRefillEntry": "{{date}}: +{{packs}} Packungen, +{{loose}} Tabletten",
     "docRefillPrescription": "(Rezept-Nachfüllung)",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -119,6 +119,17 @@
       "saving": "Saving...",
       "deleting": "Deleting..."
     },
+    "mood": {
+      "label": "Mood",
+      "clear": "Clear mood",
+      "values": {
+        "very_bad": "Very bad",
+        "bad": "Bad",
+        "neutral": "Neutral",
+        "good": "Good",
+        "very_good": "Very good"
+      }
+    },
     "history": {
       "title": "Journal history",
       "description": "Browse saved intake notes by medication or date, then reopen an entry in edit mode.",
@@ -1034,6 +1045,17 @@
     "docDosesSkipped": "Doses skipped",
     "docFirstDose": "First dose",
     "docLastDose": "Last dose",
+    "docJournal": "Journal and Mood",
+    "docJournalMoodSummary": "Mood summary",
+    "docJournalMood": "Mood",
+    "docJournalEntries": "Journal entries",
+    "docJournalScheduledFor": "Scheduled for",
+    "docJournalTakenAt": "Taken at",
+    "docJournalStatusTaken": "Taken",
+    "docJournalStatusSkipped": "Skipped",
+    "docJournalNote": "Note",
+    "docJournalNoMood": "No mood",
+    "docJournalNoEntries": "No journal entries recorded",
     "docRefillHistory": "Refill History",
     "docRefillEntry": "{{date}}: +{{packs}} packs, +{{loose}} pills",
     "docRefillPrescription": "(prescription refill)",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -435,8 +435,8 @@ export function DashboardPage() {
 		}
 	};
 
-	const handleSaveJournalNote = async (note: string) => {
-		return saveJournalNote(note);
+	const handleSaveJournalNote = async (note: string, mood: Parameters<typeof saveJournalNote>[1]) => {
+		return saveJournalNote(note, mood);
 	};
 
 	const handleDeleteJournalNote = async () => {

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -207,8 +207,8 @@ export function SchedulePage() {
 		}
 	};
 
-	const handleSaveJournalNote = async (note: string) => {
-		return saveJournalNote(note);
+	const handleSaveJournalNote = async (note: string, mood: Parameters<typeof saveJournalNote>[1]) => {
+		return saveJournalNote(note, mood);
 	};
 
 	const handleDeleteJournalNote = async () => {

--- a/frontend/src/test/components/IntakeJournalModal.test.tsx
+++ b/frontend/src/test/components/IntakeJournalModal.test.tsx
@@ -29,6 +29,7 @@ function buildEntry(overrides: Partial<IntakeJournalEntry> = {}): IntakeJournalE
 		dismissed: false,
 		takenSource: "manual",
 		markedBy: "pillamn",
+		mood: null,
 		note: "",
 		updatedAt: null,
 		createdAt: null,
@@ -111,10 +112,73 @@ describe("IntakeJournalModal", () => {
 		});
 		fireEvent.click(screen.getByRole("button", { name: "common.save" }));
 
-		expect(onSave).toHaveBeenCalledWith("Shared note");
+		expect(onSave).toHaveBeenCalledWith("Shared note", null);
 		await waitFor(() => {
 			expect(onClose).toHaveBeenCalled();
 		});
+	});
+
+	it("saves the selected mood with the note", async () => {
+		const onSave = vi.fn(async () => true);
+		const onClose = vi.fn();
+		const entry = buildEntry({ mood: "bad" });
+		render(
+			<IntakeJournalModal
+				isOpen
+				entry={entry}
+				isLoading={false}
+				isSaving={false}
+				isDeleting={false}
+				error={null}
+				onClose={onClose}
+				onSave={onSave}
+				onDelete={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByRole("button", { name: "journal.mood.values.bad" })).toHaveAttribute("aria-pressed", "true");
+		fireEvent.click(screen.getByRole("button", { name: "journal.mood.values.good" }));
+		fireEvent.change(screen.getByLabelText("journal.editor.noteLabel"), {
+			target: { value: "Mood note" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+		expect(onSave).toHaveBeenCalledWith("Mood note", "good");
+		await waitFor(() => {
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	it("shows mood labels as tooltips on hover and touch", async () => {
+		const entry = buildEntry();
+		render(
+			<IntakeJournalModal
+				isOpen
+				entry={entry}
+				isLoading={false}
+				isSaving={false}
+				isDeleting={false}
+				error={null}
+				onClose={vi.fn()}
+				onSave={vi.fn()}
+				onDelete={vi.fn()}
+			/>
+		);
+
+		const goodMoodButton = screen.getByRole("button", { name: "journal.mood.values.good" });
+		fireEvent.mouseEnter(goodMoodButton);
+
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("journal.mood.values.good");
+
+		fireEvent.mouseLeave(goodMoodButton);
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		const veryGoodMoodButton = screen.getByRole("button", { name: "journal.mood.values.very_good" });
+		fireEvent.touchStart(veryGoodMoodButton);
+
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("journal.mood.values.very_good");
 	});
 
 	it("keeps the modal open when save fails", async () => {
@@ -141,7 +205,7 @@ describe("IntakeJournalModal", () => {
 		fireEvent.click(screen.getByRole("button", { name: "common.save" }));
 
 		await waitFor(() => {
-			expect(onSave).toHaveBeenCalledWith("Shared note");
+			expect(onSave).toHaveBeenCalledWith("Shared note", null);
 		});
 		expect(onClose).not.toHaveBeenCalled();
 	});

--- a/frontend/src/test/components/ReportModal.test.tsx
+++ b/frontend/src/test/components/ReportModal.test.tsx
@@ -104,6 +104,18 @@ describe("ReportModal", () => {
 						dosesSkipped: 0,
 						firstDoseAt: "2026-01-01T08:00:00.000Z",
 						lastDoseAt: "2026-01-02T08:00:00.000Z",
+						moodSummary: { good: 1 },
+						journalEntries: [
+							{
+								scheduledFor: "2026-01-01T08:00:00.000Z",
+								takenAt: "2026-01-01T08:05:00.000Z",
+								dismissed: false,
+								takenSource: "manual",
+								takenByPerson: "Alice",
+								mood: "good",
+								note: "Journal note",
+							},
+						],
 						refills: [],
 					},
 				}),
@@ -124,6 +136,9 @@ describe("ReportModal", () => {
 			expect(onClose).not.toHaveBeenCalled();
 			expect(URL.createObjectURL).not.toHaveBeenCalled();
 			expect(getPreviewContent()).toContain("report.docTitle");
+			expect(getPreviewContent()).toContain("report.docJournal");
+			expect(getPreviewContent()).toContain("journal.mood.values.good");
+			expect(getPreviewContent()).toContain("Journal note");
 
 			view.unmount();
 		}
@@ -297,6 +312,18 @@ describe("ReportModal", () => {
 					dosesSkipped: 0,
 					firstDoseAt: "2026-03-03T12:00:00.000Z",
 					lastDoseAt: null,
+					moodSummary: { very_good: 1 },
+					journalEntries: [
+						{
+							scheduledFor: "2026-03-03T08:00:00.000Z",
+							takenAt: "2026-03-03T12:00:00.000Z",
+							dismissed: false,
+							takenSource: "manual",
+							takenByPerson: null,
+							mood: "very_good",
+							note: "PDF mood note",
+						},
+					],
 					refills: [
 						{
 							packsAdded: 1,
@@ -334,6 +361,8 @@ describe("ReportModal", () => {
 		expect(html).toContain(formatDate("2026-03-01"));
 		expect(html).toContain(formatDateTime("2026-03-02T08:30:00.000Z"));
 		expect(html).toContain(formatDate("2026-03-03T12:00:00.000Z"));
+		expect(html).toContain("journal.mood.values.very_good");
+		expect(html).toContain("PDF mood note");
 		expect(html).toContain(formatDate("2026-03-04"));
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -172,14 +172,26 @@ function createSharedDoseFetchMock(options: {
 }) {
 	const token = options.token ?? "token-123";
 	const doseState = new Map((options.initialDoses ?? []).map((dose) => [dose.doseId, { ...dose }]));
-	const journalState = new Map<string, { note: string | null; createdAt: string | null; updatedAt: string | null }>();
+	const journalState = new Map<
+		string,
+		{
+			note: string | null;
+			mood: "very_bad" | "bad" | "neutral" | "good" | "very_good" | null;
+			createdAt: string | null;
+			updatedAt: string | null;
+		}
+	>();
 	const requests: Array<{ url: string; method: string; body?: unknown }> = [];
 
 	const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
 		const method = init?.method ?? "GET";
 		const body =
 			typeof init?.body === "string" && init.body.length > 0
-				? (JSON.parse(init.body) as { doseId?: string; note?: string | null })
+				? (JSON.parse(init.body) as {
+						doseId?: string;
+						note?: string | null;
+						mood?: "very_bad" | "bad" | "neutral" | "good" | "very_good" | null;
+					})
 				: undefined;
 		requests.push({ url, method, body });
 
@@ -190,7 +202,10 @@ function createSharedDoseFetchMock(options: {
 		if (url === `/api/share/${token}/doses` && method === "GET") {
 			const doses = Array.from(doseState.values()).map((dose) => ({
 				...dose,
-				hasJournalNote: dose.hasJournalNote === true || Boolean(journalState.get(dose.doseId)?.note?.trim()),
+				hasJournalNote:
+					dose.hasJournalNote === true ||
+					Boolean(journalState.get(dose.doseId)?.note?.trim()) ||
+					Boolean(journalState.get(dose.doseId)?.mood),
 			}));
 			return { ok: true, json: async () => ({ doses }) };
 		}
@@ -207,7 +222,7 @@ function createSharedDoseFetchMock(options: {
 
 		if (url.startsWith(`/api/share/${token}/journal/event/`) && method === "GET") {
 			const doseId = decodeURIComponent(url.split("/").at(-1) ?? "");
-			const journal = journalState.get(doseId) ?? { note: null, createdAt: null, updatedAt: null };
+			const journal = journalState.get(doseId) ?? { note: null, mood: null, createdAt: null, updatedAt: null };
 			return {
 				ok: true,
 				json: async () => ({
@@ -221,6 +236,7 @@ function createSharedDoseFetchMock(options: {
 						dismissed: false,
 						takenSource: "manual",
 						markedBy: "Max",
+						mood: journal.mood,
 						note: journal.note,
 						createdAt: journal.createdAt,
 						updatedAt: journal.updatedAt,
@@ -232,7 +248,12 @@ function createSharedDoseFetchMock(options: {
 		if (url.startsWith(`/api/share/${token}/journal/event/`) && method === "PUT") {
 			const doseId = decodeURIComponent(url.split("/").at(-1) ?? "");
 			const timestamp = new Date().toISOString();
-			journalState.set(doseId, { note: body?.note ?? null, createdAt: timestamp, updatedAt: timestamp });
+			journalState.set(doseId, {
+				note: body?.note ?? null,
+				mood: body?.mood ?? null,
+				createdAt: timestamp,
+				updatedAt: timestamp,
+			});
 			return {
 				ok: true,
 				json: async () => ({
@@ -246,6 +267,7 @@ function createSharedDoseFetchMock(options: {
 						dismissed: false,
 						takenSource: "manual",
 						markedBy: "Max",
+						mood: body?.mood ?? null,
 						note: body?.note ?? null,
 						createdAt: timestamp,
 						updatedAt: timestamp,
@@ -434,13 +456,14 @@ describe("SharedSchedule", () => {
 		expect(screen.queryByRole("button", { name: "common.delete" })).not.toBeInTheDocument();
 
 		fireEvent.change(screen.getByLabelText("journal.editor.noteLabel"), { target: { value: "Shared note" } });
+		fireEvent.click(screen.getByRole("button", { name: "journal.mood.values.good" }));
 		fireEvent.click(screen.getByRole("button", { name: "common.save" }));
 
 		await waitFor(() => {
 			expect(requests).toContainEqual({
 				url: `/api/share/token-123/journal/event/${sharedData.automaticDoseId}`,
 				method: "PUT",
-				body: { note: "Shared note" },
+				body: { note: "Shared note", mood: "good" },
 			});
 		});
 

--- a/frontend/src/test/hooks/useIntakeJournal.test.ts
+++ b/frontend/src/test/hooks/useIntakeJournal.test.ts
@@ -21,6 +21,7 @@ function buildEntry(overrides: Partial<IntakeJournalEntry> = {}): IntakeJournalE
 		dismissed: false,
 		takenSource: "manual",
 		markedBy: "Daniel",
+		mood: null,
 		note: null,
 		updatedAt: null,
 		createdAt: null,
@@ -42,6 +43,7 @@ describe("useIntakeJournal", () => {
 		const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
 		const initialEntry = buildEntry();
 		const savedEntry = buildEntry({
+			mood: "good",
 			note: "Took after breakfast",
 			createdAt: "2026-02-10T08:06:00.000Z",
 			updatedAt: "2026-02-10T08:07:00.000Z",
@@ -74,7 +76,7 @@ describe("useIntakeJournal", () => {
 
 		let saveResult = false;
 		await act(async () => {
-			saveResult = await result.current.saveJournalNote("Took after breakfast");
+			saveResult = await result.current.saveJournalNote("Took after breakfast", "good");
 		});
 
 		expect(saveResult).toBe(true);
@@ -84,10 +86,11 @@ describe("useIntakeJournal", () => {
 			expect.objectContaining({
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ note: "Took after breakfast" }),
+				body: JSON.stringify({ note: "Took after breakfast", mood: "good" }),
 			})
 		);
 		expect(result.current.journalEvent?.note).toBe("Took after breakfast");
+		expect(result.current.journalEvent?.mood).toBe("good");
 
 		let deleteResult = false;
 		await act(async () => {
@@ -103,6 +106,7 @@ describe("useIntakeJournal", () => {
 		expect(result.current.journalEvent).toEqual(
 			expect.objectContaining({
 				doseId: initialEntry.doseId,
+				mood: null,
 				note: null,
 				createdAt: null,
 				updatedAt: null,
@@ -114,6 +118,7 @@ describe("useIntakeJournal", () => {
 		const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
 		const historyEntry = buildEntry({
 			doseId: "11-0-1760086400000-Daniel",
+			mood: "neutral",
 			note: "Evening note",
 			updatedAt: "2026-02-11T18:30:00.000Z",
 			createdAt: "2026-02-11T18:20:00.000Z",

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -143,6 +143,7 @@ const mockJournalEntry = {
 	dismissed: false,
 	takenSource: "manual" as const,
 	markedBy: null,
+	mood: null,
 	note: "",
 	updatedAt: null,
 	createdAt: null,
@@ -558,7 +559,7 @@ describe("DashboardPage", () => {
 		fireEvent.click(screen.getByRole("button", { name: "common.save" }));
 
 		await waitFor(() => {
-			expect(saveJournalNote).toHaveBeenCalledWith("Main app note");
+			expect(saveJournalNote).toHaveBeenCalledWith("Main app note", null);
 			expect(closeJournalEditor).toHaveBeenCalled();
 		});
 	});

--- a/frontend/src/test/pages/SchedulePage.test.tsx
+++ b/frontend/src/test/pages/SchedulePage.test.tsx
@@ -116,6 +116,7 @@ const mockJournalEntry = {
 	dismissed: false,
 	takenSource: "manual" as const,
 	markedBy: "John",
+	mood: null,
 	note: "",
 	updatedAt: null,
 	createdAt: null,
@@ -868,7 +869,7 @@ describe("SchedulePage skip behavior", () => {
 		fireEvent.click(screen.getByRole("button", { name: "common.save" }));
 
 		await waitFor(() => {
-			expect(saveJournalNote).toHaveBeenCalledWith("Main app note");
+			expect(saveJournalNote).toHaveBeenCalledWith("Main app note", null);
 			expect(closeJournalEditor).toHaveBeenCalled();
 		});
 	});

--- a/frontend/src/utils/intake-mood.ts
+++ b/frontend/src/utils/intake-mood.ts
@@ -1,0 +1,22 @@
+import { INTAKE_MOODS, type IntakeMood } from "@medassist/shared";
+
+export type { IntakeMood };
+export { INTAKE_MOODS };
+
+export const INTAKE_MOOD_EMOJI: Record<IntakeMood, string> = {
+	very_bad: "😣",
+	bad: "🙁",
+	neutral: "😐",
+	good: "🙂",
+	very_good: "😄",
+};
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+export function getIntakeMoodLabel(mood: IntakeMood, t: Translate): string {
+	return t(`journal.mood.values.${mood}`);
+}
+
+export function getIntakeMoodDisplay(mood: IntakeMood, t: Translate): string {
+	return `${INTAKE_MOOD_EMOJI[mood]} ${getIntakeMoodLabel(mood, t)}`;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./date-time.js";
+export * from "./intake-mood.js";
 export * from "./package-profiles.js";
 export * from "./timezone-regions.js";

--- a/shared/src/intake-mood.ts
+++ b/shared/src/intake-mood.ts
@@ -1,0 +1,13 @@
+export const INTAKE_MOODS = ["very_bad", "bad", "neutral", "good", "very_good"] as const;
+
+export type IntakeMood = (typeof INTAKE_MOODS)[number];
+
+const INTAKE_MOOD_SET = new Set<string>(INTAKE_MOODS);
+
+export function isIntakeMood(value: unknown): value is IntakeMood {
+	return typeof value === "string" && INTAKE_MOOD_SET.has(value);
+}
+
+export function normalizeIntakeMood(value: unknown): IntakeMood | null {
+	return isIntakeMood(value) ? value : null;
+}


### PR DESCRIPTION
Closes #867

## Summary

- Add shared 5-step intake mood values and persist mood on intake journal entries with a backward-compatible migration.
- Support mood entries across owner and shared journal APIs, export/import, report data, and report rendering.
- Add localized frontend mood controls, history badges, shared-flow handling, and focused coverage.

## Validation

- `npm --prefix backend run test:run -- src/test/intake-journal-routes.test.ts src/test/routes-real.test.ts src/test/e2e-routes.test.ts` -> 177 passed
- `npm --prefix backend run test:run -- src/test/database.test.ts src/test/doses.test.ts src/test/domain-safety.test.ts` -> 118 passed
- `npm --prefix frontend run test:run -- src/test/components/IntakeJournalModal.test.tsx src/test/components/SharedSchedule.test.tsx src/test/components/ReportModal.test.tsx src/test/hooks/useIntakeJournal.test.ts src/test/pages/DashboardPage.test.tsx src/test/pages/SchedulePage.test.tsx` -> 141 passed
- `npm --prefix frontend run test:run -- src/test/components/IntakeJournalModal.test.tsx src/test/components/AppTooltipPrimitives.test.tsx src/test/ui/modal-footer-contract.test.ts` -> 20 passed
- `npm --prefix frontend run check` -> passed
- `npm run check` -> passed
- `git diff --check` -> clean
- `CI=true PLAYWRIGHT_HTML_OPEN=never PLAYWRIGHT_WORKERS=1 npm --prefix frontend run test:e2e -- --project=chromium e2e/export-import.spec.ts` -> 3 passed
- Browser verification passed on local isolated stack for mood-only save, note+mood save, delete, report preview, compact mood buttons, centered modal layout, and tooltip hover/touch labels.