### PR TITLE
fix: guard future dose actions

### DIFF
--- a/backend/src/routes/doses.ts
+++ b/backend/src/routes/doses.ts
@@ -270,6 +270,24 @@ function isDoseInsideShareScheduleWindow(share: typeof shareTokens.$inferSelect,
 	return doseDayStart >= earliestVisible.getTime() && doseDayStart < latestVisibleExclusive.getTime();
 }
 
+function isFutureDoseDay(parsedDose: ParsedDoseId): boolean {
+	return getLocalDayStartMs(parsedDose.timestampMs) > getLocalDayStartMs(new Date());
+}
+
+function getExpectedShareMarkedBy(share: typeof shareTokens.$inferSelect, parsedDose: ParsedDoseId): string {
+	if (share.takenBy !== "all") return share.takenBy;
+	return parsedDose.personSuffix ?? "all";
+}
+
+function isDoseMarkedOutsideShareLink(
+	share: typeof shareTokens.$inferSelect,
+	parsedDose: ParsedDoseId,
+	existing: typeof doseTracking.$inferSelect
+): boolean {
+	if (existing.dismissed) return false;
+	return existing.markedBy !== getExpectedShareMarkedBy(share, parsedDose);
+}
+
 async function isDoseOutOfStock(options: {
 	userId: number;
 	doseId: string;
@@ -585,6 +603,7 @@ export async function doseRoutes(app: FastifyInstance) {
 						},
 					},
 					400: { anyOf: [genericErrorSchema, validationErrorSchema] },
+					409: genericErrorSchema,
 					401: genericErrorSchema,
 				},
 			},
@@ -596,7 +615,16 @@ export async function doseRoutes(app: FastifyInstance) {
 				return reply.status(400).send({ error: getValidationErrorMessage(parsed.error) });
 			}
 
-			const status = await markDoseSkippedForUser({ userId, doseId: parsed.data.doseId });
+			const { doseId } = parsed.data;
+			const parsedDose = parseDoseId(doseId);
+			if (parsedDose && isFutureDoseDay(parsedDose)) {
+				return reply.status(409).send({
+					error: "Future doses cannot be skipped",
+					code: "FUTURE_DOSE",
+				});
+			}
+
+			const status = await markDoseSkippedForUser({ userId, doseId });
 			if (status === "already_skipped") {
 				return { success: true, message: "Already skipped" };
 			}
@@ -665,6 +693,7 @@ export async function doseRoutes(app: FastifyInstance) {
 					},
 					400: { anyOf: [genericErrorSchema, validationErrorSchema] },
 					401: genericErrorSchema,
+					409: genericErrorSchema,
 				},
 			},
 		},
@@ -679,6 +708,16 @@ export async function doseRoutes(app: FastifyInstance) {
 			}
 
 			const { doseIds } = parsed.data;
+			const hasFutureDose = doseIds.some((doseId) => {
+				const parsedDose = parseDoseId(doseId);
+				return parsedDose ? isFutureDoseDay(parsedDose) : false;
+			});
+			if (hasFutureDose) {
+				return reply.status(409).send({
+					error: "Future doses cannot be skipped",
+					code: "FUTURE_DOSE",
+				});
+			}
 
 			// Preserve the existing route semantics for dismiss: any non-dismissed record
 			// becomes dismissed, regardless of whether it already has a taken timestamp.
@@ -1030,6 +1069,7 @@ export async function doseRoutes(app: FastifyInstance) {
 					},
 					400: { anyOf: [genericErrorSchema, validationErrorSchema] },
 					403: genericErrorSchema,
+					409: genericErrorSchema,
 					404: genericErrorSchema,
 				},
 			},
@@ -1083,6 +1123,25 @@ export async function doseRoutes(app: FastifyInstance) {
 				return reply.status(400).send({ error: "Invalid or unauthorized doseId" });
 			}
 
+			const parsedShareDose = parseDoseId(doseId);
+			if (parsedShareDose && isFutureDoseDay(parsedShareDose)) {
+				return reply.status(409).send({
+					error: "Future doses cannot be skipped via share link",
+					code: "FUTURE_DOSE",
+				});
+			}
+
+			const [existing] = await db
+				.select()
+				.from(doseTracking)
+				.where(and(eq(doseTracking.userId, share.userId), eq(doseTracking.doseId, doseId)));
+			if (existing && parsedShareDose && isDoseMarkedOutsideShareLink(share, parsedShareDose, existing)) {
+				return reply.status(409).send({
+					error: "Dose was already marked as taken in the main app",
+					code: "MAIN_APP_TAKEN",
+				});
+			}
+
 			const status = await markDoseSkippedForUser({ userId: share.userId, doseId });
 			if (status === "already_skipped") {
 				return { success: true, message: "Already skipped" };
@@ -1121,6 +1180,7 @@ export async function doseRoutes(app: FastifyInstance) {
 					200: { type: "object", properties: { success: { type: "boolean" } } },
 					400: genericErrorSchema,
 					403: genericErrorSchema,
+					409: genericErrorSchema,
 					404: genericErrorSchema,
 				},
 			},
@@ -1252,6 +1312,14 @@ export async function doseRoutes(app: FastifyInstance) {
 				return reply.status(400).send({ error: "Invalid or unauthorized doseId" });
 			}
 
+			const parsedShareDose = parseDoseId(doseId);
+			if (parsedShareDose && isFutureDoseDay(parsedShareDose)) {
+				return reply.status(409).send({
+					error: "Future doses cannot be marked as taken via share link",
+					code: "FUTURE_DOSE",
+				});
+			}
+
 			// Check if already marked
 			const [existing] = await db
 				.select()
