### PR TITLE
fix: keep Dependabot automerge PRs fresh

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -9,6 +9,9 @@ on:
       - ready_for_review
   push:
     branches: [main]
+  schedule:
+    # Bot-created auto-merge commits do not reliably trigger the push sweep.
+    - cron: '17 * * * *'
   workflow_dispatch:
 
 concurrency:
@@ -45,7 +48,7 @@ jobs:
           merge-method: squash
 
   request-dependabot-rebase:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -53,6 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          REBASE_REQUEST_COOLDOWN_SECONDS: "21600"
         run: |
           set -euo pipefail
 
@@ -77,6 +81,25 @@ jobs:
             fi
 
             echo "Requesting Dependabot rebase for PR #$pr_number."
+            latest_request="$(
+              gh pr view "$pr_number" \
+                --repo "$REPO" \
+                --json comments \
+                --jq '.comments[] | select(.author.login == "github-actions[bot]" and .body == "@dependabot rebase") | .createdAt' \
+                | tail -n 1
+            )"
+
+            if [ -n "$latest_request" ]; then
+              now_epoch="$(date -u +%s)"
+              request_epoch="$(date -u -d "$latest_request" +%s)"
+              request_age_seconds=$((now_epoch - request_epoch))
+
+              if [ "$request_age_seconds" -lt "$REBASE_REQUEST_COOLDOWN_SECONDS" ]; then
+                echo "Skipping PR #$pr_number because a rebase was requested ${request_age_seconds}s ago."
+                continue
+              fi
+            fi
+
             if ! gh pr comment "$pr_number" --repo "$REPO" --body "@dependabot rebase"; then
               echo "::warning::Failed to request Dependabot rebase for PR #$pr_number."
               failed=1

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -44,3 +44,13 @@ jobs:
       - name: Run actionlint
         if: needs.changes.outputs.workflows == 'true'
         uses: rhysd/actionlint@v1.7.12
+
+      - name: Setup Node.js
+        if: needs.changes.outputs.workflows == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Run release preflight workflow contracts
+        if: needs.changes.outputs.workflows == 'true'
+        run: node scripts/test-release-preflight.mjs

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -183,6 +183,38 @@ function validateContainerSmokeWorkflow(workflowPath) {
   }
 }
 
+function validateDependabotAutomergeWorkflow(workflowPath) {
+  const workflow = readText(workflowPath);
+
+  if (!/\n\s*schedule:\s*\n(?:\s*#.*\n)*\s*-\s*cron:\s*['"][^'"]+['"]/.test(workflow)) {
+    fail(`${workflowPath} must run a scheduled stale Dependabot auto-merge sweep.`);
+  }
+
+  if (!workflow.includes("github.event_name == 'schedule'")) {
+    fail(`${workflowPath} stale Dependabot rebase job must run for scheduled sweeps.`);
+  }
+
+  if (
+    !/gh pr list[\s\S]*--author "app\/dependabot"[\s\S]*--json number,autoMergeRequest,mergeStateStatus[\s\S]*mergeStateStatus == "BEHIND"/.test(
+      workflow
+    )
+  ) {
+    fail(`${workflowPath} must find open Dependabot auto-merge PRs that are behind main.`);
+  }
+
+  if (!/REBASE_REQUEST_COOLDOWN_SECONDS:\s*"[0-9]+"/.test(workflow)) {
+    fail(`${workflowPath} must throttle repeated scheduled rebase requests.`);
+  }
+
+  if (!/--json comments[\s\S]*\.body == "@dependabot rebase"/.test(workflow)) {
+    fail(`${workflowPath} must check recent rebase comments before requesting another rebase.`);
+  }
+
+  if (!workflow.includes('--body "@dependabot rebase"')) {
+    fail(`${workflowPath} must request stale Dependabot PR rebases with the Dependabot command comment.`);
+  }
+}
+
 function validatePackageVersion(packageName, packageJsonPath, packageJson, releaseVersion) {
   if (packageJson.version !== releaseVersion) {
     fail(`${packageJsonPath} version must match ${releaseVersion}, found ${packageJson.version}.`);
@@ -382,6 +414,11 @@ function main() {
 
   const containerSmokeWorkflowPath = String(args["container-smoke-workflow"] || ".github/workflows/container-smoke.yml");
   validateContainerSmokeWorkflow(containerSmokeWorkflowPath);
+
+  const dependabotAutomergeWorkflowPath = String(
+    args["dependabot-automerge-workflow"] || ".github/workflows/dependabot-automerge.yml"
+  );
+  validateDependabotAutomergeWorkflow(dependabotAutomergeWorkflowPath);
 
   if (args["static-only"]) {
     console.log(`release-preflight: static checks passed for ${tag}`);

--- a/scripts/test-release-preflight.mjs
+++ b/scripts/test-release-preflight.mjs
@@ -29,6 +29,7 @@ function copyFixture() {
     "shared/package-lock.json",
     ".github/workflows/docker-build.yml",
     ".github/workflows/container-smoke.yml",
+    ".github/workflows/dependabot-automerge.yml",
     ".github/workflows/test.yml",
     ".github/workflows/e2e.yml"
   ];
@@ -231,6 +232,63 @@ test("release preflight rejects fatal Docker publish cache export", () => {
     expectPreflightFailure(
       fixtureRoot,
       /\.github\/workflows\/docker-build\.yml build-and-push cache-to must ignore GitHub Actions cache export failures/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects Dependabot automerge without a scheduled stale PR sweep", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/dependabot-automerge.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      /\s{2}schedule:\n(?:\s{4}#.*\n)*\s{4}- cron: '[^']+'\n/,
+      ""
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /\.github\/workflows\/dependabot-automerge\.yml must run a scheduled stale Dependabot auto-merge sweep/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects Dependabot automerge when the scheduled sweep does not run the rebase job", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/dependabot-automerge.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      "github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'",
+      "github.event_name == 'push' || github.event_name == 'workflow_dispatch'"
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /\.github\/workflows\/dependabot-automerge\.yml stale Dependabot rebase job must run for scheduled sweeps/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects Dependabot automerge without rebase request throttling", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/dependabot-automerge.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      "          REBASE_REQUEST_COOLDOWN_SECONDS: \"21600\"\n",
+      ""
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /\.github\/workflows\/dependabot-automerge\.yml must throttle repeated scheduled rebase requests/
     );
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #897

- Add an hourly scheduled stale sweep to the Dependabot Automerge workflow.
- Request `@dependabot rebase` for open Dependabot PRs with auto-merge enabled and `BEHIND` merge state on push, schedule, or manual dispatch.
- Add a six-hour duplicate-comment cooldown for workflow-issued rebase requests.
- Extend workflow validation and release preflight tests so the scheduled stale-rebase contract is checked in workflow-only PRs.

## Validation

Reported local validation on this tracked diff:

```bash
npm run test:release-preflight
npm run release:preflight -- --tag v1.30.2 --static-only
actionlint .github/workflows/dependabot-automerge.yml .github/workflows/workflow-validation.yml
node --check scripts/release-preflight.mjs && node --check scripts/test-release-preflight.mjs
git diff --check
```

Results reported:

- `npm run test:release-preflight` passed, 14/14.
- `npm run release:preflight -- --tag v1.30.2 --static-only` passed.
- `actionlint .github/workflows/dependabot-automerge.yml .github/workflows/workflow-validation.yml` passed.
- `node --check scripts/release-preflight.mjs && node --check scripts/test-release-preflight.mjs` passed.
- `git diff --check` passed.