### PR TITLE
fix: rebase stale Dependabot PRs via update branch

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -47,16 +47,15 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
 
-  request-dependabot-rebase:
+  rebase-stale-dependabot-prs:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Request Dependabot rebase for stale auto-merge PR branches
+      - name: Rebase stale Dependabot auto-merge PR branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          REBASE_REQUEST_COOLDOWN_SECONDS: "21600"
         run: |
           set -euo pipefail
 
@@ -80,28 +79,9 @@ jobs:
               continue
             fi
 
-            echo "Requesting Dependabot rebase for PR #$pr_number."
-            latest_request="$(
-              gh pr view "$pr_number" \
-                --repo "$REPO" \
-                --json comments \
-                --jq '.comments[] | select(.author.login == "github-actions[bot]" and .body == "@dependabot rebase") | .createdAt' \
-                | tail -n 1
-            )"
-
-            if [ -n "$latest_request" ]; then
-              now_epoch="$(date -u +%s)"
-              request_epoch="$(date -u -d "$latest_request" +%s)"
-              request_age_seconds=$((now_epoch - request_epoch))
-
-              if [ "$request_age_seconds" -lt "$REBASE_REQUEST_COOLDOWN_SECONDS" ]; then
-                echo "Skipping PR #$pr_number because a rebase was requested ${request_age_seconds}s ago."
-                continue
-              fi
-            fi
-
-            if ! gh pr comment "$pr_number" --repo "$REPO" --body "@dependabot rebase"; then
-              echo "::warning::Failed to request Dependabot rebase for PR #$pr_number."
+            echo "Rebasing stale Dependabot PR #$pr_number."
+            if ! gh pr update-branch "$pr_number" --repo "$REPO" --rebase; then
+              echo "::warning::Failed to rebase stale Dependabot PR #$pr_number."
               failed=1
             fi
           done <<< "$prs"

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -202,16 +202,12 @@ function validateDependabotAutomergeWorkflow(workflowPath) {
     fail(`${workflowPath} must find open Dependabot auto-merge PRs that are behind main.`);
   }
 
-  if (!/REBASE_REQUEST_COOLDOWN_SECONDS:\s*"[0-9]+"/.test(workflow)) {
-    fail(`${workflowPath} must throttle repeated scheduled rebase requests.`);
+  if (!/gh pr update-branch "\$pr_number"[\s\S]*--repo "\$REPO"[\s\S]*--rebase/.test(workflow)) {
+    fail(`${workflowPath} must rebase stale Dependabot PRs through GitHub's update-branch API.`);
   }
 
-  if (!/--json comments[\s\S]*\.body == "@dependabot rebase"/.test(workflow)) {
-    fail(`${workflowPath} must check recent rebase comments before requesting another rebase.`);
-  }
-
-  if (!workflow.includes('--body "@dependabot rebase"')) {
-    fail(`${workflowPath} must request stale Dependabot PR rebases with the Dependabot command comment.`);
+  if (workflow.includes("@dependabot rebase") || /gh pr comment[\s\S]*dependabot rebase/.test(workflow)) {
+    fail(`${workflowPath} must not rely on Dependabot command comments from github-actions[bot].`);
   }
 }
 

--- a/scripts/test-release-preflight.mjs
+++ b/scripts/test-release-preflight.mjs
@@ -276,19 +276,38 @@ test("release preflight rejects Dependabot automerge when the scheduled sweep do
   }
 });
 
-test("release preflight rejects Dependabot automerge without rebase request throttling", () => {
+test("release preflight rejects Dependabot automerge without direct update-branch rebase", () => {
   const fixtureRoot = copyFixture();
   try {
     const workflowPath = path.join(fixtureRoot, ".github/workflows/dependabot-automerge.yml");
     const workflow = readFileSync(workflowPath, "utf8").replace(
-      "          REBASE_REQUEST_COOLDOWN_SECONDS: \"21600\"\n",
-      ""
+      'gh pr update-branch "$pr_number" --repo "$REPO" --rebase',
+      'gh pr view "$pr_number" --repo "$REPO"'
     );
     writeFileSync(workflowPath, workflow);
 
     expectPreflightFailure(
       fixtureRoot,
-      /\.github\/workflows\/dependabot-automerge\.yml must throttle repeated scheduled rebase requests/
+      /\.github\/workflows\/dependabot-automerge\.yml must rebase stale Dependabot PRs through GitHub's update-branch API/
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("release preflight rejects Dependabot automerge command comments from github-actions", () => {
+  const fixtureRoot = copyFixture();
+  try {
+    const workflowPath = path.join(fixtureRoot, ".github/workflows/dependabot-automerge.yml");
+    const workflow = readFileSync(workflowPath, "utf8").replace(
+      'gh pr update-branch "$pr_number" --repo "$REPO" --rebase',
+      'gh pr update-branch "$pr_number" --repo "$REPO" --rebase\n              gh pr comment "$pr_number" --repo "$REPO" --body "@dependabot rebase"'
+    );
+    writeFileSync(workflowPath, workflow);
+
+    expectPreflightFailure(
+      fixtureRoot,
+      /\.github\/workflows\/dependabot-automerge\.yml must not rely on Dependabot command comments from github-actions\[bot\]/
     );
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #897.

This follow-up replaces bot-authored Dependabot command comments with GitHub's update-branch rebase API for stale Dependabot PRs that already have auto-merge enabled.

## Changes

- Rename the stale refresh job to `rebase-stale-dependabot-prs`.
- Keep the push, hourly schedule, and workflow dispatch triggers.
- Keep selecting open Dependabot PRs with `autoMergeRequest != null` and `mergeStateStatus == BEHIND`.
- Rebase stale branches with `gh pr update-branch "$pr_number" --repo "$REPO" --rebase`.
- Update release-preflight checks to require the update-branch rebase path and reject `@dependabot rebase` command comments from `github-actions[bot]`.

## Validation

- `npm run test:release-preflight` passed, 15/15.
- `npm run release:preflight -- --tag v1.30.2 --static-only` passed.
- `actionlint .github/workflows/dependabot-automerge.yml .github/workflows/workflow-validation.yml` passed.
- `node --check scripts/release-preflight.mjs && node --check scripts/test-release-preflight.mjs` passed.
- `git diff --check` passed.