### PR TITLE
fix: wrap mobile swipe hint text

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -90,16 +90,16 @@
 	}
 
 	.mainSwipeHint {
-		display: flex;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
 		align-items: center;
-		justify-content: center;
-		gap: 0.35rem;
-		width: fit-content;
+		gap: 0.45rem;
+		width: calc(100% - 1rem);
 		max-width: calc(100% - 1rem);
 		margin: 0.65rem auto 0.2rem;
-		padding: 0.28rem 0.35rem 0.28rem 0.7rem;
+		padding: 0.42rem 0.35rem 0.42rem 0.85rem;
 		border: 1px solid color-mix(in srgb, var(--mantine-other-border-primary) 72%, transparent);
-		border-radius: 999px;
+		border-radius: 1.35rem;
 		background: color-mix(in srgb, var(--mantine-other-bg-tertiary) 76%, transparent);
 		color: var(--mantine-other-text-muted);
 		font-size: 0.75rem;
@@ -110,8 +110,7 @@
 
 	.mainSwipeHint span {
 		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		overflow-wrap: anywhere;
+		white-space: normal;
 	}
 }

--- a/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
@@ -33,6 +33,19 @@ function lastBlockFor(css: string, selector: string) {
 }
 
 describe("dashboard and shared mobile polish contract", () => {
+	it("lets the mobile main swipe hint wrap instead of clipping the text", () => {
+		const appCss = readSource("App.module.css");
+		const hint = lastBlockFor(appCss, ".mainSwipeHint");
+		const hintText = lastBlockFor(appCss, ".mainSwipeHint span");
+
+		expect(hint).toMatch(/grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s*auto/);
+		expect(hint).toMatch(/width\s*:\s*calc\(100%\s*-\s*1rem\)/);
+		expect(hintText).toMatch(/white-space\s*:\s*normal/);
+		expect(hintText).toMatch(/overflow-wrap\s*:\s*anywhere/);
+		expect(hintText).not.toMatch(/text-overflow\s*:\s*ellipsis/);
+		expect(hintText).not.toMatch(/white-space\s*:\s*nowrap/);
+	});
+
 	it("keeps overview table headers readable and mobile date values left aligned", () => {
 		const css = readSource("ui/primitives/DataTable.module.css");
 		const headCell = blockFor(css, ".headCell");


### PR DESCRIPTION
Closes #880

## Summary
- Let the mobile main-route swipe hint wrap instead of truncating translated text.
- Keep the dismiss button aligned to the right in the mobile hint layout.
- Add a CSS contract for the wrapping hint behavior.

## Local validation
- `npm --prefix frontend run test:run -- src/test/ui/dashboard-mobile-polish-contract.test.ts src/test/App.test.tsx`
- `npm --prefix frontend run check`