### PR TITLE
fix: propagate app language to notifications and shares

### DIFF
--- a/backend/src/routes/share.ts
+++ b/backend/src/routes/share.ts
@@ -103,6 +103,7 @@ const shareReadResponseSchema = {
 	properties: {
 		takenBy: { type: "string" },
 		sharedBy: { type: "string" },
+		language: { type: "string", enum: ["en", "de"] },
 		scheduleDays: { type: "integer" },
 		medications: { type: "array", items: { type: "object", additionalProperties: true } },
 		shareMedicationOverview: { type: "boolean" },
@@ -125,6 +126,7 @@ const shareExpiredResponseSchema = {
 		code: { type: "string" },
 		ownerUsername: { type: "string" },
 		takenBy: { type: "string" },
+		language: { type: "string", enum: ["en", "de"] },
 		expiredAt: { type: "string", format: "date-time" },
 	},
 } as const;
@@ -133,6 +135,7 @@ const shareOverviewExpiredResponseSchema = {
 	type: "object",
 	properties: {
 		error: { type: "string" },
+		language: { type: "string", enum: ["en", "de"] },
 		expiredAt: { type: "string", format: "date-time" },
 	},
 } as const;
@@ -142,6 +145,7 @@ const shareOverviewResponseSchema = {
 	properties: {
 		takenBy: { type: "string" },
 		sharedBy: { type: "string" },
+		language: { type: "string", enum: ["en", "de"] },
 		generatedAt: { type: "string", format: "date-time" },
 		medications: { type: "array", items: { type: "object", additionalProperties: true } },
 	},
@@ -198,6 +202,10 @@ function isShareRevoked(share: typeof shareTokens.$inferSelect): boolean {
 
 function isShareActive(share: typeof shareTokens.$inferSelect): boolean {
 	return !isShareRevoked(share) && !isExpiredTimestamp(share.expiresAt);
+}
+
+function getShareLanguage(language: string | null | undefined): "en" | "de" {
+	return language === "de" ? "de" : "en";
 }
 
 type MedicationRow = typeof medications.$inferSelect;
@@ -322,11 +330,16 @@ export async function shareRoutes(app: FastifyInstance) {
 				);
 				// Get the username of the owner to show in the expired message
 				const [owner] = await db.select({ username: users.username }).from(users).where(eq(users.id, share.userId));
+				const [settings] = await db
+					.select({ language: userSettings.language })
+					.from(userSettings)
+					.where(eq(userSettings.userId, share.userId));
 				return reply.status(410).send({
 					error: "Share link has expired",
 					code: "EXPIRED",
 					ownerUsername: owner?.username ?? "the owner",
 					takenBy: share.takenBy,
+					language: getShareLanguage(settings?.language),
 					expiredAt: share.expiresAt.toISOString(),
 				});
 			}
@@ -353,6 +366,7 @@ export async function shareRoutes(app: FastifyInstance) {
 			return {
 				takenBy: share.takenBy,
 				sharedBy: owner?.username ?? null,
+				language: getShareLanguage(settings?.language),
 				scheduleDays: share.scheduleDays,
 				allowJournalNotes: share.allowJournalNotes ?? false,
 				allowMarkTaken: share.allowMarkTaken ?? true,
@@ -416,8 +430,13 @@ export async function shareRoutes(app: FastifyInstance) {
 				request.log.warn(
 					`[ShareOverview] Expired token requested: tokenFingerprint=${fingerprint}, ownerUserId=${share.userId}`
 				);
+				const [settings] = await db
+					.select({ language: userSettings.language })
+					.from(userSettings)
+					.where(eq(userSettings.userId, share.userId));
 				return reply.status(410).send({
 					error: "expired",
+					language: getShareLanguage(settings?.language),
 					expiredAt: share.expiresAt.toISOString(),
 				});
 			}
@@ -439,6 +458,7 @@ export async function shareRoutes(app: FastifyInstance) {
 			return {
 				takenBy: share.takenBy,
 				sharedBy: owner?.username ?? null,
+				language: getShareLanguage(settings?.language),
 				generatedAt: new Date().toISOString(),
 				medications: overview,
 			};

--- a/backend/src/services/notification-actions-service.ts
+++ b/backend/src/services/notification-actions-service.ts
@@ -202,7 +202,21 @@ export async function createNotificationActionContext(input: {
 			)
 		);
 
-	if (!group) {
+	if (group) {
+		[group] = await db
+			.update(notificationActionGroups)
+			.set({
+				doseIdsJson: JSON.stringify(uniqueDoseIds),
+				title: input.title,
+				message: input.message,
+				language: input.language,
+				scheduledFor: input.scheduledFor,
+				expiresAt,
+				updatedAt: now,
+			})
+			.where(eq(notificationActionGroups.id, group.id))
+			.returning();
+	} else {
 		const [existingGroup] = await db
 			.select()
 			.from(notificationActionGroups)

--- a/backend/src/test/notification-actions-service.test.ts
+++ b/backend/src/test/notification-actions-service.test.ts
@@ -186,6 +186,52 @@ describe("notification-actions-service", () => {
 		expect(Number(tokens.rows[0].count)).toBe(6);
 	});
 
+	it("refreshes reused active groups with the current language and message", async () => {
+		const userId = await createUser("notify-actions-language-refresh");
+		const scheduledFor = new Date("2026-01-05T08:00:00.000Z");
+		const doseIds = ["9-0-1736064000000"];
+
+		const first = await createNotificationActionContext({
+			userId,
+			title: "Erinnerung",
+			message: "Nimm deine Medikamente",
+			doseIds,
+			scheduledFor,
+			publicAppUrl: mockedEnv.PUBLIC_APP_URL,
+			language: "de",
+		});
+		const second = await createNotificationActionContext({
+			userId,
+			title: "Reminder",
+			message: "Take your medication now",
+			doseIds,
+			scheduledFor,
+			publicAppUrl: mockedEnv.PUBLIC_APP_URL,
+			language: "en",
+		});
+
+		expect(first?.actions.find((action) => action.kind === "taken")?.label).toBe("Einnehmen");
+		expect(second?.sequenceId).toBe(first?.sequenceId);
+		expect(second?.actions.find((action) => action.kind === "taken")?.label).toBe("Take");
+		expect(second?.actions.find((action) => action.kind === "skip")?.label).toBe("Skip");
+
+		const groups = await testClient.execute(
+			"SELECT title, message, language, dose_ids_json FROM notification_action_groups"
+		);
+		expect(groups.rows).toHaveLength(1);
+		expect(groups.rows[0]).toEqual(
+			expect.objectContaining({
+				title: "Reminder",
+				message: "Take your medication now",
+				language: "en",
+				dose_ids_json: JSON.stringify(doseIds),
+			})
+		);
+
+		const tokens = await testClient.execute("SELECT COUNT(*) AS count FROM notification_action_tokens");
+		expect(Number(tokens.rows[0].count)).toBe(6);
+	});
+
 	it("reactivates a resolved group with the same key instead of inserting a duplicate", async () => {
 		const userId = await createUser("notify-actions-reactivate");
 		const scheduledFor = new Date("2026-01-05T08:00:00.000Z");

--- a/backend/src/test/share-hardening.test.ts
+++ b/backend/src/test/share-hardening.test.ts
@@ -202,6 +202,22 @@ describe("share link hardening", () => {
 		expect(response.json()).toMatchObject({ takenBy: "Daniel", allowMarkTaken: true });
 	});
 
+	it("returns the owner's saved language for public shared schedules", async () => {
+		await testClient.execute(
+			"INSERT INTO user_settings (user_id, language, share_medication_overview) VALUES (1, 'de', 1)"
+		);
+		await insertMedication();
+		await insertShareToken({ token: "abcdef0123456789" });
+
+		const response = await app.inject({ method: "GET", url: "/share/abcdef0123456789" });
+		const overviewResponse = await app.inject({ method: "GET", url: "/share/abcdef0123456789/overview" });
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json()).toMatchObject({ takenBy: "Daniel", language: "de" });
+		expect(overviewResponse.statusCode, overviewResponse.body).toBe(200);
+		expect(overviewResponse.json()).toMatchObject({ takenBy: "Daniel", language: "de" });
+	});
+
 	it("scopes public share schedule and overview data to the selected person", async () => {
 		const start = buildLocalDoseStart();
 		await testClient.execute({
@@ -229,6 +245,7 @@ describe("share link hardening", () => {
 		const scheduleResponse = await app.inject({ method: "GET", url: "/share/abcdef0123456789" });
 		expect(scheduleResponse.statusCode, scheduleResponse.body).toBe(200);
 		const schedule = scheduleResponse.json();
+		expect(schedule.language).toBe("en");
 		expect(JSON.stringify(schedule)).not.toContain("Bob");
 		expect(schedule.medications).toHaveLength(1);
 		expect(schedule.medications[0].takenBy).toEqual(["Alice"]);
@@ -242,6 +259,7 @@ describe("share link hardening", () => {
 		const overviewResponse = await app.inject({ method: "GET", url: "/share/abcdef0123456789/overview" });
 		expect(overviewResponse.statusCode, overviewResponse.body).toBe(200);
 		const overview = overviewResponse.json();
+		expect(overview.language).toBe("en");
 		expect(JSON.stringify(overview)).not.toContain("Bob");
 		expect(overview.medications[0].daysLeft).toBe(2);
 	});
@@ -287,6 +305,21 @@ describe("share link hardening", () => {
 
 		expect(readResponse.statusCode).toBe(410);
 		expect(writeResponse.statusCode).not.toBe(200);
+	});
+
+	it("returns the owner's saved language for expired public shared schedules", async () => {
+		await testClient.execute("INSERT INTO user_settings (user_id, language) VALUES (1, 'de')");
+		await insertMedication();
+		const token = "1212121212121212";
+		await insertShareToken({ token, expiresAt: Math.floor(Date.now() / 1000) - 60 });
+
+		const response = await app.inject({ method: "GET", url: `/share/${token}` });
+		const overviewResponse = await app.inject({ method: "GET", url: `/share/${token}/overview` });
+
+		expect(response.statusCode, response.body).toBe(410);
+		expect(response.json()).toMatchObject({ takenBy: "Daniel", language: "de" });
+		expect(overviewResponse.statusCode, overviewResponse.body).toBe(410);
+		expect(overviewResponse.json()).toMatchObject({ language: "de" });
 	});
 
 	it("rejects revoked tokens for read and write", async () => {

--- a/frontend/src/components/SharedSchedule.tsx
+++ b/frontend/src/components/SharedSchedule.tsx
@@ -73,6 +73,14 @@ function getExpectedSharedDoseMarker(doseId: string, sharedTakenBy: string | nul
 	return getDosePersonSuffix(doseId) ?? "all";
 }
 
+function getSharedLanguage(language: unknown): "en" | "de" | null {
+	if (language === "en" || language === "de") {
+		return language;
+	}
+
+	return null;
+}
+
 export function SharedSchedule() {
 	const { token } = useParams<{ token: string }>();
 	const { t, i18n } = useTranslation();
@@ -817,14 +825,23 @@ export function SharedSchedule() {
 			try {
 				const res = await fetch(`/api/share/${token}`);
 				if (res.ok) {
-					const json = await res.json();
-					setData(json);
+					const json = (await res.json()) as SharedScheduleData;
+					const sharedLanguage = getSharedLanguage(json.language);
+					if (sharedLanguage && i18n.language !== sharedLanguage) {
+						await i18n.changeLanguage(sharedLanguage);
+					}
+					setData(sharedLanguage ? { ...json, language: sharedLanguage } : json);
 				} else if (res.status === 410) {
 					// Link expired - get owner info
 					const json = await res.json();
+					const sharedLanguage = getSharedLanguage(json.language);
+					if (sharedLanguage && i18n.language !== sharedLanguage) {
+						await i18n.changeLanguage(sharedLanguage);
+					}
 					setExpiredData({
 						ownerUsername: json.ownerUsername,
 						takenBy: json.takenBy,
+						language: sharedLanguage ?? undefined,
 						expiredAt: json.expiredAt,
 					});
 				} else if (res.status === 404) {
@@ -839,7 +856,7 @@ export function SharedSchedule() {
 			}
 		}
 		fetchData();
-	}, [token, t]);
+	}, [i18n, token, t]);
 
 	function buildGroupedSchedule() {
 		if (!data) return [];

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -7,7 +7,10 @@ import { useTranslation } from "react-i18next";
 import { log } from "../utils/logger";
 import { settingsChanged } from "../utils/settings";
 
+export type AppLanguage = "en" | "de";
+
 export interface Settings {
+	language: AppLanguage;
 	timezone: string;
 	availableTimezones: string[];
 	serverTimezone: string;
@@ -62,6 +65,7 @@ export interface Settings {
 export type SettingsLoadError = "auth" | "forbidden" | "request" | null;
 
 const defaultSettings: Settings = {
+	language: "en",
 	timezone: "",
 	availableTimezones: [],
 	serverTimezone: "UTC",
@@ -126,6 +130,10 @@ const reminderMetadataKeys = [
 	"lastPrescriptionReminderChannel",
 	"lastPrescriptionReminderMedNames",
 ] as const;
+
+function getSupportedLanguage(value: unknown): AppLanguage {
+	return value === "de" ? "de" : "en";
+}
 
 function mergeReminderMetadata(prev: Settings, data: unknown): Settings {
 	if (typeof data !== "object" || data === null) {
@@ -272,54 +280,51 @@ export function useSettings(options: UseSettingsOptions = {}): UseSettingsReturn
 		return response;
 	}, []);
 
-	const buildSettingsPayload = useCallback(
-		(settingsToSave: Settings) => {
-			const effectiveEmailEnabled = settingsToSave.emailEnabled && !!settingsToSave.notificationEmail?.trim();
-			const effectiveShoutrrrEnabled = settingsToSave.shoutrrrEnabled && !!settingsToSave.shoutrrrUrl?.trim();
-			const hasEmailStock =
-				effectiveEmailEnabled && settingsToSave.emailStockReminders && !!settingsToSave.notificationEmail?.trim();
-			const hasShoutrrrStock =
-				effectiveShoutrrrEnabled && settingsToSave.shoutrrrStockReminders && !!settingsToSave.shoutrrrUrl?.trim();
-			const hasAnyStockReminder = hasEmailStock || hasShoutrrrStock;
-			const repeatDailyReminders = hasAnyStockReminder ? settingsToSave.repeatDailyReminders : false;
+	const buildSettingsPayload = useCallback((settingsToSave: Settings) => {
+		const effectiveEmailEnabled = settingsToSave.emailEnabled && !!settingsToSave.notificationEmail?.trim();
+		const effectiveShoutrrrEnabled = settingsToSave.shoutrrrEnabled && !!settingsToSave.shoutrrrUrl?.trim();
+		const hasEmailStock =
+			effectiveEmailEnabled && settingsToSave.emailStockReminders && !!settingsToSave.notificationEmail?.trim();
+		const hasShoutrrrStock =
+			effectiveShoutrrrEnabled && settingsToSave.shoutrrrStockReminders && !!settingsToSave.shoutrrrUrl?.trim();
+		const hasAnyStockReminder = hasEmailStock || hasShoutrrrStock;
+		const repeatDailyReminders = hasAnyStockReminder ? settingsToSave.repeatDailyReminders : false;
 
-			return {
-				timezone: settingsToSave.timezone,
-				emailEnabled: effectiveEmailEnabled,
-				notificationEmail: settingsToSave.notificationEmail,
-				reminderDaysBefore: settingsToSave.reminderDaysBefore,
-				repeatDailyReminders,
-				skipRemindersForTakenDoses: settingsToSave.skipRemindersForTakenDoses,
-				repeatRemindersEnabled: settingsToSave.repeatRemindersEnabled,
-				reminderRepeatIntervalMinutes: settingsToSave.reminderRepeatIntervalMinutes,
-				maxNaggingReminders: settingsToSave.maxNaggingReminders ?? 5,
-				lowStockDays: settingsToSave.lowStockDays,
-				normalStockDays: settingsToSave.normalStockDays,
-				highStockDays: settingsToSave.highStockDays,
-				shoutrrrEnabled: effectiveShoutrrrEnabled,
-				shoutrrrUrl: settingsToSave.shoutrrrUrl,
-				emailStockReminders: settingsToSave.emailStockReminders,
-				emailIntakeReminders: settingsToSave.emailIntakeReminders,
-				emailPrescriptionReminders: settingsToSave.emailPrescriptionReminders,
-				shoutrrrStockReminders: settingsToSave.shoutrrrStockReminders,
-				shoutrrrIntakeReminders: settingsToSave.shoutrrrIntakeReminders,
-				shoutrrrPrescriptionReminders: settingsToSave.shoutrrrPrescriptionReminders,
-				stockCalculationMode: settingsToSave.stockCalculationMode,
-				shareMedicationOverview: settingsToSave.shareMedicationOverview,
-				upcomingTodayOnly: settingsToSave.upcomingTodayOnly,
-				shareScheduleTodayOnly: settingsToSave.shareScheduleTodayOnly,
-				swapDashboardMainSections: settingsToSave.swapDashboardMainSections,
-				language: i18n.language,
-				smtpHost: settingsToSave.smtpHost,
-				smtpPort: settingsToSave.smtpPort,
-				smtpUser: settingsToSave.smtpUser,
-				smtpPass: settingsToSave.smtpPass || undefined,
-				smtpFrom: settingsToSave.smtpFrom,
-				smtpSecure: settingsToSave.smtpSecure,
-			};
-		},
-		[i18n.language]
-	);
+		return {
+			timezone: settingsToSave.timezone,
+			emailEnabled: effectiveEmailEnabled,
+			notificationEmail: settingsToSave.notificationEmail,
+			reminderDaysBefore: settingsToSave.reminderDaysBefore,
+			repeatDailyReminders,
+			skipRemindersForTakenDoses: settingsToSave.skipRemindersForTakenDoses,
+			repeatRemindersEnabled: settingsToSave.repeatRemindersEnabled,
+			reminderRepeatIntervalMinutes: settingsToSave.reminderRepeatIntervalMinutes,
+			maxNaggingReminders: settingsToSave.maxNaggingReminders ?? 5,
+			lowStockDays: settingsToSave.lowStockDays,
+			normalStockDays: settingsToSave.normalStockDays,
+			highStockDays: settingsToSave.highStockDays,
+			shoutrrrEnabled: effectiveShoutrrrEnabled,
+			shoutrrrUrl: settingsToSave.shoutrrrUrl,
+			emailStockReminders: settingsToSave.emailStockReminders,
+			emailIntakeReminders: settingsToSave.emailIntakeReminders,
+			emailPrescriptionReminders: settingsToSave.emailPrescriptionReminders,
+			shoutrrrStockReminders: settingsToSave.shoutrrrStockReminders,
+			shoutrrrIntakeReminders: settingsToSave.shoutrrrIntakeReminders,
+			shoutrrrPrescriptionReminders: settingsToSave.shoutrrrPrescriptionReminders,
+			stockCalculationMode: settingsToSave.stockCalculationMode,
+			shareMedicationOverview: settingsToSave.shareMedicationOverview,
+			upcomingTodayOnly: settingsToSave.upcomingTodayOnly,
+			shareScheduleTodayOnly: settingsToSave.shareScheduleTodayOnly,
+			swapDashboardMainSections: settingsToSave.swapDashboardMainSections,
+			language: settingsToSave.language,
+			smtpHost: settingsToSave.smtpHost,
+			smtpPort: settingsToSave.smtpPort,
+			smtpUser: settingsToSave.smtpUser,
+			smtpPass: settingsToSave.smtpPass || undefined,
+			smtpFrom: settingsToSave.smtpFrom,
+			smtpSecure: settingsToSave.smtpSecure,
+		};
+	}, []);
 
 	const flushSettingsWithKeepalive = useCallback(
 		(settingsToSave: Settings) => {
@@ -360,9 +365,13 @@ export function useSettings(options: UseSettingsOptions = {}): UseSettingsReturn
 			.then((data) => {
 				if (!data || loadGenerationRef.current !== generation) return;
 				log.debug("[useSettings] settings loaded", { smtpConfigured: !!data.smtpHost });
-				const newSettings = { ...defaultSettings, ...data, smtpPass: "" };
+				const loadedLanguage = getSupportedLanguage((data as Partial<Settings>).language);
+				const newSettings = { ...defaultSettings, ...data, language: loadedLanguage, smtpPass: "" };
 				setSettings(newSettings);
 				setSavedSettings(newSettings);
+				if (i18n.language !== loadedLanguage) {
+					void i18n.changeLanguage(loadedLanguage);
+				}
 				setSettingsLoadError(null);
 				setSettingsSaved(false);
 			})
@@ -383,7 +392,7 @@ export function useSettings(options: UseSettingsOptions = {}): UseSettingsReturn
 			.finally(() => {
 				if (loadGenerationRef.current === generation) setSettingsLoading(false);
 			});
-	}, [fetchWithRefresh, resetSettingsState]);
+	}, [fetchWithRefresh, i18n, resetSettingsState]);
 
 	// Load settings on mount
 	useEffect(() => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 /* biome-ignore-all lint/a11y/noLabelWithoutControl: settings rows use label-styled text with adjacent custom toggle controls */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
 import ExportModal from "../components/ExportModal";
@@ -15,6 +15,8 @@ import { StatusBadge } from "../ui/primitives/StatusBadge";
 import { getSystemLocale, withFormattingTimezone } from "../utils/formatters";
 import classes from "./SettingsPage.module.css";
 import surfaceClasses from "./SettingsPageSurfaces.module.css";
+
+type SettingsLanguage = "en" | "de";
 
 function sx(...classNames: Array<string | false | null | undefined>) {
 	return classNames.filter(Boolean).join(" ");
@@ -35,6 +37,7 @@ export function SettingsPage() {
 		settings,
 		savedSettings,
 		setSettings,
+		loadSettings,
 		settingsLoading,
 		settingsSaving,
 		settingsSaved,
@@ -65,10 +68,65 @@ export function SettingsPage() {
 	} = useAppContext();
 	const [timezoneTouched, setTimezoneTouched] = useState(false);
 	const [timezoneDraft, setTimezoneDraft] = useState("");
+	const languageSaveInFlightRef = useRef(false);
+	const pendingLanguageRef = useRef<SettingsLanguage | null>(null);
 
 	const formattedImportPreviewDate = importPreview
 		? new Date(importPreview.exportedAt).toLocaleString(getSystemLocale(i18n.language))
 		: "";
+
+	const flushLanguageSaveQueue = useCallback(
+		function flushLanguageSaveQueue() {
+			if (languageSaveInFlightRef.current) {
+				return;
+			}
+
+			const nextLanguage = pendingLanguageRef.current;
+			if (!nextLanguage) {
+				return;
+			}
+
+			pendingLanguageRef.current = null;
+			languageSaveInFlightRef.current = true;
+
+			void authFetch("/api/settings/language", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ language: nextLanguage }),
+			})
+				.then((response) => {
+					if (!response.ok) {
+						throw new Error(`LANGUAGE_SAVE_FAILED_${response.status}`);
+					}
+				})
+				.catch(() => {
+					if (!pendingLanguageRef.current) {
+						loadSettings();
+					}
+				})
+				.finally(() => {
+					languageSaveInFlightRef.current = false;
+					if (pendingLanguageRef.current) {
+						flushLanguageSaveQueue();
+					}
+				});
+		},
+		[authFetch, loadSettings]
+	);
+
+	const handleLanguageChange = useCallback(
+		(language: string) => {
+			if (language !== "en" && language !== "de") {
+				return;
+			}
+
+			pendingLanguageRef.current = language;
+			setSettings((current) => ({ ...current, language }));
+			void i18n.changeLanguage(language);
+			flushLanguageSaveQueue();
+		},
+		[flushLanguageSaveQueue, i18n, setSettings]
+	);
 
 	const closeExportModal = useCallback(() => {
 		setShowExportModal(false);
@@ -227,17 +285,9 @@ export function SettingsPage() {
 						>
 							<span className={surfaceClass("setting-label")}>{t("settings.language.select")}</span>
 							<AppSelect
-								value={i18n.language}
+								value={settings.language}
 								size="md"
-								onChange={(e) => {
-									const lang = e.currentTarget.value;
-									i18n.changeLanguage(lang);
-									authFetch("/api/settings/language", {
-										method: "PUT",
-										headers: { "Content-Type": "application/json" },
-										body: JSON.stringify({ language: lang }),
-									});
-								}}
+								onChange={(e) => handleLanguageChange(e.currentTarget.value)}
 								classNames={{ root: classes.languageSelectRoot, input: classes.languageSelect }}
 								data={[
 									{ value: "en", label: "🇬🇧 English" },

--- a/frontend/src/test/components/SharedSchedule.test.tsx
+++ b/frontend/src/test/components/SharedSchedule.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { useTranslation } from "react-i18next";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockSharedScheduleRead, renderSharedSchedule } from "../helpers/shared-schedule";
 
@@ -610,6 +611,17 @@ describe("SharedSchedule", () => {
 
 		await waitFor(() => {
 			expect(screen.getByText("share.error")).toBeInTheDocument();
+		});
+	});
+
+	it("switches shared schedules to the owner language from the share response", async () => {
+		const { i18n } = useTranslation();
+		mockSharedScheduleRead({ ...createSharedData(), language: "de" });
+
+		renderSharedSchedule("/share/token-123");
+
+		await waitFor(() => {
+			expect(i18n.changeLanguage).toHaveBeenCalledWith("de");
 		});
 	});
 

--- a/frontend/src/test/hooks/useSettings.test.ts
+++ b/frontend/src/test/hooks/useSettings.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type React from "react";
+import { useTranslation } from "react-i18next";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSettings } from "../../hooks/useSettings";
 
@@ -114,6 +115,23 @@ describe("useSettings", () => {
 
 		expect(result.current.settings.emailEnabled).toBe(true);
 		expect(result.current.settings.notificationEmail).toBe("test@example.com");
+	});
+
+	it("syncs the UI language from loaded backend settings", async () => {
+		const { i18n } = useTranslation();
+		(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve({ language: "de" }),
+		});
+
+		const { result } = renderHook(() => useSettings());
+
+		await waitFor(() => {
+			expect(result.current.settingsLoading).toBe(false);
+		});
+
+		expect(result.current.settings.language).toBe("de");
+		expect(i18n.changeLanguage).toHaveBeenCalledWith("de");
 	});
 
 	it("tracks unsaved changes only for user-editable settings fields", async () => {
@@ -259,16 +277,17 @@ describe("useSettings", () => {
 		const keepaliveCall = fetchMock.mock.calls.find(
 			([url, init]) => url === "/api/settings" && (init as RequestInit | undefined)?.keepalive === true
 		);
+		const keepaliveInit = keepaliveCall?.[1] as RequestInit | undefined;
 
 		expect(keepaliveCall).toBeDefined();
-		expect(keepaliveCall?.[1]).toEqual(
+		expect(keepaliveInit).toEqual(
 			expect.objectContaining({
 				method: "PUT",
 				keepalive: true,
 			})
 		);
 
-		const payload = JSON.parse(((keepaliveCall?.[1] as RequestInit).body as string) ?? "{}");
+		const payload = JSON.parse((keepaliveInit?.body as string | undefined) ?? "{}");
 		expect(payload.shareMedicationOverview).toBe(true);
 
 		vi.useRealTimers();

--- a/frontend/src/test/pages/SettingsPage.test.tsx
+++ b/frontend/src/test/pages/SettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsPage } from "../../pages/SettingsPage";
@@ -66,6 +66,7 @@ const createMockContext = (overrides = {}) => ({
 		lastPrescriptionReminderMedNames: null,
 	},
 	setSettings: vi.fn(),
+	loadSettings: vi.fn(),
 	settingsLoading: false,
 	settingsLoadError: null,
 	settingsSaving: false,
@@ -229,6 +230,56 @@ describe("SettingsPage", () => {
 		fireEvent.change(select as HTMLSelectElement, { target: { value: "de" } });
 		expect(changeLanguageMock).toHaveBeenCalledWith("de");
 		expect(authFetchMock).toHaveBeenCalledWith("/api/settings/language", expect.objectContaining({ method: "PUT" }));
+	});
+
+	it("serializes rapid language changes and persists the final selection last", async () => {
+		let resolveFirstSave: (response: Response) => void = () => {};
+		authFetchMock
+			.mockImplementationOnce(
+				() =>
+					new Promise<Response>((resolve) => {
+						resolveFirstSave = resolve;
+					})
+			)
+			.mockResolvedValueOnce({ ok: true } as Response);
+
+		renderPage();
+		const select = screen.getByTestId("settings-language-select").querySelector("select") as HTMLSelectElement | null;
+		expect(select).toBeInTheDocument();
+
+		fireEvent.change(select as HTMLSelectElement, { target: { value: "de" } });
+		fireEvent.change(select as HTMLSelectElement, { target: { value: "en" } });
+
+		expect(authFetchMock).toHaveBeenCalledTimes(1);
+		expect(JSON.parse((authFetchMock.mock.calls[0]?.[1]?.body as string) ?? "{}")).toEqual({ language: "de" });
+
+		await act(async () => {
+			resolveFirstSave({ ok: true } as Response);
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(authFetchMock).toHaveBeenCalledTimes(2);
+		});
+		expect(JSON.parse((authFetchMock.mock.calls[1]?.[1]?.body as string) ?? "{}")).toEqual({ language: "en" });
+		expect(changeLanguageMock).toHaveBeenCalledWith("de");
+		expect(changeLanguageMock).toHaveBeenCalledWith("en");
+	});
+
+	it("reloads persisted settings when the final language save fails", async () => {
+		const loadSettings = vi.fn();
+		mockContextValue = createMockContext({ loadSettings });
+		authFetchMock.mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+
+		renderPage();
+		const select = screen.getByTestId("settings-language-select").querySelector("select") as HTMLSelectElement | null;
+		expect(select).toBeInTheDocument();
+
+		fireEvent.change(select as HTMLSelectElement, { target: { value: "de" } });
+
+		await waitFor(() => {
+			expect(loadSettings).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	it("generates an API key through authFetch and shows the returned token", async () => {

--- a/frontend/src/test/utils/settings.test.ts
+++ b/frontend/src/test/utils/settings.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../utils/settings";
 
 const baseSettings: Settings = {
+	language: "en",
 	timezone: "Europe/Berlin",
 	availableTimezones: ["Europe/Berlin", "UTC"],
 	serverTimezone: "UTC",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -327,6 +327,7 @@ export type SharedMedication = {
 export type SharedScheduleData = {
 	takenBy: string;
 	sharedBy: string | null;
+	language?: "en" | "de";
 	scheduleDays: number;
 	allowJournalNotes?: boolean;
 	allowMarkTaken?: boolean;
@@ -348,6 +349,7 @@ export type SharedScheduleData = {
 export type ExpiredLinkData = {
 	ownerUsername: string;
 	takenBy: string;
+	language?: "en" | "de";
 	expiredAt: string;
 };
 


### PR DESCRIPTION
Closes #900

## Summary
- Use saved backend `user_settings.language` as the source of truth for settings loads, notification actions, and shared-link language behavior.
- Refresh metadata for reused unresolved ntfy/action reminder groups while preserving existing unresolved tokens.
- Include owner language in shared schedule and overview responses, including expired share links with an English fallback.
- Apply shared response language before rendering localized shared schedule UI.

## Validation
- `CI=true npm --prefix backend run test -- src/test/notification-actions-service.test.ts src/test/share-hardening.test.ts`
- `CI=true npm --prefix frontend run test:run -- src/test/hooks/useSettings.test.ts src/test/pages/SettingsPage.test.tsx src/test/components/SharedSchedule.test.tsx`
- `npm --prefix backend run check`
- `npm --prefix frontend run check`
- `npm --prefix frontend run test:run -- src/test/hooks/useSettings.test.ts`
- pre-commit Biome check on staged backend/frontend files

Residual risk: no Playwright/E2E run; behavior is covered by focused backend injection and frontend Vitest/jsdom tests.