### PR TITLE
feat: add mobile route swipe navigation

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { authFile, navigateTo, test } from "./fixtures";
 
 /**
@@ -9,6 +9,24 @@ import { authFile, navigateTo, test } from "./fixtures";
  */
 test.describe("Dashboard", () => {
 	test.use({ storageState: authFile });
+
+	async function swipeMainRoute(page: Page, fromX: number, toX: number) {
+		const surface = page.getByTestId("main-route-swipe-surface");
+		const y = 360;
+		for (const point of [
+			{ type: "touchstart", clientX: fromX, clientY: y },
+			{ type: "touchmove", clientX: toX, clientY: y + 6 },
+			{ type: "touchend", clientX: toX, clientY: y + 6 },
+		] as const) {
+			await surface.evaluate((element, eventPoint) => {
+				const event = new Event(eventPoint.type, { bubbles: true, cancelable: true });
+				const touch = { clientX: eventPoint.clientX, clientY: eventPoint.clientY };
+				Object.defineProperty(event, "touches", { value: eventPoint.type === "touchend" ? [] : [touch] });
+				Object.defineProperty(event, "changedTouches", { value: [touch] });
+				element.dispatchEvent(event);
+			}, point);
+		}
+	}
 
 	test("should display the dashboard page with header", async ({ page }) => {
 		await navigateTo(page, "/dashboard");
@@ -51,6 +69,39 @@ test.describe("Dashboard", () => {
 			.getByRole("button", { name: /Planner/i })
 			.click();
 		await expect(page).toHaveURL(/\/planner/);
+	});
+
+	test.describe("mobile swipe navigation", () => {
+		test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+		test("swipes between Dashboard, Medications, and Planner", async ({ page }) => {
+			await page.addInitScript(() => window.localStorage.removeItem("medassist.mainRouteSwipeHintDismissed"));
+			await navigateTo(page, "/dashboard");
+			await expect(page).toHaveURL(/\/dashboard/);
+			await expect(page.getByTestId("main-swipe-hint")).toBeVisible();
+			await page.getByTestId("main-swipe-hint-dismiss").tap();
+			await expect(page.getByTestId("main-swipe-hint")).toBeHidden();
+			await expect
+				.poll(() => page.evaluate(() => window.localStorage.getItem("medassist.mainRouteSwipeHintDismissed")))
+				.toBe("true");
+
+			await swipeMainRoute(page, 340, 80);
+			await expect(page).toHaveURL(/\/medications/);
+			await expect(page.getByTestId("main-nav").getByRole("button", { name: /Medications/i })).toHaveAttribute(
+				"aria-current",
+				"page"
+			);
+
+			await swipeMainRoute(page, 340, 80);
+			await expect(page).toHaveURL(/\/planner/);
+			await expect(page.getByTestId("main-nav").getByRole("button", { name: /Planner/i })).toHaveAttribute(
+				"aria-current",
+				"page"
+			);
+
+			await swipeMainRoute(page, 80, 340);
+			await expect(page).toHaveURL(/\/medications/);
+		});
 	});
 
 	test("should display medication overview section", async ({ page }) => {

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -48,6 +48,23 @@
 	padding: 0 var(--page-pad-x) 1.5rem;
 }
 
+.routeSwipeSurface {
+	min-width: 0;
+}
+
+.mainSwipeHint {
+	display: none;
+}
+
+.mainSwipeHintClose {
+	flex: 0 0 auto;
+	color: var(--mantine-other-text-muted);
+}
+
+.mainSwipeHintClose:hover {
+	color: var(--mantine-other-text-primary);
+}
+
 .routeTransitionMask {
 	position: fixed;
 	inset: 0;
@@ -66,5 +83,35 @@
 @media (max-width: 700px) {
 	.page {
 		--page-pad-x: 0.4rem;
+	}
+
+	.routeSwipeSurface {
+		touch-action: pan-y;
+	}
+
+	.mainSwipeHint {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.35rem;
+		width: fit-content;
+		max-width: calc(100% - 1rem);
+		margin: 0.65rem auto 0.2rem;
+		padding: 0.28rem 0.35rem 0.28rem 0.7rem;
+		border: 1px solid color-mix(in srgb, var(--mantine-other-border-primary) 72%, transparent);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--mantine-other-bg-tertiary) 76%, transparent);
+		color: var(--mantine-other-text-muted);
+		font-size: 0.75rem;
+		font-weight: 650;
+		line-height: 1.35;
+		text-align: center;
+	}
+
+	.mainSwipeHint span {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { Alert, Box, Center, Paper, Stack, Text, Title } from "@mantine/core";
+import { ActionIcon, Alert, Box, Center, Paper, Stack, Text, Title } from "@mantine/core";
+import { X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
@@ -6,7 +7,14 @@ import classes from "./App.module.css";
 import "./AppSurfaces.css";
 import { AppHeader } from "./components/AppHeader";
 import { AuthPage, AuthProvider, useAuth } from "./components/Auth";
-import { AppProvider, FeedbackProvider, UnsavedChangesProvider, useAppContext, useShareContext } from "./context";
+import {
+	AppProvider,
+	FeedbackProvider,
+	UnsavedChangesProvider,
+	useAppContext,
+	useShareContext,
+	useUnsavedChanges,
+} from "./context";
 import { useModalHistory } from "./hooks/useModalHistory";
 import { useScrollLock } from "./hooks/useScrollLock";
 import { AppButton } from "./ui/primitives/AppButton";
@@ -40,6 +48,59 @@ declare const __APP_VERSION__: string;
 export const FRONTEND_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
 const GITHUB_REPO = "DanielVolz/medassist-ng";
 export const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
+
+const MAIN_SWIPE_ROUTES = ["/dashboard", "/medications", "/planner"] as const;
+const MAIN_SWIPE_HINT_STORAGE_KEY = "medassist.mainRouteSwipeHintDismissed";
+
+function getMainSwipeRouteIndex(pathname: string): number {
+	return (MAIN_SWIPE_ROUTES as readonly string[]).indexOf(pathname);
+}
+
+function isMobileRouteSwipeEnabled(): boolean {
+	if (typeof window === "undefined") return false;
+	return window.matchMedia?.("(max-width: 700px)").matches ?? window.innerWidth <= 700;
+}
+
+function shouldShowInitialMainSwipeHint() {
+	if (typeof window === "undefined") return true;
+	try {
+		return window.localStorage.getItem(MAIN_SWIPE_HINT_STORAGE_KEY) !== "true";
+	} catch {
+		return true;
+	}
+}
+
+function persistMainSwipeHintDismissed() {
+	try {
+		window.localStorage.setItem(MAIN_SWIPE_HINT_STORAGE_KEY, "true");
+	} catch {
+		// Non-critical: the hint can still be dismissed for the current render.
+	}
+}
+
+function shouldIgnoreRouteSwipeTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof Element)) return true;
+
+	return Boolean(
+		target.closest(
+			[
+				"input",
+				"textarea",
+				"select",
+				"button",
+				"a",
+				'[role="button"]',
+				'[role="link"]',
+				'[role="tab"]',
+				'[role="dialog"]',
+				'[contenteditable="true"]',
+				"[data-app-swipe-ignore]",
+				".mantine-Menu-dropdown",
+				".mantine-Modal-root",
+			].join(", ")
+		)
+	);
+}
 
 function RouteLoadingFallback() {
 	const { t } = useTranslation();
@@ -167,8 +228,10 @@ function AppRouter() {
 // =============================================================================
 
 function AppContent() {
+	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const location = useLocation();
+	const { confirmNavigation } = useUnsavedChanges();
 	// Get shared state from AppContext
 	const ctx = useAppContext();
 	const shareCtx = useShareContext();
@@ -256,8 +319,17 @@ function AppContent() {
 	const [showProfile, setShowProfile] = useState(false);
 	const [showAbout, setShowAbout] = useState(false);
 	const [routeTransitionMaskActive, setRouteTransitionMaskActive] = useState(false);
+	const [showMainSwipeHint, setShowMainSwipeHint] = useState(shouldShowInitialMainSwipeHint);
+	const [mainSwipeHintViewport, setMainSwipeHintViewport] = useState(isMobileRouteSwipeEnabled);
 	const routeTransitionMinEndRef = useRef(0);
 	const routeTransitionFallbackTimerRef = useRef<number | null>(null);
+	const routeSwipeSurfaceRef = useRef<HTMLDivElement | null>(null);
+	const routeSwipeStartRef = useRef<{ x: number; y: number } | null>(null);
+	const routeSwipeAxisRef = useRef<"x" | "y" | null>(null);
+	const dismissMainSwipeHint = useCallback(() => {
+		setShowMainSwipeHint(false);
+		persistMainSwipeHintDismissed();
+	}, []);
 	const dismissProfile = useCallback(() => {
 		setShowProfile(false);
 	}, []);
@@ -361,6 +433,125 @@ function AppContent() {
 		)
 	);
 
+	const hasBlockingOverlay = !!(
+		selectedMed ||
+		selectedUser ||
+		showProfile ||
+		showAbout ||
+		showShareDialog ||
+		showRefillModal ||
+		showEditStockModal ||
+		showImageLightbox ||
+		scheduleLightboxImage ||
+		routeTransitionMaskActive
+	);
+	const routeSupportsMainSwipe = getMainSwipeRouteIndex(location.pathname) >= 0;
+	const shouldRenderMainSwipeHint =
+		showMainSwipeHint && mainSwipeHintViewport && routeSupportsMainSwipe && !hasBlockingOverlay;
+
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+
+		const mediaQuery = window.matchMedia?.("(max-width: 700px)");
+		const updateViewport = () => {
+			setMainSwipeHintViewport(mediaQuery?.matches ?? window.innerWidth <= 700);
+		};
+
+		updateViewport();
+		if (mediaQuery?.addEventListener) {
+			mediaQuery.addEventListener("change", updateViewport);
+			return () => mediaQuery.removeEventListener("change", updateViewport);
+		}
+
+		window.addEventListener("resize", updateViewport);
+		return () => window.removeEventListener("resize", updateViewport);
+	}, []);
+
+	useEffect(() => {
+		const swipeSurface = routeSwipeSurfaceRef.current;
+		if (!swipeSurface) return;
+
+		const AXIS_LOCK_THRESHOLD = 8;
+		const touchListenerOptions = { capture: true };
+
+		function resetSwipe() {
+			routeSwipeStartRef.current = null;
+			routeSwipeAxisRef.current = null;
+		}
+
+		function onTouchStart(e: TouchEvent) {
+			if (e.touches.length !== 1 || hasBlockingOverlay || !isMobileRouteSwipeEnabled()) {
+				resetSwipe();
+				return;
+			}
+			if (getMainSwipeRouteIndex(location.pathname) === -1 || shouldIgnoreRouteSwipeTarget(e.target)) {
+				resetSwipe();
+				return;
+			}
+
+			const touch = e.touches[0];
+			routeSwipeStartRef.current = { x: touch.clientX, y: touch.clientY };
+			routeSwipeAxisRef.current = null;
+		}
+
+		function onTouchMove(e: TouchEvent) {
+			if (!routeSwipeStartRef.current || e.touches.length !== 1) return;
+
+			const touch = e.touches[0];
+			const dx = touch.clientX - routeSwipeStartRef.current.x;
+			const dy = touch.clientY - routeSwipeStartRef.current.y;
+			const ax = Math.abs(dx);
+			const ay = Math.abs(dy);
+
+			if (!routeSwipeAxisRef.current) {
+				if (ax < AXIS_LOCK_THRESHOLD && ay < AXIS_LOCK_THRESHOLD) return;
+				routeSwipeAxisRef.current = ax >= ay ? "x" : "y";
+			}
+
+			if (routeSwipeAxisRef.current === "x") {
+				e.preventDefault();
+			}
+		}
+
+		function onTouchEnd(e: TouchEvent) {
+			if (!routeSwipeStartRef.current || e.changedTouches.length !== 1) {
+				resetSwipe();
+				return;
+			}
+
+			if (routeSwipeAxisRef.current === "x") {
+				const touch = e.changedTouches[0];
+				const dx = touch.clientX - routeSwipeStartRef.current.x;
+				const surfaceWidth = routeSwipeSurfaceRef.current?.clientWidth || window.innerWidth || 360;
+				const minSwipe = Math.max(64, surfaceWidth * 0.16);
+				if (Math.abs(dx) >= minSwipe) {
+					const direction = dx < 0 ? 1 : -1;
+					const idx = getMainSwipeRouteIndex(location.pathname);
+					const next = Math.min(Math.max(idx + direction, 0), MAIN_SWIPE_ROUTES.length - 1);
+					if (idx >= 0 && next !== idx) {
+						void (async () => {
+							if (await confirmNavigation()) {
+								navigate(MAIN_SWIPE_ROUTES[next]);
+							}
+						})();
+					}
+				}
+			}
+			resetSwipe();
+		}
+
+		swipeSurface.addEventListener("touchstart", onTouchStart, { ...touchListenerOptions, passive: true });
+		swipeSurface.addEventListener("touchmove", onTouchMove, { ...touchListenerOptions, passive: false });
+		swipeSurface.addEventListener("touchend", onTouchEnd, { ...touchListenerOptions, passive: true });
+		swipeSurface.addEventListener("touchcancel", resetSwipe, { ...touchListenerOptions, passive: true });
+		return () => {
+			swipeSurface.removeEventListener("touchstart", onTouchStart, touchListenerOptions);
+			swipeSurface.removeEventListener("touchmove", onTouchMove, touchListenerOptions);
+			swipeSurface.removeEventListener("touchend", onTouchEnd, touchListenerOptions);
+			swipeSurface.removeEventListener("touchcancel", resetSwipe, touchListenerOptions);
+		};
+	}, [confirmNavigation, hasBlockingOverlay, location.pathname, navigate]);
+
 	// Update selectedMed when meds change (e.g., after refill)
 	useEffect(() => {
 		if (selectedMed) {
@@ -463,6 +654,24 @@ function AppContent() {
 		<Box className={classes.page} component="main" data-testid="app-shell">
 			<AppHeader onOpenProfile={openProfile} onOpenAbout={openAbout} />
 
+			{shouldRenderMainSwipeHint && (
+				<div className={classes.mainSwipeHint} role="note" data-testid="main-swipe-hint">
+					<span>{t("nav.mobileSwipeHint")}</span>
+					<ActionIcon
+						type="button"
+						aria-label={t("nav.dismissSwipeHint")}
+						className={classes.mainSwipeHintClose}
+						color="gray"
+						data-testid="main-swipe-hint-dismiss"
+						onClick={dismissMainSwipeHint}
+						size="sm"
+						variant="subtle"
+					>
+						<X size={14} aria-hidden="true" />
+					</ActionIcon>
+				</div>
+			)}
+
 			{/* Profile Modal */}
 			{showProfile && (
 				<Suspense fallback={null}>
@@ -477,22 +686,24 @@ function AppContent() {
 				</Suspense>
 			)}
 
-			<Suspense fallback={<RouteLoadingFallback />}>
-				<Routes>
-					<Route path="/" element={<Navigate to={{ pathname: "/dashboard", search: location.search }} replace />} />
-					<Route path="/dashboard" element={<DashboardPage />} />
+			<div ref={routeSwipeSurfaceRef} className={classes.routeSwipeSurface} data-testid="main-route-swipe-surface">
+				<Suspense fallback={<RouteLoadingFallback />}>
+					<Routes>
+						<Route path="/" element={<Navigate to={{ pathname: "/dashboard", search: location.search }} replace />} />
+						<Route path="/dashboard" element={<DashboardPage />} />
 
-					<Route path="/medications" element={<MedicationsPage />} />
+						<Route path="/medications" element={<MedicationsPage />} />
 
-					<Route path="/planner" element={<PlannerPage />} />
+						<Route path="/planner" element={<PlannerPage />} />
 
-					<Route path="/settings" element={<SettingsPage />} />
+						<Route path="/settings" element={<SettingsPage />} />
 
-					<Route path="/schedule" element={<SchedulePage />} />
-					{/* Catch-all: redirect unknown routes to dashboard */}
-					<Route path="*" element={<Navigate to="/dashboard" replace />} />
-				</Routes>
-			</Suspense>
+						<Route path="/schedule" element={<SchedulePage />} />
+						{/* Catch-all: redirect unknown routes to dashboard */}
+						<Route path="*" element={<Navigate to="/dashboard" replace />} />
+					</Routes>
+				</Suspense>
+			</div>
 
 			{/* Medication Detail Modal */}
 			{stockCorrectionMed && (

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -4,7 +4,9 @@
     "medications": "Medikamente",
     "planner": "Planer",
     "settings": "Einstellungen",
-    "schedule": "Zeitplan"
+    "schedule": "Zeitplan",
+    "mobileSwipeHint": "Wische seitlich, um zwischen Übersicht, Medikamente und Planer zu wechseln.",
+    "dismissSwipeHint": "Navigationshinweis ausblenden"
   },
   "header": {
     "eyebrow": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -4,7 +4,9 @@
     "medications": "Medications",
     "planner": "Planner",
     "settings": "Settings",
-    "schedule": "Schedule"
+    "schedule": "Schedule",
+    "mobileSwipeHint": "Swipe sideways to switch Dashboard, Medications, and Planner.",
+    "dismissSwipeHint": "Dismiss navigation swipe hint"
   },
   "header": {
     "eyebrow": {

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -9,6 +9,8 @@ const appTranslations: Record<string, string> = {
 	"common.initializing": "Initializing...",
 	"common.loading": "Loading...",
 	"common.retry": "Retry",
+	"nav.dismissSwipeHint": "Dismiss navigation swipe hint",
+	"nav.mobileSwipeHint": "Swipe sideways to switch Dashboard, Medications, and Planner.",
 };
 
 vi.mock("react-i18next", async () => {
@@ -43,6 +45,36 @@ let authMock: AuthStateMock = {
 
 let appContextMock: Record<string, unknown>;
 let shareContextMock: Record<string, unknown>;
+const confirmNavigationMock = vi.fn(async () => true);
+
+function dispatchTouchEvent(
+	element: HTMLElement,
+	type: "touchstart" | "touchmove" | "touchend",
+	point: { clientX: number; clientY: number }
+) {
+	const event = new Event(type, { bubbles: true, cancelable: true });
+	const touches = type === "touchend" ? [] : [point];
+	const changedTouches = [point];
+	Object.defineProperty(event, "touches", { value: touches });
+	Object.defineProperty(event, "changedTouches", { value: changedTouches });
+	fireEvent(element, event);
+}
+
+function mockMobileMediaQuery(matches: boolean) {
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: query === "(max-width: 700px)" ? matches : false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+}
 
 vi.mock("../components/AboutModal", () => ({
 	default: ({ isOpen }: { isOpen: boolean }) => (isOpen ? <div>about-modal-open</div> : null),
@@ -95,6 +127,11 @@ vi.mock("../context", async () => {
 		AppProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 		ShareContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 		UnsavedChangesProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+		useUnsavedChanges: () => ({
+			hasUnsavedChanges: false,
+			setHasUnsavedChanges: vi.fn(),
+			confirmNavigation: confirmNavigationMock,
+		}),
 		useAppContext: () => appContextMock,
 		useShareContext: () => shareContextMock,
 	};
@@ -224,6 +261,8 @@ describe("App", () => {
 		document.body.classList.remove("modal-open");
 		vi.spyOn(window.history, "back").mockImplementation(() => {});
 		vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+		confirmNavigationMock.mockClear();
+		mockMobileMediaQuery(true);
 		vi.clearAllMocks();
 	});
 
@@ -343,6 +382,61 @@ describe("App", () => {
 		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
 	});
 
+	it("shows and dismisses the mobile main route swipe hint", async () => {
+		render(
+			<MemoryRouter initialEntries={["/dashboard"]}>
+				<App />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
+		expect(screen.getByTestId("main-swipe-hint")).toHaveTextContent(
+			"Swipe sideways to switch Dashboard, Medications, and Planner."
+		);
+
+		fireEvent.click(screen.getByTestId("main-swipe-hint-dismiss"));
+
+		expect(screen.queryByTestId("main-swipe-hint")).not.toBeInTheDocument();
+		expect(window.localStorage.setItem).toHaveBeenCalledWith("medassist.mainRouteSwipeHintDismissed", "true");
+	});
+
+	it("does not show the main route swipe hint on desktop or non-swipe routes", async () => {
+		mockMobileMediaQuery(false);
+		render(
+			<MemoryRouter initialEntries={["/dashboard"]}>
+				<App />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
+		expect(screen.queryByTestId("main-swipe-hint")).not.toBeInTheDocument();
+
+		mockMobileMediaQuery(true);
+		render(
+			<MemoryRouter initialEntries={["/settings"]}>
+				<App />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByText("settings-page")).toBeInTheDocument();
+		expect(screen.queryByTestId("main-swipe-hint")).not.toBeInTheDocument();
+	});
+
+	it("does not show the main route swipe hint after it was dismissed", async () => {
+		vi.mocked(window.localStorage.getItem).mockImplementation((key) =>
+			key === "medassist.mainRouteSwipeHintDismissed" ? "true" : null
+		);
+
+		render(
+			<MemoryRouter initialEntries={["/dashboard"]}>
+				<App />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
+		expect(screen.queryByTestId("main-swipe-hint")).not.toBeInTheDocument();
+	});
+
 	it("preserves notification query params when redirecting root to dashboard", async () => {
 		const search = "?date=2026-05-06&medId=4332&doseId=4332-0-1778104500000";
 
@@ -426,5 +520,51 @@ describe("App", () => {
 		);
 
 		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
+	});
+
+	it("swipes between main app routes on mobile", async () => {
+		render(
+			<MemoryRouter initialEntries={["/dashboard"]}>
+				<App />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
+		const swipeSurface = screen.getByTestId("main-route-swipe-surface");
+
+		dispatchTouchEvent(swipeSurface, "touchstart", { clientX: 330, clientY: 260 });
+		dispatchTouchEvent(swipeSurface, "touchmove", { clientX: 110, clientY: 266 });
+		dispatchTouchEvent(swipeSurface, "touchend", { clientX: 110, clientY: 266 });
+		expect(await screen.findByText("medications-page")).toBeInTheDocument();
+
+		dispatchTouchEvent(swipeSurface, "touchstart", { clientX: 330, clientY: 260 });
+		dispatchTouchEvent(swipeSurface, "touchmove", { clientX: 110, clientY: 266 });
+		dispatchTouchEvent(swipeSurface, "touchend", { clientX: 110, clientY: 266 });
+		expect(await screen.findByText("planner-page")).toBeInTheDocument();
+
+		dispatchTouchEvent(swipeSurface, "touchstart", { clientX: 110, clientY: 260 });
+		dispatchTouchEvent(swipeSurface, "touchmove", { clientX: 330, clientY: 266 });
+		dispatchTouchEvent(swipeSurface, "touchend", { clientX: 330, clientY: 266 });
+		expect(await screen.findByText("medications-page")).toBeInTheDocument();
+		expect(confirmNavigationMock).toHaveBeenCalled();
+	});
+
+	it("does not swipe between main app routes on desktop", async () => {
+		mockMobileMediaQuery(false);
+		render(
+			<MemoryRouter initialEntries={["/dashboard"]}>
+				<App />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByText("dashboard-page")).toBeInTheDocument();
+		const swipeSurface = screen.getByTestId("main-route-swipe-surface");
+
+		dispatchTouchEvent(swipeSurface, "touchstart", { clientX: 330, clientY: 260 });
+		dispatchTouchEvent(swipeSurface, "touchmove", { clientX: 110, clientY: 266 });
+		dispatchTouchEvent(swipeSurface, "touchend", { clientX: 110, clientY: 266 });
+
+		expect(screen.getByText("dashboard-page")).toBeInTheDocument();
+		expect(screen.queryByText("medications-page")).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Closes #873

## Summary

- Add horizontal swipe navigation between Dashboard, Medications, and Planner on mobile.
- Add a dismissible mobile navigation hint below the app header.
- Cover the route swipe flow with focused unit and Playwright regressions.

## Validation

- `npm --prefix frontend run check`
- `npm --prefix frontend run test:run -- src/test/App.test.tsx`
- `PLAYWRIGHT_HTML_OPEN=never PLAYWRIGHT_WORKERS=1 CI=true npm --prefix frontend run test:e2e -- e2e/dashboard.spec.ts -g "swipes between Dashboard"`