### PR TITLE
fix: preserve refill package capacity after stock correction

### DIFF
--- a/backend/src/routes/medications.ts
+++ b/backend/src/routes/medications.ts
@@ -1198,9 +1198,11 @@ export async function medicationRoutes(app: FastifyInstance) {
 					updateFields.totalPills = normalizedAmountBase;
 					updateFields.looseTablets = normalizedAmountBase;
 				}
-				if (packageAmountValue !== undefined) updateFields.packageAmountValue = packageAmountValue;
+				if (packageAmountValue !== undefined && packageAmountValue > 0) {
+					updateFields.packageAmountValue = packageAmountValue;
+				}
 			}
-			if (allowsDiscreteCapacityUpdate && totalPills !== undefined) {
+			if (allowsDiscreteCapacityUpdate && totalPills !== undefined && totalPills > 0) {
 				updateFields.totalPills = totalPills;
 			}
 			if (packCount !== undefined) updateFields.packCount = packCount;

--- a/backend/src/test/e2e-routes.test.ts
+++ b/backend/src/test/e2e-routes.test.ts
@@ -2521,7 +2521,7 @@ describe("E2E Tests with Real Routes", () => {
 			expect(med).toBeTruthy();
 			expect(med.packCount).toBe(0);
 			expect(med.looseTablets).toBe(0);
-			expect(med.totalPills).toBe(0);
+			expect(med.totalPills).toBe(payload.totalPills);
 			expect(med.stockAdjustment).toBe(0);
 		});
 
@@ -2592,7 +2592,7 @@ describe("E2E Tests with Real Routes", () => {
 			expect(med.packCount).toBe(0);
 			expect(med.looseTablets).toBe(0);
 			expect(med.totalPills).toBe(0);
-			expect(med.packageAmountValue).toBe(0);
+			expect(med.packageAmountValue).toBe(payload.packageAmountValue);
 			expect(med.stockAdjustment).toBe(0);
 		});
 
@@ -3421,6 +3421,161 @@ describe("E2E Tests with Real Routes", () => {
 				);
 			}
 		}
