### PR TITLE
fix: pin frontend undici override

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,5 +71,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vitest": "^4.1.0"
+  },
+  "overrides": {
+    "undici": "7.28.0"
   }
 }


### PR DESCRIPTION
Closes #946

## Summary
- add a frontend-level npm override for `undici@7.28.0`
- harden the frontend dev dependency tree against GHSA-vmh5-mc38-953g
- keep the scope limited to the frontend toolchain guard with no runtime code changes
