### PR TITLE
fix: align journal history mood icons

### DIFF
--- a/frontend/src/components/intake-journal/IntakeJournalHistoryModal.tsx
+++ b/frontend/src/components/intake-journal/IntakeJournalHistoryModal.tsx
@@ -4,10 +4,11 @@ import type { Medication } from "../../types";
 import { AppModal, AppModalFooter } from "../../ui/modal/AppModal";
 import { AppButton } from "../../ui/primitives/AppButton";
 import { AppSelect } from "../../ui/primitives/AppSelect";
-import { getIntakeMoodDisplay } from "../../utils/intake-mood";
+import { getIntakeMoodLabel } from "../../utils/intake-mood";
 import { DateTimeInput } from "../DateTimeInput";
 import { MedicationAvatar } from "../MedicationAvatar";
 import classes from "./IntakeJournalModal.module.css";
+import { INTAKE_MOOD_ICONS } from "./intake-mood-icons";
 import { formatJournalDisplayDateTime, getJournalSourceLabel } from "./journal-display";
 
 interface IntakeJournalHistoryModalProps {
@@ -58,6 +59,8 @@ export function IntakeJournalHistoryModal({
 					: null;
 				const statusLabel = t(entry.dismissed ? "journal.context.statusSkipped" : "journal.context.statusTaken");
 				const sourceLabel = getJournalSourceLabel(entry, t);
+				const MoodIcon = entry.mood ? INTAKE_MOOD_ICONS[entry.mood] : null;
+				const moodLabel = entry.mood ? getIntakeMoodLabel(entry.mood, t) : null;
 
 				return (
 					<article key={entry.doseTrackingId} className={classes.entry}>
@@ -71,7 +74,12 @@ export function IntakeJournalHistoryModal({
 							</div>
 							<div className={classes.noteBlock}>
 								<span className={classes.noteLabel}>{t("journal.actions.note")}</span>
-								{entry.mood ? <span className={classes.moodBadge}>{getIntakeMoodDisplay(entry.mood, t)}</span> : null}
+								{MoodIcon && moodLabel ? (
+									<span className={classes.moodBadge}>
+										<MoodIcon aria-hidden="true" className={classes.moodBadgeIcon} />
+										<span>{moodLabel}</span>
+									</span>
+								) : null}
 								<p className={classes.entryNote}>{entry.note ?? t("journal.history.noNote")}</p>
 							</div>
 							<dl className={classes.entryMetaGrid}>

--- a/frontend/src/components/intake-journal/IntakeJournalModal.module.css
+++ b/frontend/src/components/intake-journal/IntakeJournalModal.module.css
@@ -279,6 +279,7 @@
 .moodBadge {
 	display: inline-flex;
 	align-items: center;
+	gap: 0.32rem;
 	width: fit-content;
 	min-height: 1.55rem;
 	padding: 0.18rem 0.55rem;
@@ -289,6 +290,14 @@
 	font-size: 0.8rem;
 	font-weight: 700;
 	line-height: 1.15;
+}
+
+.moodBadgeIcon {
+	width: 0.95rem;
+	height: 0.95rem;
+	flex: 0 0 auto;
+	color: var(--accent);
+	stroke-width: 2.2;
 }
 
 .noteLabel {

--- a/frontend/src/components/intake-journal/IntakeJournalModal.tsx
+++ b/frontend/src/components/intake-journal/IntakeJournalModal.tsx
@@ -1,4 +1,3 @@
-import { Angry, Frown, Laugh, type LucideIcon, Meh, Smile } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { IntakeJournalEntry } from "../../hooks/useIntakeJournal";
@@ -9,15 +8,8 @@ import { AppTooltip } from "../../ui/primitives/AppTooltip";
 import { getIntakeMoodLabel, INTAKE_MOODS, type IntakeMood } from "../../utils/intake-mood";
 import { MedicationAvatar } from "../MedicationAvatar";
 import classes from "./IntakeJournalModal.module.css";
+import { INTAKE_MOOD_ICONS } from "./intake-mood-icons";
 import { formatJournalDisplayDateTime, getJournalSourceLabel } from "./journal-display";
-
-const INTAKE_MOOD_ICONS: Record<IntakeMood, LucideIcon> = {
-	very_bad: Angry,
-	bad: Frown,
-	neutral: Meh,
-	good: Smile,
-	very_good: Laugh,
-};
 
 interface IntakeJournalModalProps {
 	isOpen: boolean;

--- a/frontend/src/components/intake-journal/intake-mood-icons.ts
+++ b/frontend/src/components/intake-journal/intake-mood-icons.ts
@@ -1,0 +1,10 @@
+import { Angry, Frown, Laugh, type LucideIcon, Meh, Smile } from "lucide-react";
+import type { IntakeMood } from "../../utils/intake-mood";
+
+export const INTAKE_MOOD_ICONS: Record<IntakeMood, LucideIcon> = {
+	very_bad: Angry,
+	bad: Frown,
+	neutral: Meh,
+	good: Smile,
+	very_good: Laugh,
+};

--- a/frontend/src/test/components/IntakeJournalModal.test.tsx
+++ b/frontend/src/test/components/IntakeJournalModal.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { IntakeJournalHistoryModal } from "../../components/intake-journal/IntakeJournalHistoryModal";
 import { IntakeJournalModal } from "../../components/intake-journal/IntakeJournalModal";
 import type { IntakeJournalEntry } from "../../hooks/useIntakeJournal";
 import { setDefaultFormattingTimezone } from "../../utils/formatters";
@@ -179,6 +180,33 @@ describe("IntakeJournalModal", () => {
 		fireEvent.touchStart(veryGoodMoodButton);
 
 		expect(await screen.findByRole("tooltip")).toHaveTextContent("journal.mood.values.very_good");
+	});
+
+	it("renders history mood with the same icon set as the note editor", () => {
+		const entry = buildEntry({ mood: "very_good", note: "Mood note" });
+
+		render(
+			<IntakeJournalHistoryModal
+				isOpen
+				entries={[entry]}
+				filters={{ medicationId: null, from: "", to: "", limit: 100 }}
+				medications={[]}
+				isLoading={false}
+				error={null}
+				onClose={vi.fn()}
+				onFilterChange={vi.fn()}
+				onReload={vi.fn()}
+				onResetFilters={vi.fn()}
+				onReopen={vi.fn()}
+			/>
+		);
+
+		const moodLabel = screen.getByText("journal.mood.values.very_good");
+		const moodBadge = moodLabel.parentElement;
+
+		expect(moodBadge?.querySelector("svg")).not.toBeNull();
+		expect(moodBadge?.textContent).not.toContain("\u{1f604}");
+		expect(screen.getByText("Mood note")).toBeInTheDocument();
 	});
 
 	it("keeps the modal open when save fails", async () => {


### PR DESCRIPTION
Closes #879

## Summary
- Share the intake mood Lucide icon map between the journal editor and history modal.
- Render history mood badges with the same icons and translated labels as the editor.
- Add coverage for history mood icon rendering.

## Local validation
- `npm --prefix frontend run test:run -- src/test/components/IntakeJournalModal.test.tsx`
- `npm --prefix frontend run check`