### PR TITLE
chore: release 1.29.0

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,7 @@ jobs:
       checks: read
       contents: read
       packages: read
+      pull-requests: read
     uses: ./.github/workflows/container-smoke.yml
     secrets: inherit
     with:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Share your medication schedule with others via a public link.
 
 ### Reports
 - Generate medication reports as PDF, Markdown, or plain text
-- Include intake history, refill history, and prescription details
+- Include intake history with mood summaries, refill history, and prescription details
 
 ### Multi-Person Support
 - Manage medications for multiple people
@@ -161,7 +161,7 @@ Share your medication schedule with others via a public link.
 - Optionally embed the medication overview directly on shared links via a settings toggle
 
 ### Data Export & Import
-- Export all your data (medications, dose history, intake journal notes, settings) as JSON
+- Export all your data (medications, dose history, intake journal notes and moods, settings) as JSON
 - Review validated import contents before replacing current data
 - Optionally download a fresh backup before confirming import
 - Import previously exported data with automatic ID remapping

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.28.1
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.29.0
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.28.1
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.29.0
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "dependencies": {
         "@mantine/core": "^9.4.1",
         "@mantine/dates": "^9.4.1",
@@ -43,7 +43,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.28.1",
+  "version": "1.29.0",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Prepare MedAssist-ng v1.29.0 for release.

Changes:
- Bump backend, frontend, and shared versions plus lockfiles to 1.29.0.
- Pin production Docker Compose image tags to 1.29.0.
- Document mood-aware intake journal report/export behavior in the README.
- Grant the Docker release workflow caller `pull-requests: read` so the reusable Container Smoke workflow can start during release builds.

## Validation

- `actionlint -color=false .github/workflows/docker-build.yml .github/workflows/container-smoke.yml`
- `npm run check`
- `npm run test:release-preflight`
- `npm run release:preflight -- --tag v1.29.0 --static-only --compose docker-compose.yml --workflow .github/workflows/docker-build.yml`

Closes #869