+
+		it.each([
+			{
+				name: "blister",
+				payload: {
+					...blisterMedication,
+					packCount: 2,
+					blistersPerPack: 2,
+					pillsPerBlister: 5,
+					looseTablets: 3,
+				},
+				zeroPayload: { stockAdjustment: 0, packCount: 0, looseTablets: 0 },
+				refillPayload: { packsAdded: 1, loosePillsAdded: 2 },
+				expectedTotalPills: 12,
+				expectedPackCount: 1,
+				expectedLooseTablets: 2,
+				expectedPersistedCapacity: null,
+			},
+			{
+				name: "bottle",
+				payload: {
+					...bottleMedication,
+					totalPills: 100,
+					looseTablets: 40,
+				},
+				zeroPayload: { stockAdjustment: 0, packCount: 0, looseTablets: 0, totalPills: 0 },
+				refillPayload: { packsAdded: 0, loosePillsAdded: 25 },
+				expectedTotalPills: 25,
+				expectedPackCount: 0,
+				expectedLooseTablets: 25,
+				expectedPersistedCapacity: 100,
+			},
+			{
+				name: "tube",
+				payload: {
+					...tubeMedication,
+					packCount: 1,
+					packageAmountValue: 40,
+					totalPills: 40,
+					looseTablets: 40,
+				},
+				zeroPayload: {
+					stockAdjustment: 0,
+					packCount: 0,
+					looseTablets: 0,
+					totalPills: 0,
+					packageAmountValue: 0,
+				},
+				refillPayload: { packsAdded: 1, loosePillsAdded: 40, quantityAdded: 40 },
+				expectedTotalPills: 40,
+				expectedPackCount: 1,
+				expectedLooseTablets: 40,
+				expectedPersistedCapacity: 40,
+			},
+			{
+				name: "liquid_container",
+				payload: {
+					...liquidContainerMedication,
+					packCount: 1,
+					packageAmountValue: 180,
+					packageAmountUnit: "ml",
+					totalPills: 180,
+					looseTablets: 180,
+				},
+				zeroPayload: {
+					stockAdjustment: 0,
+					packCount: 0,
+					looseTablets: 0,
+					totalPills: 0,
+					packageAmountValue: 0,
+				},
+				refillPayload: { packsAdded: 1, loosePillsAdded: 180, quantityAdded: 180 },
+				expectedTotalPills: 180,
+				expectedPackCount: 1,
+				expectedLooseTablets: 180,
+				expectedPersistedCapacity: 180,
+			},
+			{
+				name: "inhaler",
+				payload: {
+					...discreteContainerMedications[0].payload,
+					totalPills: 200,
+					looseTablets: 40,
+				},
+				zeroPayload: { stockAdjustment: 0, packCount: 0, looseTablets: 0, totalPills: 0 },
+				refillPayload: { packsAdded: 1, loosePillsAdded: 60 },
+				expectedTotalPills: 60,
+				expectedPackCount: 0,
+				expectedLooseTablets: 60,
+				expectedPersistedCapacity: 200,
+			},
+			{
+				name: "injection",
+				payload: {
+					...discreteContainerMedications[1].payload,
+					totalPills: 12,
+					looseTablets: 4,
+				},
+				zeroPayload: { stockAdjustment: 0, packCount: 0, looseTablets: 0, totalPills: 0 },
+				refillPayload: { packsAdded: 1, loosePillsAdded: 3 },
+				expectedTotalPills: 3,
+				expectedPackCount: 0,
+				expectedLooseTablets: 3,
+				expectedPersistedCapacity: 12,
+			},
+		])("should refill $name correctly after stock correction to zero", async ({
+			payload,
+			zeroPayload,
+			refillPayload,
+			expectedTotalPills,
+			expectedPackCount,
+			expectedLooseTablets,
+			expectedPersistedCapacity,
+		}) => {
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload,
+			});
+			expect(createResponse.statusCode).toBe(200);
+			const medId = createResponse.json().id;
+
+			const zeroResponse = await app.inject({
+				method: "PATCH",
+				url: `/medications/${medId}/stock-adjustment`,
+				payload: zeroPayload,
+			});
+			expect(zeroResponse.statusCode).toBe(200);
+
+			const refillResponse = await app.inject({
+				method: "POST",
+				url: `/medications/${medId}/refill`,
+				payload: refillPayload,
+			});
+			expect(refillResponse.statusCode).toBe(200);
+			const refillData = refillResponse.json();
+			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+			expect(refillData.newStock.packCount).toBe(expectedPackCount);
+			expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
+
+			const medsResponse = await app.inject({ method: "GET", url: "/medications" });
+			expect(medsResponse.statusCode).toBe(200);
+			const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
+			expect(med).toBeTruthy();
+			expect(med.packCount).toBe(expectedPackCount);
+			expect(med.looseTablets).toBe(expectedLooseTablets);
+			expect(med.stockAdjustment).toBe(0);
+			if (typeof expectedPersistedCapacity === "number") {
+				if (med.packageType === "tube" || med.packageType === "liquid_container") {
+					expect(med.packageAmountValue).toBe(expectedPersistedCapacity);
+				} else {
+					expect(med.totalPills).toBe(expectedPersistedCapacity);
+				}
+			}
+		});
 
 		it("should create and return bottle type medication", async () => {
 			const response = await app.inject({

--- a/frontend/e2e/refill-restock-matrix.spec.ts
+++ b/frontend/e2e/refill-restock-matrix.spec.ts
@@ -1,0 +1,282 @@
+import type { Page } from "@playwright/test";
+import { authFile, createMedicationViaAPI, deleteAllMedicationsViaAPI, expect, navigateTo, test } from "./fixtures";
+
+type PackageType = "blister" | "bottle" | "tube" | "liquid_container" | "inhaler" | "injection";
+
+type MedicationSnapshot = {
+	id: number;
+	name: string;
+	packageType: PackageType;
+	packCount: number;
+	blistersPerPack: number;
+	pillsPerBlister: number;
+	looseTablets: number;
+	totalPills: number | null;
+	stockAdjustment: number;
+	packageAmountValue: number | null;
+};
+
+type Scenario = {
+	label: string;
+	create: Parameters<typeof createMedicationViaAPI>[0];
+	stockCorrectionInputs: number[];
+	expectedAfterCorrection: number;
+	refillInputs: number[];
+	expectedRefillAdded: number;
+	expectedFinalStock: number;
+	expectedCapacity: number;
+	expectedPackageAmountValue?: number;
+};
+
+function tomorrowMorningLocal() {
+	const date = new Date();
+	date.setDate(date.getDate() + 1);
+	date.setHours(8, 0, 0, 0);
+	const pad = (value: number) => String(value).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function currentStock(med: MedicationSnapshot) {
+	const adjustment = med.stockAdjustment ?? 0;
+	if (med.packageType === "blister") {
+		return med.packCount * med.blistersPerPack * med.pillsPerBlister + med.looseTablets + adjustment;
+	}
+	return med.looseTablets + adjustment;
+}
+
+function displayCapacity(med: MedicationSnapshot) {
+	if (med.packageType === "tube" || med.packageType === "liquid_container") {
+		const amountPerPackage = med.packageAmountValue ?? 0;
+		if (amountPerPackage > 0) {
+			return Math.max(1, med.packCount || 1) * amountPerPackage;
+		}
+	}
+	if (med.packageType === "bottle" || med.packageType === "inhaler" || med.packageType === "injection") {
+		return med.totalPills ?? med.looseTablets;
+	}
+	return med.packCount * med.blistersPerPack * med.pillsPerBlister + med.looseTablets;
+}
+
+async function getMedication(page: Page, id: number): Promise<MedicationSnapshot> {
+	const response = await page.request.get("/api/medications");
+	expect(response.ok()).toBeTruthy();
+	const medications = (await response.json()) as MedicationSnapshot[];
+	const medication = medications.find((item) => item.id === id);
+	expect(medication).toBeTruthy();
+	return medication as MedicationSnapshot;
+}
+
+async function getRefillHistory(page: Page, id: number): Promise<Array<{ quantityAdded: number }>> {
+	const response = await page.request.get(`/api/medications/${id}/refills`);
+	expect(response.ok()).toBeTruthy();
+	return response.json() as Promise<Array<{ quantityAdded: number }>>;
+}
+
+async function openMedicationDetail(page: Page, medName: string) {
+	await navigateTo(page, "/dashboard");
+	const overviewTable = page.getByTestId("dashboard-overview-table");
+	await expect(overviewTable).toBeVisible({ timeout: 10000 });
+	const medRow = overviewTable.getByTestId("dashboard-overview-row").filter({ hasText: medName }).first();
+	await expect(medRow).toBeVisible({ timeout: 10000 });
+	await medRow.getByRole("button", { name: medName }).click();
+
+	const modal = page
+		.getByRole("dialog")
+		.filter({ has: page.getByRole("heading", { name: medName }) })
+		.last();
+	await expect(modal).toBeVisible({ timeout: 5000 });
+	return modal;
+}
+
+async function fillNumberInput(page: Page, index: number, value: number) {
+	const input = page.getByRole("dialog").last().getByRole("spinbutton").nth(index);
+	await expect(input).toBeVisible();
+	await input.fill(String(value));
+}
+
+test.describe("Refill and stock correction package matrix", () => {
+	test.use({ storageState: authFile });
+	test.describe.configure({ timeout: 180000, mode: "serial" });
+
+	const start = tomorrowMorningLocal();
+	const scenarios: Scenario[] = [
+		{
+			label: "blister",
+			create: {
+				name: "Matrix Blister Refill",
+				packageType: "blister",
+				packCount: 2,
+				blistersPerPack: 2,
+				pillsPerBlister: 5,
+				looseTablets: 1,
+				intakes: [{ usage: 1, every: 1, start, intakeRemindersEnabled: false }],
+			},
+			stockCorrectionInputs: [2, 0, 2],
+			expectedAfterCorrection: 12,
+			refillInputs: [1, 3],
+			expectedRefillAdded: 13,
+			expectedFinalStock: 25,
+			expectedCapacity: 35,
+		},
+		{
+			label: "bottle",
+			create: {
+				name: "Matrix Bottle Refill",
+				packageType: "bottle",
+				totalPills: 100,
+				looseTablets: 40,
+				intakes: [{ usage: 1, every: 1, start, intakeRemindersEnabled: false }],
+			},
+			stockCorrectionInputs: [55],
+			expectedAfterCorrection: 55,
+			refillInputs: [20],
+			expectedRefillAdded: 20,
+			expectedFinalStock: 75,
+			expectedCapacity: 100,
+		},
+		{
+			label: "tube",
+			create: {
+				name: "Matrix Tube Refill",
+				packageType: "tube",
+				medicationForm: "topical",
+				packageAmountValue: 40,
+				totalPills: 40,
+				looseTablets: 40,
+				intakes: [{ usage: 2, every: 1, start, intakeRemindersEnabled: false }],
+			},
+			stockCorrectionInputs: [24],
+			expectedAfterCorrection: 24,
+			refillInputs: [1],
+			expectedRefillAdded: 40,
+			expectedFinalStock: 64,
+			expectedCapacity: 80,
+			expectedPackageAmountValue: 40,
+		},
+		{
+			label: "liquid_container",
+			create: {
+				name: "Matrix Liquid Refill",
+				packageType: "liquid_container",
+				medicationForm: "liquid",
+				packCount: 1,
+				packageAmountValue: 180,
+				totalPills: 180,
+				looseTablets: 180,
+				intakes: [{ usage: 5, every: 1, start, intakeRemindersEnabled: false }],
+			},
+			stockCorrectionInputs: [90],
+			expectedAfterCorrection: 90,
+			refillInputs: [1],
+			expectedRefillAdded: 180,
+			expectedFinalStock: 270,
+			expectedCapacity: 360,
+			expectedPackageAmountValue: 180,
+		},
+		{
+			label: "inhaler",
+			create: {
+				name: "Matrix Inhaler Refill",
+				packageType: "inhaler",
+				totalPills: 200,
+				looseTablets: 80,
+				intakes: [{ usage: 2, every: 1, start, intakeRemindersEnabled: false }],
+			},
+			stockCorrectionInputs: [110],
+			expectedAfterCorrection: 110,
+			refillInputs: [40],
+			expectedRefillAdded: 40,
+			expectedFinalStock: 150,
+			expectedCapacity: 200,
+		},
+		{
+			label: "injection",
+			create: {
+				name: "Matrix Injection Refill",
+				packageType: "injection",
+				totalPills: 12,
+				looseTablets: 4,
+				intakes: [{ usage: 1, every: 7, start, intakeRemindersEnabled: false }],
+			},
+			stockCorrectionInputs: [5],
+			expectedAfterCorrection: 5,
+			refillInputs: [3],
+			expectedRefillAdded: 3,
+			expectedFinalStock: 8,
+			expectedCapacity: 12,
+		},
+	];
+
+	test.beforeAll(async () => {
+		await deleteAllMedicationsViaAPI();
+	});
+
+	test.afterAll(async () => {
+		await deleteAllMedicationsViaAPI();
+	});
+
+	test("corrects stock and refills every package type through the web UI", async ({ page }) => {
+		for (const scenario of scenarios) {
+			await test.step(`${scenario.label}: create, correct stock, refill`, async () => {
+				const med = await createMedicationViaAPI(scenario.create);
+
+				let modal = await openMedicationDetail(page, scenario.create.name);
+				await modal
+					.getByRole("button", {
+						name: /^(Correct Stock\/Partial Blister|Bestand\/Angebrochene Blister korrigieren|editStock\.buttonLabel)$/i,
+					})
+					.click();
+				const stockDialog = page
+					.getByRole("dialog")
+					.filter({ has: page.getByRole("heading", { name: /Correct Stock|Bestand korrigieren|editStock\.title/i }) })
+					.last();
+				await expect(stockDialog).toBeVisible({ timeout: 5000 });
+				for (const [index, value] of scenario.stockCorrectionInputs.entries()) {
+					await fillNumberInput(page, index, value);
+				}
+				await stockDialog.getByRole("button", { name: /Save Correction|Korrektur speichern|editStock\.save/i }).click();
+				await expect(stockDialog).not.toBeVisible({ timeout: 10000 });
+				await expect
+					.poll(async () => currentStock(await getMedication(page, med.id)), { timeout: 10000 })
+					.toBe(scenario.expectedAfterCorrection);
+
+				await modal
+					.getByLabel(/Close|Schließen|common\.close/i)
+					.first()
+					.click();
+				await expect(modal).not.toBeVisible({ timeout: 5000 });
+
+				modal = await openMedicationDetail(page, scenario.create.name);
+				await modal.getByRole("button", { name: /Refill|Nachfüllen|refill\.button/i }).click();
+				const refillDialog = page
+					.getByRole("dialog")
+					.filter({ has: page.getByRole("heading", { name: /^(Refill|Nachfüllen|refill\.title)$/i }) })
+					.last();
+				await expect(refillDialog).toBeVisible({ timeout: 5000 });
+				for (const [index, value] of scenario.refillInputs.entries()) {
+					await fillNumberInput(page, index, value);
+				}
+				await expect(refillDialog.getByText(new RegExp(`\\+${scenario.expectedRefillAdded}\\b`)).first()).toBeVisible();
+				await refillDialog.getByRole("button", { name: /Refill|Nachfüllen|refill\.button/i }).click();
+				await expect(refillDialog).not.toBeVisible({ timeout: 10000 });
+				await expect
+					.poll(async () => currentStock(await getMedication(page, med.id)), { timeout: 10000 })
+					.toBe(scenario.expectedFinalStock);
+
+				const updated = await getMedication(page, med.id);
+				expect(displayCapacity(updated)).toBe(scenario.expectedCapacity);
+				if (scenario.expectedPackageAmountValue !== undefined) {
+					expect(updated.packageAmountValue).toBe(scenario.expectedPackageAmountValue);
+				}
+				const refills = await getRefillHistory(page, med.id);
+				expect(refills[0]?.quantityAdded).toBe(scenario.expectedRefillAdded);
+
+				await modal
+					.getByLabel(/Close|Schließen|common\.close/i)
+					.first()
+					.click();
+				await expect(modal).not.toBeVisible({ timeout: 5000 });
+			});
+		}
+	});
+});

--- a/frontend/src/hooks/useRefill.ts
+++ b/frontend/src/hooks/useRefill.ts
@@ -262,20 +262,18 @@ export function useRefill(): UseRefillReturn {
 					patchBody.stockAdjustment = 0;
 					patchBody.packCount = 0;
 					patchBody.looseTablets = 0;
-					if (isDiscreteCountPackage || isAmountPackage) {
+					if (isPackageAmountPackage) {
 						patchBody.totalPills = 0;
 					}
-					if (isPackageAmountPackage) {
-						patchBody.packageAmountValue = 0;
-					}
 				} else if (isTubePackage) {
-					// Tube has fixed count=1 and no automatic depletion.
-					// Correction must update the base amount fields directly.
+					// Keep the configured amount per tube stable. A correction changes
+					// the amount on hand, not the size of future tube refills.
+					const correctedTubeCount = Math.max(1, Math.ceil(desiredTotal / liquidAmountPerBottle));
 					patchBody.stockAdjustment = 0;
-					patchBody.packCount = 1;
+					patchBody.packCount = correctedTubeCount;
 					patchBody.totalPills = desiredTotal;
 					patchBody.looseTablets = desiredTotal;
-					patchBody.packageAmountValue = desiredTotal;
+					patchBody.packageAmountValue = liquidAmountPerBottle;
 				} else if (isLiquidPackage) {
 					// Liquid correction supports bottle-count updates.
 					// Keep packageAmountValue (ml per bottle) and update capacity base by bottle count.

--- a/frontend/src/test/hooks/useRefill.test.ts
+++ b/frontend/src/test/hooks/useRefill.test.ts
@@ -455,7 +455,6 @@ describe("useRefill", () => {
 			stockAdjustment: 0,
 			packCount: 0,
 			looseTablets: 0,
-			totalPills: 0,
 		});
 	});
 
@@ -518,7 +517,53 @@ describe("useRefill", () => {
 			packCount: 0,
 			looseTablets: 0,
 			totalPills: 0,
-			packageAmountValue: 0,
+		});
+	});
+
+	it("keeps tube amount per package stable when correcting current stock", async () => {
+		(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+
+		const tubeMed: Medication = {
+			id: 13,
+			name: "Tube Stable Package Size",
+			medicationForm: "topical",
+			packageType: "tube",
+			doseUnit: "units",
+			packCount: 1,
+			packageAmountValue: 40,
+			packageAmountUnit: "g",
+			blistersPerPack: 1,
+			pillsPerBlister: 1,
+			totalPills: 40,
+			looseTablets: 40,
+			stockAdjustment: 0,
+			takenBy: [],
+			blisters: [{ usage: 2, every: 1, start: "2026-01-31T20:27:00" }],
+			updatedAt: null,
+		};
+
+		const mockLoadMeds = vi.fn();
+		const { result } = renderHook(() => useRefill());
+
+		act(() => {
+			result.current.openEditStockModal(tubeMed, {
+				all: [{ name: tubeMed.name, medsLeft: 24, daysLeft: 12 }] as Coverage[],
+			});
+			result.current.setEditStockPartialBlisterPills(24);
+		});
+
+		await act(async () => {
+			await result.current.submitStockCorrection(13, tubeMed, mockLoadMeds);
+		});
+
+		const [, requestInit] = authFetchMock.mock.calls[0] ?? [];
+		const body = parseRequestBody(requestInit);
+		expect(body).toEqual({
+			stockAdjustment: 0,
+			packCount: 1,
+			totalPills: 24,
+			looseTablets: 24,
+			packageAmountValue: 40,
 		});
 	});
 


### PR DESCRIPTION
## Summary

- preserve configured package capacity when stock corrections set current stock to zero
- keep tube amount-per-package stable while updating current stock and pack count separately
- add backend, hook, and browser E2E refill/restock matrix coverage for blister, bottle, tube, liquid container, inhaler, and injection packages

Closes #885

## Validation

- `npm --prefix frontend run test:run -- src/test/hooks/useRefill.test.ts` -> 30 passed
- `npm --prefix backend run test:run -- src/test/e2e-routes.test.ts -t "refill|stock-adjustment|package"` -> 54 passed, 90 skipped
- `npm run check` -> green
- `PLAYWRIGHT_HTML_OPEN=never npm --prefix frontend run test:e2e -- e2e/refill-restock-matrix.spec.ts` -> 2 passed
- `PLAYWRIGHT_HTML_OPEN=never npm --prefix frontend run test:e2e:all -- e2e/refill-restock-matrix.spec.ts` -> 4 passed across setup, chromium, firefox, webkit