### PR TITLE
fix: polish mobile dose action labels

### DIFF
--- a/frontend/src/components/DoseActionButton.module.css
+++ b/frontend/src/components/DoseActionButton.module.css
@@ -20,11 +20,21 @@
 	--button-radius: var(--button-radius);
 }
 
-.button :global(.mantine-Button-label) {
+.buttonInner {
+	width: 100%;
+	overflow: visible;
+}
+
+.buttonLabel {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	gap: 0.35rem;
+	width: 100%;
+	min-width: 0;
+	max-width: 100%;
+	overflow: visible;
+	line-height: 1.1;
 }
 
 .actionIcon {
@@ -39,7 +49,16 @@
 }
 
 .label {
-	display: inline;
+	display: inline-block;
+	min-width: 0;
+	max-width: 100%;
+	overflow: visible;
+	text-align: center;
+	text-overflow: clip;
+}
+
+.skipAction .label {
+	width: 100%;
 }
 
 @media (min-width: 601px) {
@@ -66,7 +85,7 @@
 		--button-fz: 0.74rem;
 	}
 
-	.undo :global(.mantine-Button-label) {
+	.undo .buttonLabel {
 		gap: 0.22rem;
 	}
 

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -4,7 +4,7 @@
 /* biome-ignore-all lint/style/noNestedTernary: rendering branches are intentionally explicit in schedule UI */
 /* biome-ignore-all lint/correctness/useExhaustiveDependencies: modal and helper callbacks are stable at runtime */
 
-import { Check, NotebookPen, Undo2 } from "lucide-react";
+import { NotebookPen, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -625,6 +625,11 @@ export function SharedSchedule() {
 		isEmpty: boolean;
 		isFuture: boolean;
 	}) => {
+		const hideDoseActionIcons = i18n.language.startsWith("de");
+		const doseActionButtonClassNames = {
+			inner: doseButtonClasses.buttonInner,
+			label: doseButtonClasses.buttonLabel,
+		};
 		const showSharedJournalAction = Boolean(data?.allowJournalNotes);
 		const canMarkTaken = data?.allowMarkTaken !== false;
 		const canOpenSharedJournal = showSharedJournalAction && (options.isTaken || options.isSkipped);
@@ -646,6 +651,7 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"shared-dose-action-button",
 					"shared-dose-action-take",
@@ -657,20 +663,21 @@ export function SharedSchedule() {
 				onClick={() => undoDoseTaken(options.doseId)}
 				disabled={Boolean(takeBlockLabel)}
 			>
-				{options.isAutomaticallyTaken && (
+				{options.isAutomaticallyTaken && !hideDoseActionIcons && (
 					<AppTooltip label={t("tooltips.automaticTaken")}>
 						<span className={doseButtonClasses.actionIcon} aria-hidden="true">
 							🤖
 						</span>
 					</AppTooltip>
 				)}
-				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
+				<span className={doseButtonClasses.label}>{t("dose.undoAction")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"take-action-button",
 					"shared-dose-action-button",
@@ -685,11 +692,7 @@ export function SharedSchedule() {
 				disabled={Boolean(takeBlockLabel)}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
-				{options.isEmpty ? (
-					<span aria-hidden="true">⊘</span>
-				) : (
-					<Check className={doseButtonClasses.actionIcon} aria-hidden="true" />
-				)}
+				{options.isEmpty && !hideDoseActionIcons ? <span aria-hidden="true">⊘</span> : null}
 			</AppButton>
 		);
 		const takeButton = takeBlockLabel ? (
@@ -706,6 +709,7 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"shared-dose-action-button",
 					"shared-dose-action-skip",
@@ -717,13 +721,14 @@ export function SharedSchedule() {
 				onClick={() => undoDoseSkipped(options.doseId)}
 				disabled={Boolean(skipBlockLabel)}
 			>
-				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
+				<span className={doseButtonClasses.label}>{t("dose.undoAction")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"shared-dose-action-button",
 					"shared-dose-action-skip",
@@ -751,6 +756,7 @@ export function SharedSchedule() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"shared-dose-action-button",
 					"shared-dose-action-journal",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -114,7 +114,7 @@
     "editor": {
       "addTitle": "Journal-Notiz hinzufügen",
       "editTitle": "Journal-Notiz bearbeiten",
-      "description": "Halte fest, was bei dieser Einnahme passiert ist, ohne den bestehenden Einnahme- oder Überspringen-Status zu ändern.",
+      "description": "Halte fest, was bei dieser Einnahme passiert ist, ohne den bestehenden Einnahme- oder Auslassen-Status zu ändern.",
       "loading": "Journal-Eintrag wird geladen...",
       "noteLabel": "Notiz",
       "notePlaceholder": "Möchtest du mehr dazu notieren?",
@@ -642,10 +642,11 @@
     "takenBy": "eingenommen von",
     "markAsTaken": "Als eingenommen markieren",
     "take": "Nehmen",
-    "skip": "Überspringen",
-    "markAsSkipped": "Als übersprungen markieren",
+    "skip": "Auslassen",
+    "undoAction": "Rückg.",
+    "markAsSkipped": "Als ausgelassen markieren",
     "undoTake": "Nehmen rückgängig",
-    "undoSkip": "Überspringen rückgängig",
+    "undoSkip": "Auslassen rückgängig",
     "actionBlocked": {
       "futureTake": "Zukuenftige Einnahmen koennen noch nicht als eingenommen markiert werden.",
       "futureSkip": "Zukuenftige Einnahmen koennen noch nicht uebersprungen werden."

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -643,6 +643,7 @@
     "markAsTaken": "Mark as taken",
     "take": "Take",
     "skip": "Skip",
+    "undoAction": "Undo",
     "markAsSkipped": "Mark as skipped",
     "undoTake": "Undo take",
     "undoSkip": "Undo skip",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 /* biome-ignore-all lint/style/noNestedTernary: timeline rendering uses explicit UI-state branching */
 import { ActionIcon, Group } from "@mantine/core";
-import { Archive, Bell, Check, ClipboardList, NotebookPen, Share2, Undo2 } from "lucide-react";
+import { Archive, Bell, ClipboardList, NotebookPen, Share2, Undo2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
@@ -463,6 +463,11 @@ export function DashboardPage() {
 		isEmpty: boolean;
 		isFuture: boolean;
 	}) => {
+		const hideDoseActionIcons = i18n.language.startsWith("de");
+		const doseActionButtonClassNames = {
+			inner: doseButtonClasses.buttonInner,
+			label: doseButtonClasses.buttonLabel,
+		};
 		const journalUnavailable = !(options.isTaken || options.isSkipped);
 		const takeBlockLabel = (() => {
 			if (options.isFuture) return t("dose.actionBlocked.futureTake");
@@ -474,6 +479,7 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
@@ -483,20 +489,21 @@ export function DashboardPage() {
 				onClick={() => undoDoseTaken(options.doseId)}
 				disabled={Boolean(takeBlockLabel)}
 			>
-				{options.isAutomaticallyTaken && (
+				{options.isAutomaticallyTaken && !hideDoseActionIcons && (
 					<AppTooltip label={t("tooltips.automaticTaken")}>
 						<span className={doseButtonClasses.actionIcon} aria-hidden="true">
 							🤖
 						</span>
 					</AppTooltip>
 				)}
-				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
+				<span className={doseButtonClasses.label}>{t("dose.undoAction")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"take-action-button",
 					doseButtonClasses.button,
@@ -509,11 +516,7 @@ export function DashboardPage() {
 				disabled={Boolean(takeBlockLabel) || options.isSkipped}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
-				{options.isEmpty ? (
-					<span aria-hidden="true">⊘</span>
-				) : (
-					<Check className={doseButtonClasses.actionIcon} aria-hidden="true" />
-				)}
+				{options.isEmpty && !hideDoseActionIcons ? <span aria-hidden="true">⊘</span> : null}
 			</AppButton>
 		);
 		const takeButton = takeBlockLabel ? (
@@ -528,6 +531,7 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(doseButtonClasses.button, doseButtonClasses.journal, doseButtonClasses.journalAction)}
 				onClick={() => {
 					if (!journalUnavailable) {
@@ -563,6 +567,7 @@ export function DashboardPage() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					doseButtonClasses.button,
 					doseButtonClasses.skipAction,
@@ -572,13 +577,14 @@ export function DashboardPage() {
 				onClick={() => undoDoseSkipped(options.doseId)}
 				disabled={Boolean(skipBlockLabel)}
 			>
-				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
+				<span className={doseButtonClasses.label}>{t("dose.undoAction")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken || Boolean(skipBlockLabel)}

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -1,6 +1,6 @@
 /* biome-ignore-all lint/style/noNestedTernary: schedule timeline branches are intentionally explicit */
 import { Group } from "@mantine/core";
-import { Archive, Bell, Check, ClipboardList, NotebookPen, Undo2 } from "lucide-react";
+import { Archive, Bell, ClipboardList, NotebookPen, Undo2 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
@@ -102,7 +102,7 @@ function getDosePersonTextColor(isTaken: boolean, isSkipped: boolean): string {
 }
 
 export function SchedulePage() {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const { user, authFetch } = useAuth();
 	const { showFeedback } = useFeedback();
 	const {
@@ -334,11 +334,17 @@ export function SchedulePage() {
 		isAutomaticallyTaken: boolean;
 		isEmpty: boolean;
 	}) => {
+		const hideDoseActionIcons = i18n.language.startsWith("de");
+		const doseActionButtonClassNames = {
+			inner: doseButtonClasses.buttonInner,
+			label: doseButtonClasses.buttonLabel,
+		};
 		const journalUnavailable = !(options.isTaken || options.isSkipped);
 		const takeButtonControl = options.isTaken ? (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					doseButtonClasses.button,
 					doseButtonClasses.takeAction,
@@ -347,20 +353,21 @@ export function SchedulePage() {
 				)}
 				onClick={() => undoDoseTaken(options.doseId)}
 			>
-				{options.isAutomaticallyTaken && (
+				{options.isAutomaticallyTaken && !hideDoseActionIcons && (
 					<AppTooltip label={t("tooltips.automaticTaken")}>
 						<span className={doseButtonClasses.actionIcon} aria-hidden="true">
 							🤖
 						</span>
 					</AppTooltip>
 				)}
-				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
+				<span className={doseButtonClasses.label}>{t("dose.undoAction")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					"take-action-button",
 					doseButtonClasses.button,
@@ -372,11 +379,7 @@ export function SchedulePage() {
 				disabled={options.isEmpty || options.isSkipped}
 			>
 				<span className={doseButtonClasses.label}>{t("dose.take")}</span>
-				{options.isEmpty ? (
-					<span aria-hidden="true">⊘</span>
-				) : (
-					<Check className={doseButtonClasses.actionIcon} aria-hidden="true" />
-				)}
+				{options.isEmpty && !hideDoseActionIcons ? <span aria-hidden="true">⊘</span> : null}
 			</AppButton>
 		);
 		const takeButton =
@@ -392,6 +395,7 @@ export function SchedulePage() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(
 					doseButtonClasses.button,
 					doseButtonClasses.skipAction,
@@ -400,13 +404,14 @@ export function SchedulePage() {
 				)}
 				onClick={() => undoDoseSkipped(options.doseId)}
 			>
-				<span className={doseButtonClasses.label}>{t("common.undo")}</span>
+				<span className={doseButtonClasses.label}>{t("dose.undoAction")}</span>
 				<Undo2 className={doseButtonClasses.actionIcon} aria-hidden="true" />
 			</AppButton>
 		) : (
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(doseButtonClasses.button, doseButtonClasses.skipAction, doseButtonClasses.skip)}
 				onClick={() => markDoseSkipped(options.doseId)}
 				disabled={options.isTaken}
@@ -419,6 +424,7 @@ export function SchedulePage() {
 			<AppButton
 				type="button"
 				size="sm"
+				classNames={doseActionButtonClassNames}
 				className={cx(doseButtonClasses.button, doseButtonClasses.journalAction, doseButtonClasses.journal)}
 				onClick={() => {
 					if (!journalUnavailable) {

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -694,7 +694,7 @@ describe("SharedSchedule", () => {
 				method: "POST",
 				body: { doseId: sharedData.automaticDoseId },
 			});
-			expect(screen.getByRole("button", { name: "common.undo" })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "dose.undoAction" })).toBeInTheDocument();
 		});
 	});
 
@@ -763,11 +763,11 @@ describe("SharedSchedule", () => {
 		fireEvent.click(document.querySelector(".day-block.today .day-divider.clickable") as HTMLElement);
 
 		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "common.undo" })).toBeDisabled();
+			expect(screen.getByRole("button", { name: "dose.undoAction" })).toBeDisabled();
 			expect(screen.getByRole("button", { name: "dose.skip" })).toBeDisabled();
 		});
 
-		const undoButton = screen.getByRole("button", { name: "common.undo" });
+		const undoButton = screen.getByRole("button", { name: "dose.undoAction" });
 		const skipButton = screen.getByRole("button", { name: "dose.skip" });
 		fireEvent.click(undoButton);
 		fireEvent.click(skipButton);
@@ -802,10 +802,10 @@ describe("SharedSchedule", () => {
 		renderSharedSchedule("/share/token-123");
 
 		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "common.undo" })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "dose.undoAction" })).toBeInTheDocument();
 		});
 
-		fireEvent.click(screen.getByRole("button", { name: "common.undo" }));
+		fireEvent.click(screen.getByRole("button", { name: "dose.undoAction" }));
 
 		await waitFor(() => {
 			expect(requests).toContainEqual({
@@ -830,7 +830,7 @@ describe("SharedSchedule", () => {
 		renderSharedSchedule("/share/token-123");
 
 		await waitFor(() => {
-			expect(screen.getByRole("button", { name: "common.undo" })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "dose.undoAction" })).toBeInTheDocument();
 		});
 
 		fireEvent.click(screen.getByRole("button", { name: "dose.take" }));

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -1585,7 +1585,7 @@ describe("DashboardPage additional branches", () => {
 			</MemoryRouter>
 		);
 
-		const undoButton = screen.getByRole("button", { name: "common.undo" });
+		const undoButton = screen.getByRole("button", { name: "dose.undoAction" });
 		expect(undoButton).toBeInTheDocument();
 		fireEvent.click(undoButton);
 		expect(undoDoseTaken).toHaveBeenCalled();
@@ -1767,7 +1767,7 @@ describe("DashboardPage dose interactions", () => {
 			</MemoryRouter>
 		);
 
-		fireEvent.click(screen.getByRole("button", { name: "common.undo" }));
+		fireEvent.click(screen.getByRole("button", { name: "dose.undoAction" }));
 		expect(undoDoseTaken).toHaveBeenCalled();
 	});
 });

--- a/frontend/src/test/pages/SchedulePage.test.tsx
+++ b/frontend/src/test/pages/SchedulePage.test.tsx
@@ -743,7 +743,7 @@ describe("SchedulePage with taken doses", () => {
 		);
 
 		// When dose is taken, the undo button should appear
-		const undoBtn = screen.getByRole("button", { name: "common.undo" });
+		const undoBtn = screen.getByRole("button", { name: "dose.undoAction" });
 		expect(undoBtn).toBeInTheDocument();
 	});
 
@@ -766,7 +766,7 @@ describe("SchedulePage with taken doses", () => {
 			</MemoryRouter>
 		);
 
-		fireEvent.click(screen.getByRole("button", { name: "common.undo" }));
+		fireEvent.click(screen.getByRole("button", { name: "dose.undoAction" }));
 		expect(undoDoseTaken).toHaveBeenCalled();
 	});
 });
@@ -833,7 +833,7 @@ describe("SchedulePage skip behavior", () => {
 			</MemoryRouter>
 		);
 
-		expect(screen.getByRole("button", { name: "common.undo" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "dose.undoAction" })).toBeInTheDocument();
 		expect(screen.getByText("John", { selector: ".person-name" }).closest(".dose-person")).toHaveClass("skipped");
 		const noteButton = screen.getByRole("button", { name: "journal.actions.note" });
 		expect(noteButton).not.toBeDisabled();
@@ -891,7 +891,7 @@ describe("SchedulePage skip behavior", () => {
 			</MemoryRouter>
 		);
 
-		const undoSkipButton = screen.getByRole("button", { name: "common.undo" });
+		const undoSkipButton = screen.getByRole("button", { name: "dose.undoAction" });
 		expect(undoSkipButton).toBeInTheDocument();
 
 		fireEvent.click(undoSkipButton);

--- a/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-mobile-polish-contract.test.ts
@@ -67,4 +67,15 @@ describe("dashboard and shared mobile polish contract", () => {
 		expect(en.form.blisters.takenByTooltip).not.toBe("form.blisters.takenByTooltip");
 		expect(de.form.blisters.takenByTooltip).not.toBe("form.blisters.takenByTooltip");
 	});
+
+	it("keeps German mobile dose action labels concise without changing English copy", () => {
+		expect(en.dose.take).toBe("Take");
+		expect(en.dose.skip).toBe("Skip");
+		expect(en.dose.undoAction).toBe("Undo");
+		expect(de.dose.take).toBe("Nehmen");
+		expect(de.dose.skip).toBe("Auslassen");
+		expect(de.dose.undoAction).toBe("Rückg.");
+		expect(de.dose.skip.length).toBeLessThan("Überspringen".length);
+		expect(de.dose.undoAction.length).toBeLessThan("Rückgängig".length);
+	});
 });

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -114,6 +114,9 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 	it("keeps mobile dose action buttons in stable slots", () => {
 		const surfacesCss = readSource("AppSurfaces.css");
 		const dashboardSource = readSource("pages/DashboardPage.tsx");
+		const scheduleSource = readSource("pages/SchedulePage.tsx");
+		const sharedScheduleSource = readSource("components/SharedSchedule.tsx");
+		const doseActionSources = [dashboardSource, scheduleSource, sharedScheduleSource];
 		const buttonCss = readSource("components/DoseActionButton.module.css");
 		const doseRecipientName = blockFor(surfacesCss, ".dose-recipient-name");
 		const dosePerson = lastBlockFor(surfacesCss, ".dose-person");
@@ -126,6 +129,11 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 		const dosePersonButton = lastBlockFor(surfacesCss, ".dose-person .dose-btn");
 		const dosePersonRawButton = blockFor(surfacesCss, ".dose-person button");
 		const tooltipTarget = blockFor(buttonCss, ".tooltipTarget");
+		const buttonInner = blockFor(buttonCss, ".buttonInner");
+		const buttonLabel = blockFor(buttonCss, ".buttonLabel");
+		const actionLabel = blockFor(buttonCss, ".label");
+		const skipActionLabel = blockFor(buttonCss, ".skipAction .label");
+		const undoButtonLabel = blockFor(buttonCss, ".undo .buttonLabel");
 		const takeAction = blockFor(buttonCss, ".takeAction");
 		const skipAction = blockFor(buttonCss, ".skipAction");
 		const journalAction = blockFor(buttonCss, ".journalAction");
@@ -148,6 +156,18 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 		expect(dosePersonButton).toMatch(/width\s*:\s*100%/);
 		expect(dosePersonRawButton).toMatch(/width\s*:\s*100%/);
 		expect(tooltipTarget).toMatch(/width\s*:\s*100%/);
+		expect(buttonInner).toMatch(/overflow\s*:\s*visible/);
+		expect(buttonLabel).toMatch(/width\s*:\s*100%/);
+		expect(buttonLabel).toMatch(/overflow\s*:\s*visible/);
+		expect(buttonLabel).toMatch(/line-height\s*:\s*1\.1/);
+		expect(actionLabel).toMatch(/text-align\s*:\s*center/);
+		expect(actionLabel).toMatch(/text-overflow\s*:\s*clip/);
+		expect(actionLabel).not.toMatch(/text-overflow\s*:\s*ellipsis/);
+		expect(skipActionLabel).toMatch(/width\s*:\s*100%/);
+		expect(undoButtonLabel).toMatch(/gap\s*:\s*0\.22rem/);
+		expect(buttonCss).toMatch(/@media \(max-width: 600px\)[\s\S]*--button-padding-x\s*:\s*0\.62rem/);
+		expect(buttonCss).toMatch(/@media \(max-width: 600px\)[\s\S]*--button-fz\s*:\s*0\.78rem/);
+		expect(buttonCss).not.toMatch(/font-size\s*:\s*clamp\(0\.62rem, 2\.45vw, 0\.7rem\)/);
 		expect(buttonCss).toMatch(
 			/@media \(min-width: 601px\)[\s\S]*\.takeAction:global\(\.mantine-Button-root\)[\s\S]*\.skipAction:global\(\.mantine-Button-root\)[\s\S]*width\s*:\s*7\.5rem[\s\S]*min-width\s*:\s*7\.5rem/
 		);
@@ -158,6 +178,21 @@ describe("dashboard no-wrap and reminder spacing contract", () => {
 		expect(dashboardSource).toContain('className="dose-recipient-name"');
 		expect(dashboardSource).toContain("lineHeight={1.3}");
 		expect(dashboardSource).toContain('paddingBlockEnd: "0.08em"');
+		for (const source of doseActionSources) {
+			expect(source).toContain('const hideDoseActionIcons = i18n.language.startsWith("de");');
+			expect(source).toContain("inner: doseButtonClasses.buttonInner");
+			expect(source).toContain("label: doseButtonClasses.buttonLabel");
+			expect(source).toContain("classNames={doseActionButtonClassNames}");
+			expect(source).toContain("options.isAutomaticallyTaken && !hideDoseActionIcons");
+			expect(source).toContain("options.isEmpty && !hideDoseActionIcons");
+			expect(source).toContain('t("dose.undoAction")');
+			expect(source).toContain("<Undo2");
+			expect(source).not.toContain("{!hideDoseActionIcons && <Undo2");
+			expect(source).toContain("<NotebookPen");
+			expect(source).not.toContain("{!hideDoseActionIcons && <NotebookPen");
+			expect(source).not.toContain('t("common.undo")');
+			expect(source).not.toContain("<Check");
+		}
 	});
 
 	it("lets desktop dose action names use the available row width", () => {


### PR DESCRIPTION
Closes #881

## Summary
- Shorten German mobile dose action labels and add a dedicated dose undo label.
- Remove the Take check icon and suppress German-only non-status symbols where needed.
- Keep Undo and journal note icons where they fit, and stabilize label centering through Mantine Button classNames slots.
- Update dashboard, schedule, shared schedule, and focused UI/i18n tests.

## Local validation
- `npm --prefix frontend run test:run -- src/test/ui/dashboard-nowrap-spacing-contract.test.ts src/test/ui/dashboard-mobile-polish-contract.test.ts src/test/pages/DashboardPage.test.tsx src/test/pages/SchedulePage.test.tsx src/test/components/SharedSchedule.test.tsx`
- `npm --prefix frontend run check`