### PR TITLE
chore: release 1.30.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.30.1
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.30.2
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.30.1
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.30.2
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
@@ -45,7 +45,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.30.1",
+  "version": "1.30.2",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3"

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Prepare MedAssist-ng v1.30.2 as a patch release.

## Changes

- Bump backend, frontend, and shared package metadata to 1.30.2.
- Pin production Docker Compose images to the 1.30.2 release tags.
- Include the already-merged mobile/Firefox dose-action layout fix in a versioned release.

## Validation

- `npm run release:preflight -- --tag v1.30.2 --static-only --compose docker-compose.yml --workflow .github/workflows/docker-build.yml`
- `npm run check`
- `git diff --check`

Closes #891