@@ -1259,6 +1327,12 @@ export async function doseRoutes(app: FastifyInstance) {
 				.where(and(eq(doseTracking.userId, share.userId), eq(doseTracking.doseId, doseId)));
 
 			if (existing) {
+				if (parsedShareDose && isDoseMarkedOutsideShareLink(share, parsedShareDose, existing)) {
+					return reply.status(409).send({
+						error: "Dose was already marked as taken in the main app",
+						code: "MAIN_APP_TAKEN",
+					});
+				}
 				logShareDoseDebug(request, "[ShareDose] Duplicate mark ignored", {
 					token,
 					doseId,
@@ -1288,7 +1362,6 @@ export async function doseRoutes(app: FastifyInstance) {
 			}
 
 			// Insert new record - marked by the shared person, or the concrete intake person for an "all" link.
-			const parsedShareDose = parseDoseId(doseId);
 			const markedBy = share.takenBy === "all" ? (parsedShareDose?.personSuffix ?? share.takenBy) : share.takenBy;
 
 			await db.insert(doseTracking).values({
@@ -1332,6 +1405,7 @@ export async function doseRoutes(app: FastifyInstance) {
 					200: { type: "object", properties: { success: { type: "boolean" } } },
 					400: genericErrorSchema,
 					403: genericErrorSchema,
+					409: genericErrorSchema,
 					404: genericErrorSchema,
 				},
 			},
@@ -1384,6 +1458,14 @@ export async function doseRoutes(app: FastifyInstance) {
 				.select()
 				.from(doseTracking)
 				.where(and(eq(doseTracking.userId, share.userId), eq(doseTracking.doseId, doseId)));
+
+			const parsedShareDose = parseDoseId(doseId);
+			if (existing && parsedShareDose && isDoseMarkedOutsideShareLink(share, parsedShareDose, existing)) {
+				return reply.status(409).send({
+					error: "Dose was already marked as taken in the main app",
+					code: "MAIN_APP_TAKEN",
+				});
+			}
 
 			if (existing?.dismissed) {
 				// Already dismissed - keep the record as-is

--- a/backend/src/services/dose-tracking-service.ts
+++ b/backend/src/services/dose-tracking-service.ts
@@ -14,7 +14,7 @@ export type MarkDoseTakenResult =
 	  }
 	| {
 			success: false;
-			code: "OUT_OF_STOCK" | "INVALID_DOSE" | "ALREADY_SKIPPED";
+			code: "OUT_OF_STOCK" | "INVALID_DOSE" | "ALREADY_SKIPPED" | "FUTURE_DOSE";
 			message: string;
 	  };
 
@@ -33,6 +33,16 @@ export type SkipDosesResult = {
 
 function hasRealTakenTimestamp(takenAt: Date | null): boolean {
 	return takenAt instanceof Date && takenAt.getTime() > 0;
+}
+
+function getLocalDayStartMs(value: Date | number): number {
+	const date = typeof value === "number" ? new Date(value) : new Date(value.getTime());
+	date.setHours(0, 0, 0, 0);
+	return date.getTime();
+}
+
+function isFutureDoseDay(timestampMs: number): boolean {
+	return getLocalDayStartMs(timestampMs) > getLocalDayStartMs(new Date());
 }
 
 function isDoseTrackingUniqueConflict(error: unknown): boolean {
@@ -119,6 +129,14 @@ export async function markDoseTakenForUser(input: {
 			success: false,
 			code: "INVALID_DOSE",
 			message: "Invalid dose ID",
+		};
+	}
+
+	if (isFutureDoseDay(parsedDose.timestampMs)) {
+		return {
+			success: false,
+			code: "FUTURE_DOSE",
+			message: "Future doses cannot be marked as taken",
 		};
 	}
 

--- a/backend/src/test/doses.test.ts
+++ b/backend/src/test/doses.test.ts
@@ -137,6 +137,13 @@ function buildLocalDoseStart(hours = 8): string {
 	return `${year}-${month}-${day}T${hour}:00:00.000`;
 }
 
+function buildFutureDoseId(medicationId = 1): string {
+	const future = new Date();
+	future.setDate(future.getDate() + 1);
+	future.setHours(0, 0, 0, 0);
+	return `${medicationId}-0-${future.getTime()}`;
+}
+
 async function buildSessionCookie(app: FastifyInstance, userId: number, username: string) {
 	const token = await app.jwt.sign({ sub: userId, username });
 	return `access_token=${token}`;
@@ -276,6 +283,29 @@ describe("Dose Tracking API", () => {
 
 			expect(response.statusCode).toBe(400);
 			expect(response.json()).toEqual({ error: "Required" });
+		});
+
+		it("rejects future doses before stock checks or tracking changes", async () => {
+			const doseId = buildFutureDoseId();
+
+			const response = await app.inject({
+				method: "POST",
+				url: "/doses/taken",
+				headers: { cookie: cookieHeader },
+				payload: { doseId },
+			});
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json()).toEqual({
+				error: "Future doses cannot be marked as taken",
+				code: "FUTURE_DOSE",
+			});
+
+			const result = await testClient.execute({
+				sql: "SELECT COUNT(*) AS count FROM dose_tracking WHERE user_id = ? AND dose_id = ?",
+				args: [userId, doseId],
+			});
+			expect(Number(result.rows[0].count)).toBe(0);
 		});
 
 		it("accepts dose IDs with a person suffix and special characters", async () => {
@@ -511,6 +541,29 @@ describe("Dose Tracking API", () => {
 			expect(missingResponse.statusCode).toBe(400);
 			expect(missingResponse.json()).toEqual({ error: "Required" });
 		});
+
+		it("rejects future doses instead of dismissing them", async () => {
+			const doseId = buildFutureDoseId();
+
+			const response = await app.inject({
+				method: "POST",
+				url: "/doses/dismiss",
+				headers: { cookie: cookieHeader },
+				payload: { doseIds: [doseId] },
+			});
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json()).toEqual({
+				error: "Future doses cannot be skipped",
+				code: "FUTURE_DOSE",
+			});
+
+			const result = await testClient.execute({
+				sql: "SELECT COUNT(*) AS count FROM dose_tracking WHERE user_id = ? AND dose_id = ?",
+				args: [userId, doseId],
+			});
+			expect(Number(result.rows[0].count)).toBe(0);
+		});
 	});
 
 	describe("single-dose skip routes", () => {
@@ -532,6 +585,29 @@ describe("Dose Tracking API", () => {
 				args: [userId, doseId],
 			});
 			expect(result.rows).toEqual([expect.objectContaining({ dose_id: doseId, marked_by: null, dismissed: 1 })]);
+		});
+
+		it("rejects future doses instead of marking them skipped", async () => {
+			const doseId = buildFutureDoseId();
+
+			const response = await app.inject({
+				method: "POST",
+				url: "/doses/skip",
+				headers: { cookie: cookieHeader },
+				payload: { doseId },
+			});
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json()).toEqual({
+				error: "Future doses cannot be skipped",
+				code: "FUTURE_DOSE",
+			});
+
+			const result = await testClient.execute({
+				sql: "SELECT COUNT(*) AS count FROM dose_tracking WHERE user_id = ? AND dose_id = ?",
+				args: [userId, doseId],
+			});
+			expect(Number(result.rows[0].count)).toBe(0);
 		});
 
 		it("undoes a skipped-only owner dose through the frontend route", async () => {

--- a/backend/src/test/share-hardening.test.ts
+++ b/backend/src/test/share-hardening.test.ts
@@ -128,6 +128,19 @@ function buildDoseId(medicationId: number, person = "Daniel"): string {
 	return `${medicationId}-0-${new Date(buildLocalDoseStart()).getTime()}-${person}`;
 }
 
+function buildFutureDoseId(medicationId: number, person = "Daniel"): string {
+	const start = new Date(buildLocalDoseStart());
+	start.setDate(start.getDate() + 1);
+	return `${medicationId}-0-${start.getTime()}-${person}`;
+}
+
+async function insertDoseTracking(options: { doseId: string; markedBy?: string | null; dismissed?: boolean }) {
+	await testClient.execute({
+		sql: "INSERT INTO dose_tracking (user_id, dose_id, marked_by, dismissed, taken_source) VALUES (1, ?, ?, ?, 'manual')",
+		args: [options.doseId, options.markedBy ?? null, options.dismissed ? 1 : 0],
+	});
+}
+
 describe("share link hardening", () => {
 	let app: FastifyInstance;
 
@@ -312,6 +325,59 @@ describe("share link hardening", () => {
 		expect(readResponse.statusCode, readResponse.body).toBe(200);
 		expect(markResponse.statusCode).toBe(403);
 		expect(unmarkResponse.statusCode).toBe(403);
+	});
+
+	it("rejects future shared take and skip mutations", async () => {
+		const medId = await insertMedication();
+		const token = "5555555555555555";
+		const doseId = buildFutureDoseId(medId);
+		await insertShareToken({ token, allowMarkTaken: true });
+
+		const markResponse = await app.inject({
+			method: "POST",
+			url: `/share/${token}/doses`,
+			payload: { doseId },
+		});
+		const skipResponse = await app.inject({
+			method: "POST",
+			url: `/share/${token}/doses/skip`,
+			payload: { doseId },
+		});
+
+		expect(markResponse.statusCode).toBe(409);
+		expect(markResponse.json()).toMatchObject({ code: "FUTURE_DOSE" });
+		expect(skipResponse.statusCode).toBe(409);
+		expect(skipResponse.json()).toMatchObject({ code: "FUTURE_DOSE" });
+	});
+
+	it("rejects shared changes to doses already marked as taken in the main app", async () => {
+		const medId = await insertMedication();
+		const token = "6666666666666666";
+		const doseId = buildDoseId(medId);
+		await insertShareToken({ token, allowMarkTaken: true });
+		await insertDoseTracking({ doseId, markedBy: null });
+
+		const markResponse = await app.inject({
+			method: "POST",
+			url: `/share/${token}/doses`,
+			payload: { doseId },
+		});
+		const skipResponse = await app.inject({
+			method: "POST",
+			url: `/share/${token}/doses/skip`,
+			payload: { doseId },
+		});
+		const unmarkResponse = await app.inject({
+			method: "DELETE",
+			url: `/share/${token}/doses/${encodeURIComponent(doseId)}`,
+		});
+
+		expect(markResponse.statusCode).toBe(409);
+		expect(markResponse.json()).toMatchObject({ code: "MAIN_APP_TAKEN" });
+		expect(skipResponse.statusCode).toBe(409);
+		expect(skipResponse.json()).toMatchObject({ code: "MAIN_APP_TAKEN" });
+		expect(unmarkResponse.statusCode).toBe(409);
+		expect(unmarkResponse.json()).toMatchObject({ code: "MAIN_APP_TAKEN" });
 	});
 
 	it("rate limits public share dose mutations per IP and token", async () => {

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -61,6 +61,18 @@ function cx(...classNames: Array<string | false | null | undefined>) {
 	return classNames.filter(Boolean).join(" ");
 }
 
+function getDosePersonSuffix(doseId: string): string | null {
+	const parts = doseId.split("-");
+	if (parts.length <= 3) return null;
+	return parts.slice(3).join("-");
+}
+
+function getExpectedSharedDoseMarker(doseId: string, sharedTakenBy: string | null | undefined): string | null {
+	if (!sharedTakenBy) return null;
+	if (sharedTakenBy !== "all") return sharedTakenBy;
+	return getDosePersonSuffix(doseId) ?? "all";
+}
+
 export function SharedSchedule() {
 	const { token } = useParams<{ token: string }>();
 	const { t, i18n } = useTranslation();
@@ -71,6 +83,7 @@ export function SharedSchedule() {
 	const [expiredData, setExpiredData] = useState<ExpiredLinkData | null>(null);
 	const [takenDoses, setTakenDoses] = useState<Set<string>>(new Set());
 	const [automaticTakenDoses, setAutomaticTakenDoses] = useState<Set<string>>(new Set());
+	const [mainAppTakenDoses, setMainAppTakenDoses] = useState<Set<string>>(new Set());
 	const [dismissedDoses, setDismissedDoses] = useState<Set<string>>(new Set());
 	const [sharedJournalDoseIdsWithNotes, setSharedJournalDoseIdsWithNotes] = useState<Set<string>>(new Set());
 	const mutationInFlightRef = useRef(0);
@@ -324,15 +337,17 @@ export function SharedSchedule() {
 			if (res.ok) {
 				if (mutationInFlightRef.current > 0) return;
 
-				const data = await res.json();
+				const dosePayload = await res.json();
 				const taken = new Set<string>();
 				const automatic = new Set<string>();
+				const mainAppTaken = new Set<string>();
 				const dismissed = new Set<string>();
 				const journalDoseIds = new Set<string>();
-				for (const d of data.doses as Array<{
+				for (const d of dosePayload.doses as Array<{
 					doseId: string;
 					dismissed?: boolean;
 					skipped?: boolean;
+					markedBy?: string | null;
 					takenSource?: string;
 					hasJournalNote?: boolean;
 				}>) {
@@ -343,6 +358,9 @@ export function SharedSchedule() {
 						if (d.takenSource === "automatic") {
 							automatic.add(d.doseId);
 						}
+						if (Object.hasOwn(d, "markedBy") && d.markedBy !== getExpectedSharedDoseMarker(d.doseId, data?.takenBy)) {
+							mainAppTaken.add(d.doseId);
+						}
 					}
 					if (d.hasJournalNote === true) {
 						journalDoseIds.add(d.doseId);
@@ -350,13 +368,14 @@ export function SharedSchedule() {
 				}
 				setTakenDoses(taken);
 				setAutomaticTakenDoses(automatic);
+				setMainAppTakenDoses(mainAppTaken);
 				setDismissedDoses(dismissed);
 				setSharedJournalDoseIdsWithNotes(journalDoseIds);
 			}
 		} catch {
 			// Keep the current optimistic/shared state on transient read errors.
 		}
-	}, [token]);
+	}, [data?.takenBy, token]);
 
 	useEffect(() => {
 		if (!token) return;
@@ -602,12 +621,27 @@ export function SharedSchedule() {
 		isTaken: boolean;
 		isSkipped: boolean;
 		isAutomaticallyTaken: boolean;
+		isTakenInMainApp: boolean;
 		isEmpty: boolean;
+		isFuture: boolean;
 	}) => {
 		const showSharedJournalAction = Boolean(data?.allowJournalNotes);
 		const canMarkTaken = data?.allowMarkTaken !== false;
 		const canOpenSharedJournal = showSharedJournalAction && (options.isTaken || options.isSkipped);
 		const hasSharedJournalNote = sharedJournalDoseIdsWithNotes.has(options.doseId);
+		const takeBlockLabel = (() => {
+			if (options.isFuture) return t("share.actionBlocked.futureTake");
+			if (options.isTakenInMainApp) return t("share.actionBlocked.alreadyTakenMainApp");
+			if (!options.isTaken && options.isEmpty) return t("common.outOfStockTakeBlocked");
+			if (!canMarkTaken) return t("share.readOnly");
+			return null;
+		})();
+		const skipBlockLabel = (() => {
+			if (options.isFuture) return t("share.actionBlocked.futureSkip");
+			if (options.isTakenInMainApp) return t("share.actionBlocked.alreadyTakenMainApp");
+			if (!canMarkTaken) return t("share.readOnly");
+			return null;
+		})();
 		const takeButtonControl = options.isTaken ? (
 			<AppButton
 				type="button"
@@ -621,6 +655,7 @@ export function SharedSchedule() {
 					doseButtonClasses.undoTake
 				)}
 				onClick={() => undoDoseTaken(options.doseId)}
+				disabled={Boolean(takeBlockLabel)}
 			>
 				{options.isAutomaticallyTaken && (
 					<AppTooltip label={t("tooltips.automaticTaken")}>
@@ -647,7 +682,7 @@ export function SharedSchedule() {
 					options.isEmpty && doseButtonClasses.outOfStock
 				)}
 				onClick={() => markDoseTaken(options.doseId)}
-				disabled={options.isEmpty || !canMarkTaken}
+				disabled={Boolean(takeBlockLabel)}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
 				{options.isEmpty ? (
@@ -657,26 +692,15 @@ export function SharedSchedule() {
 				)}
 			</AppButton>
 		);
-		const takeButton =
-			!options.isTaken && options.isEmpty ? (
-				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
-					<span
-						className={cx("shared-dose-action-take", doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}
-					>
-						{takeButtonControl}
-					</span>
-				</AppTooltip>
-			) : !canMarkTaken ? (
-				<AppTooltip label={t("share.readOnly")}>
-					<span
-						className={cx("shared-dose-action-take", doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}
-					>
-						{takeButtonControl}
-					</span>
-				</AppTooltip>
-			) : (
-				takeButtonControl
-			);
+		const takeButton = takeBlockLabel ? (
+			<AppTooltip label={takeBlockLabel}>
+				<span className={cx("shared-dose-action-take", doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>
+					{takeButtonControl}
+				</span>
+			</AppTooltip>
+		) : (
+			takeButtonControl
+		);
 
 		const skipButton = options.isSkipped ? (
 			<AppButton
@@ -691,6 +715,7 @@ export function SharedSchedule() {
 					doseButtonClasses.undoSkip
 				)}
 				onClick={() => undoDoseSkipped(options.doseId)}
+				disabled={Boolean(skipBlockLabel)}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.undoSkip")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
@@ -707,13 +732,13 @@ export function SharedSchedule() {
 					doseButtonClasses.skip
 				)}
 				onClick={() => markDoseSkipped(options.doseId)}
-				disabled={options.isTaken || !canMarkTaken}
+				disabled={options.isTaken || Boolean(skipBlockLabel)}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.skip")}</span>
 			</AppButton>
 		);
-		const skipButtonWithReadOnlyTooltip = !canMarkTaken ? (
-			<AppTooltip label={t("share.readOnly")}>
+		const skipButtonWithTooltip = skipBlockLabel ? (
+			<AppTooltip label={skipBlockLabel}>
 				<span className={cx("shared-dose-action-skip", doseButtonClasses.tooltipTarget, doseButtonClasses.skipAction)}>
 					{skipButton}
 				</span>
@@ -765,13 +790,14 @@ export function SharedSchedule() {
 		return (
 			<>
 				{takeButton}
-				{skipButtonWithReadOnlyTooltip}
+				{skipButtonWithTooltip}
 				{journalButton}
 			</>
 		);
 	};
 
 	const isDoseTakenAutomatically = (doseId: string) => automaticTakenDoses.has(doseId);
+	const isDoseTakenInMainApp = (doseId: string) => mainAppTakenDoses.has(doseId);
 
 	useEffect(() => {
 		async function fetchData() {
@@ -1459,7 +1485,9 @@ export function SharedSchedule() {
 																							isTaken,
 																							isSkipped,
 																							isAutomaticallyTaken,
+																							isTakenInMainApp: isDoseTakenInMainApp(dose.id),
 																							isEmpty,
+																							isFuture: false,
 																						})}
 																					</div>
 																				</div>
@@ -1669,7 +1697,9 @@ export function SharedSchedule() {
 																							isTaken,
 																							isSkipped,
 																							isAutomaticallyTaken,
+																							isTakenInMainApp: isDoseTakenInMainApp(dose.id),
 																							isEmpty,
+																							isFuture: false,
 																						})}
 																					</div>
 																				</div>
@@ -1860,7 +1890,9 @@ export function SharedSchedule() {
 																							isTaken,
 																							isSkipped,
 																							isAutomaticallyTaken,
-																							isEmpty: true,
+																							isTakenInMainApp: isDoseTakenInMainApp(dose.id),
+																							isEmpty,
+																							isFuture: true,
 																						})}
 																					</div>
 																				</div>

--- a/frontend/src/hooks/useDoses.ts
+++ b/frontend/src/hooks/useDoses.ts
@@ -260,6 +260,8 @@ export function useDoses(options: UseDosesOptions = {}): UseDosesReturn {
 					failureCode = await getErrorCode(response);
 					if (failureCode === "OUT_OF_STOCK") {
 						showFeedback({ message: t("common.outOfStockTakeBlocked"), tone: "error" });
+					} else if (failureCode === "FUTURE_DOSE") {
+						showFeedback({ message: t("dose.actionBlocked.futureTake"), tone: "error" });
 					}
 					throw new Error(`HTTP ${response.status}`);
 				}
@@ -345,6 +347,7 @@ export function useDoses(options: UseDosesOptions = {}): UseDosesReturn {
 			clearTakenDoseState(doseId);
 
 			let failureStatus: number | null = null;
+			let failureCode: string | null = null;
 			try {
 				const response = await authFetch("/api/doses/skip", {
 					method: "POST",
@@ -353,11 +356,16 @@ export function useDoses(options: UseDosesOptions = {}): UseDosesReturn {
 				});
 				if (!response.ok) {
 					failureStatus = response.status;
+					failureCode = await getErrorCode(response);
+					if (failureCode === "FUTURE_DOSE") {
+						showFeedback({ message: t("dose.actionBlocked.futureSkip"), tone: "error" });
+					}
 					throw new Error(`HTTP ${response.status}`);
 				}
 			} catch (error) {
 				log.warn("[useDoses] mark dose skipped failed", {
 					status: failureStatus,
+					code: failureCode,
 					error: getErrorMessage(error),
 				});
 				setDismissedDoses((prev) => {
@@ -379,8 +387,11 @@ export function useDoses(options: UseDosesOptions = {}): UseDosesReturn {
 			authFetch,
 			clearTakenDoseState,
 			dismissedDoses,
+			getErrorCode,
 			loadTakenDoses,
 			restoreTakenDoseState,
+			showFeedback,
+			t,
 			takenDoseSources,
 			takenDoseTimestamps,
 			takenDoses,

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -638,11 +638,15 @@
   "dose": {
     "takenBy": "eingenommen von",
     "markAsTaken": "Als eingenommen markieren",
-  "take": "Nehmen",
-  "skip": "Überspringen",
-  "markAsSkipped": "Als übersprungen markieren",
-  "undoTake": "Nehmen rückgängig",
-  "undoSkip": "Überspringen rückgängig"
+    "take": "Nehmen",
+    "skip": "Überspringen",
+    "markAsSkipped": "Als übersprungen markieren",
+    "undoTake": "Nehmen rückgängig",
+    "undoSkip": "Überspringen rückgängig",
+    "actionBlocked": {
+      "futureTake": "Zukuenftige Einnahmen koennen noch nicht als eingenommen markiert werden.",
+      "futureSkip": "Zukuenftige Einnahmen koennen noch nicht uebersprungen werden."
+    }
   },
   "auth": {
     "login": "Anmelden",
@@ -772,6 +776,11 @@
     "allowJournalNotes": "Diesem geteilten Link das Anzeigen und Bearbeiten von Journal-Notizen erlauben",
     "markTakenEnabled": "Dosisaktionen erlaubt",
     "readOnly": "Nur Lesen",
+    "actionBlocked": {
+      "futureTake": "Zukuenftige Einnahmen koennen noch nicht als eingenommen markiert werden.",
+      "futureSkip": "Zukuenftige Einnahmen koennen noch nicht uebersprungen werden.",
+      "alreadyTakenMainApp": "Diese Einnahme wurde bereits in der Haupt-App als eingenommen markiert."
+    },
     "journalNotesEnabled": "Journal anzeigen/bearbeiten erlaubt",
     "expiryNever": "Laeuft nicht ab",
     "neverExpiresWarning": "Links ohne Ablauf bleiben gueltig, bis du sie widerrufst oder neu generierst.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -638,11 +638,15 @@
   "dose": {
     "takenBy": "taken by",
     "markAsTaken": "Mark as taken",
-  "take": "Take",
-  "skip": "Skip",
-  "markAsSkipped": "Mark as skipped",
-  "undoTake": "Undo take",
-  "undoSkip": "Undo skip"
+    "take": "Take",
+    "skip": "Skip",
+    "markAsSkipped": "Mark as skipped",
+    "undoTake": "Undo take",
+    "undoSkip": "Undo skip",
+    "actionBlocked": {
+      "futureTake": "Future intakes cannot be marked as taken yet.",
+      "futureSkip": "Future intakes cannot be skipped yet."
+    }
   },
   "auth": {
     "login": "Login",
@@ -772,6 +776,11 @@
     "allowJournalNotes": "Allow this shared link to view and edit journal notes",
     "markTakenEnabled": "Dose actions enabled",
     "readOnly": "Read-only",
+    "actionBlocked": {
+      "futureTake": "Future intakes cannot be marked as taken yet.",
+      "futureSkip": "Future intakes cannot be skipped yet.",
+      "alreadyTakenMainApp": "This intake was already marked as taken in the main app."
+    },
     "journalNotesEnabled": "Journal view/edit enabled",
     "expiryNever": "Never expires",
     "neverExpiresWarning": "Never-expiring links stay valid until you revoke or regenerate them.",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -461,8 +461,15 @@ export function DashboardPage() {
 		isSkipped: boolean;
 		isAutomaticallyTaken: boolean;
 		isEmpty: boolean;
+		isFuture: boolean;
 	}) => {
 		const journalUnavailable = !(options.isTaken || options.isSkipped);
+		const takeBlockLabel = (() => {
+			if (options.isFuture) return t("dose.actionBlocked.futureTake");
+			if (!options.isTaken && options.isEmpty) return t("common.outOfStockTakeBlocked");
+			return null;
+		})();
+		const skipBlockLabel = options.isFuture ? t("dose.actionBlocked.futureSkip") : null;
 		const takeButtonControl = options.isTaken ? (
 			<AppButton
 				type="button"
@@ -474,6 +481,7 @@ export function DashboardPage() {
 					doseButtonClasses.undoTake
 				)}
 				onClick={() => undoDoseTaken(options.doseId)}
+				disabled={Boolean(takeBlockLabel)}
 			>
 				{options.isAutomaticallyTaken && (
 					<AppTooltip label={t("tooltips.automaticTaken")}>
@@ -498,7 +506,7 @@ export function DashboardPage() {
 					options.isEmpty && doseButtonClasses.outOfStock
 				)}
 				onClick={() => markDoseTaken(options.doseId)}
-				disabled={options.isEmpty || options.isSkipped}
+				disabled={Boolean(takeBlockLabel) || options.isSkipped}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
 				{options.isEmpty ? (
@@ -508,14 +516,13 @@ export function DashboardPage() {
 				)}
 			</AppButton>
 		);
-		const takeButton =
-			!options.isTaken && options.isEmpty ? (
-				<AppTooltip label={t("common.outOfStockTakeBlocked")}>
-					<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
-				</AppTooltip>
-			) : (
-				takeButtonControl
-			);
+		const takeButton = takeBlockLabel ? (
+			<AppTooltip label={takeBlockLabel}>
+				<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.takeAction)}>{takeButtonControl}</span>
+			</AppTooltip>
+		) : (
+			takeButtonControl
+		);
 
 		const journalButtonControl = (
 			<AppButton
@@ -563,6 +570,7 @@ export function DashboardPage() {
 					doseButtonClasses.undoSkip
 				)}
 				onClick={() => undoDoseSkipped(options.doseId)}
+				disabled={Boolean(skipBlockLabel)}
 			>
 				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
@@ -573,16 +581,23 @@ export function DashboardPage() {
 				size="sm"
 				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
-				disabled={options.isTaken}
+				disabled={options.isTaken || Boolean(skipBlockLabel)}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.skip")}</span>
 			</AppButton>
+		);
+		const skipButtonWithTooltip = skipBlockLabel ? (
+			<AppTooltip label={skipBlockLabel}>
+				<span className={cx(doseButtonClasses.tooltipTarget, doseButtonClasses.skipAction)}>{skipButton}</span>
+			</AppTooltip>
+		) : (
+			skipButton
 		);
 
 		return (
 			<>
 				{takeButton}
-				{skipButton}
+				{skipButtonWithTooltip}
 				{journalButton}
 			</>
 		);
@@ -1481,6 +1496,7 @@ export function DashboardPage() {
 																									isSkipped,
 																									isAutomaticallyTaken,
 																									isEmpty,
+																									isFuture: false,
 																								})}
 																							</div>
 																						);
@@ -1815,6 +1831,7 @@ export function DashboardPage() {
 																									isSkipped,
 																									isAutomaticallyTaken,
 																									isEmpty,
+																									isFuture: false,
 																								})}
 																							</div>
 																						);
@@ -2088,7 +2105,8 @@ export function DashboardPage() {
 																									isTaken,
 																									isSkipped,
 																									isAutomaticallyTaken,
-																									isEmpty: true,
+																									isEmpty,
+																									isFuture: true,
 																								})}
 																							</div>
 																						);

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -159,6 +159,25 @@ function createSharedDataWithTodayDose(referenceNow: Date) {
 	};
 }
 
+function createSharedDataWithFutureDose(referenceNow: Date) {
+	const data = createSharedDataWithTodayDose(referenceNow);
+	const scheduledAt = new Date(referenceNow);
+	scheduledAt.setDate(scheduledAt.getDate() + 1);
+	scheduledAt.setHours(9, 0, 0, 0);
+	const dateOnlyMs = new Date(scheduledAt.getFullYear(), scheduledAt.getMonth(), scheduledAt.getDate()).getTime();
+	const start = `${scheduledAt.getFullYear()}-${String(scheduledAt.getMonth() + 1).padStart(2, "0")}-${String(
+		scheduledAt.getDate()
+	).padStart(
+		2,
+		"0"
+	)}T${String(scheduledAt.getHours()).padStart(2, "0")}:${String(scheduledAt.getMinutes()).padStart(2, "0")}:00`;
+
+	data.automaticDoseId = `1-0-${dateOnlyMs}`;
+	data.medications[0].blisters[0].start = start;
+	data.medications[0].intakes[0].start = start;
+	return data;
+}
+
 function createSharedDoseFetchMock(options: {
 	token?: string;
 	sharedData: ReturnType<typeof createSharedDataWithTodayDose>;
@@ -166,6 +185,7 @@ function createSharedDoseFetchMock(options: {
 		doseId: string;
 		skipped?: boolean;
 		dismissed?: boolean;
+		markedBy?: string | null;
 		takenSource?: string;
 		hasJournalNote?: boolean;
 	}>;
@@ -292,6 +312,12 @@ function createSharedDoseFetchMock(options: {
 	});
 
 	return { fetchMock, requests, getDoses: () => Array.from(doseState.values()) };
+}
+
+function openButtonTooltip(button: HTMLElement) {
+	const target = button.closest("span");
+	expect(target).not.toBeNull();
+	fireEvent.touchStart(target as HTMLElement);
 }
 
 describe("SharedSchedule", () => {
@@ -670,6 +696,90 @@ describe("SharedSchedule", () => {
 			});
 			expect(screen.getByRole("button", { name: "dose.undoSkip" })).toBeInTheDocument();
 		});
+	});
+
+	it("explains that future shared doses cannot be taken or skipped", async () => {
+		const referenceNow = new Date();
+		referenceNow.setHours(12, 0, 0, 0);
+		vi.spyOn(Date, "now").mockReturnValue(referenceNow.getTime());
+		const sharedData = createSharedDataWithFutureDose(referenceNow);
+		const { fetchMock, requests } = createSharedDoseFetchMock({ sharedData });
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		renderSharedSchedule("/share/token-123");
+
+		await waitFor(() => {
+			expect(screen.getByText("dashboard.schedules.showFutureDays")).toBeInTheDocument();
+		});
+
+		const futureToggle = screen.getByText("dashboard.schedules.showFutureDays").closest(".future-days-toggle");
+		expect(futureToggle).not.toBeNull();
+		fireEvent.click(futureToggle as HTMLElement);
+		const futureDayToggle = document.querySelector(".day-block:not(.today) .day-divider.clickable");
+		expect(futureDayToggle).not.toBeNull();
+		fireEvent.click(futureDayToggle as HTMLElement);
+
+		const takeButton = await screen.findByRole("button", { name: "dose.take" });
+		const skipButton = screen.getByRole("button", { name: "dose.skip" });
+		expect(takeButton).toBeDisabled();
+		expect(skipButton).toBeDisabled();
+		expect(document.querySelector(".dose-item.future.med-empty")).toBeNull();
+
+		fireEvent.click(takeButton);
+		fireEvent.click(skipButton);
+		expect(requests.some((request) => request.method === "POST")).toBe(false);
+
+		openButtonTooltip(takeButton);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("share.actionBlocked.futureTake");
+
+		fireEvent.touchMove(takeButton.closest("span") as HTMLElement);
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		openButtonTooltip(skipButton);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("share.actionBlocked.futureSkip");
+	});
+
+	it("explains that doses already taken in the main app cannot be changed from the shared link", async () => {
+		const referenceNow = new Date();
+		referenceNow.setHours(12, 0, 0, 0);
+		vi.spyOn(Date, "now").mockReturnValue(referenceNow.getTime());
+		const sharedData = createSharedDataWithTodayDose(referenceNow);
+		const { fetchMock, requests } = createSharedDoseFetchMock({
+			sharedData,
+			initialDoses: [{ doseId: sharedData.automaticDoseId, markedBy: null, takenSource: "manual" }],
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		renderSharedSchedule("/share/token-123");
+		await waitFor(() => {
+			expect(document.querySelector(".day-block.today .day-divider.clickable")).toBeInTheDocument();
+		});
+
+		fireEvent.click(document.querySelector(".day-block.today .day-divider.clickable") as HTMLElement);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "common.undo" })).toBeDisabled();
+			expect(screen.getByRole("button", { name: "dose.skip" })).toBeDisabled();
+		});
+
+		const undoButton = screen.getByRole("button", { name: "common.undo" });
+		const skipButton = screen.getByRole("button", { name: "dose.skip" });
+		fireEvent.click(undoButton);
+		fireEvent.click(skipButton);
+		expect(requests.some((request) => request.method === "DELETE" || request.method === "POST")).toBe(false);
+
+		openButtonTooltip(undoButton);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("share.actionBlocked.alreadyTakenMainApp");
+
+		fireEvent.touchMove(undoButton.closest("span") as HTMLElement);
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		openButtonTooltip(skipButton);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("share.actionBlocked.alreadyTakenMainApp");
 	});
 
 	it("undoes a skipped shared dose via the delete skip endpoint", async () => {

--- a/frontend/src/test/hooks/useDoses.test.ts
+++ b/frontend/src/test/hooks/useDoses.test.ts
@@ -359,6 +359,64 @@ describe("useDoses", () => {
 		});
 	});
 
+	it("shows a future-dose alert and reverts the optimistic take", async () => {
+		(global.fetch as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ doses: [] }) })
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 409,
+				json: () => Promise.resolve({ code: "FUTURE_DOSE" }),
+			})
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ doses: [] }) });
+
+		const { result } = renderHook(() => useDoses());
+
+		await waitFor(() => {
+			expect(result.current.takenDoses.size).toBe(0);
+		});
+
+		await act(async () => {
+			await result.current.markDoseTaken("future-dose");
+		});
+
+		await waitFor(() => {
+			expect(result.current.takenDoses.has("future-dose")).toBe(false);
+		});
+		expect(feedbackMock.showFeedback).toHaveBeenCalledWith({
+			message: "dose.actionBlocked.futureTake",
+			tone: "error",
+		});
+	});
+
+	it("shows a future-dose alert and reverts the optimistic skip", async () => {
+		(global.fetch as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ doses: [] }) })
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 409,
+				json: () => Promise.resolve({ code: "FUTURE_DOSE" }),
+			})
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ doses: [] }) });
+
+		const { result } = renderHook(() => useDoses());
+
+		await waitFor(() => {
+			expect(result.current.dismissedDoses.size).toBe(0);
+		});
+
+		await act(async () => {
+			await result.current.markDoseSkipped("future-dose");
+		});
+
+		await waitFor(() => {
+			expect(result.current.dismissedDoses.has("future-dose")).toBe(false);
+		});
+		expect(feedbackMock.showFeedback).toHaveBeenCalledWith({
+			message: "dose.actionBlocked.futureSkip",
+			tone: "error",
+		});
+	});
+
 	it("undoDoseTaken encodes special characters in dose ID", async () => {
 		(global.fetch as ReturnType<typeof vi.fn>)
 			.mockResolvedValueOnce({

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -156,6 +156,12 @@ function getRouteDateKey(value: Date): string {
 	return `${year}-${month}-${day}`;
 }
 
+function openButtonTooltip(button: HTMLElement) {
+	const target = button.closest("span");
+	expect(target).not.toBeNull();
+	fireEvent.touchStart(target as HTMLElement);
+}
+
 // Default mock factory
 const createMockAppContext = (overrides = {}) => ({
 	meds: [],
@@ -1655,6 +1661,72 @@ describe("DashboardPage dose interactions", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "dose.take" }));
 		expect(markDoseTaken).toHaveBeenCalled();
+	});
+
+	it("explains that future dashboard doses cannot be taken or skipped", async () => {
+		const markDoseTaken = vi.fn();
+		const markDoseSkipped = vi.fn();
+		const futureAt = new Date();
+		futureAt.setDate(futureAt.getDate() + 1);
+		futureAt.setHours(9, 0, 0, 0);
+		const futureDayStart = new Date(futureAt.getFullYear(), futureAt.getMonth(), futureAt.getDate()).getTime();
+		const doseId = `1-0-${futureDayStart}`;
+		const futureDay = [
+			{
+				dateStr: "Tomorrow",
+				date: futureAt,
+				isPast: false,
+				meds: [
+					{
+						medName: "Aspirin",
+						total: 1,
+						doses: [{ id: doseId, timeStr: "09:00", when: futureAt.getTime(), usage: 1, takenBy: ["John"] }],
+						lastWhen: futureAt.getTime(),
+					},
+				],
+			},
+		];
+		mockContextValue = createMockAppContext({
+			meds: mockMeds,
+			coverage: mockCoverage,
+			coverageByMed: { Aspirin: mockCoverage.all[0] },
+			depletionByMed: { Aspirin: Date.now() + 25 * 86400000 },
+			futureDays: futureDay,
+			showFutureDays: true,
+			manuallyExpandedDays: new Set(["Tomorrow"]),
+			markDoseTaken,
+			markDoseSkipped,
+			undoDoseSkipped: vi.fn(),
+			getDoseId: vi.fn((id: string, person: string | null) => (person ? `${id}-${person}` : id)),
+		});
+
+		render(
+			<MemoryRouter>
+				<DashboardPage />
+			</MemoryRouter>
+		);
+
+		const takeButton = screen.getByRole("button", { name: "dose.take" });
+		const skipButton = screen.getByRole("button", { name: "dose.skip" });
+		expect(takeButton).toBeDisabled();
+		expect(skipButton).toBeDisabled();
+		expect(document.querySelector(".dose-item.future.med-empty")).toBeNull();
+
+		fireEvent.click(takeButton);
+		fireEvent.click(skipButton);
+		expect(markDoseTaken).not.toHaveBeenCalled();
+		expect(markDoseSkipped).not.toHaveBeenCalled();
+
+		openButtonTooltip(takeButton);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("dose.actionBlocked.futureTake");
+
+		fireEvent.touchMove(takeButton.closest("span") as HTMLElement);
+		await waitFor(() => {
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+
+		openButtonTooltip(skipButton);
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("dose.actionBlocked.futureSkip");
 	});
 
 	it("calls undoDoseTaken when clicking undo button", () => {


### PR DESCRIPTION
Closes #871

## Summary

- Reject future take/skip/dismiss mutations for owner dose routes before any stock or tracking state changes.
- Reject future shared-link take/skip mutations and shared-link edits to doses already marked in the main app.
- Show accurate disabled action messages for future intakes and main-app-taken shared doses.

## Validation

- `npm --prefix backend run check`
- `npm --prefix frontend run check`
- `npm --prefix backend run test:run -- src/test/doses.test.ts src/test/share-hardening.test.ts`
- `npm --prefix frontend run test:run -- src/test/components/SharedSchedule.test.tsx src/test/hooks/useDoses.test.ts src/test/pages/DashboardPage.test.tsx`