### PR TITLE
fix: allow clearing intake person assignment

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1350,9 +1350,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1368,9 +1365,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1388,9 +1382,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1406,9 +1397,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1426,9 +1414,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1444,9 +1429,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1464,9 +1446,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1483,9 +1462,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1501,9 +1477,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1527,9 +1500,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1551,9 +1521,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1577,9 +1544,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1601,9 +1565,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1627,9 +1588,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1652,9 +1610,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1676,9 +1631,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2149,9 +2101,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2169,9 +2118,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2189,9 +2135,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2209,9 +2152,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2229,9 +2169,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2249,9 +2186,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3719,9 +3653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3743,9 +3674,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3767,9 +3695,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3791,9 +3716,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -882,9 +882,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -902,9 +899,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -922,9 +916,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -942,9 +933,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,9 +950,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -982,9 +967,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/src/components/MobileEditModal.tsx
+++ b/frontend/src/components/MobileEditModal.tsx
@@ -1077,6 +1077,7 @@ export function MobileEditModal({
 															value={intake.takenBy}
 															onChange={(e) => onSetIntakeValue(idx, "takenBy", e.target.value)}
 														>
+															<option value="">{t("common.none")}</option>
 															{form.takenBy.map((person) => (
 																<option key={person} value={person}>
 																	{person}

--- a/frontend/src/pages/MedicationsPage.tsx
+++ b/frontend/src/pages/MedicationsPage.tsx
@@ -2262,6 +2262,7 @@ export function MedicationsPage() {
 														value={intake.takenBy}
 														onChange={(e) => setIntakeValue(idx, "takenBy", e.target.value)}
 													>
+														<option value="">{t("common.none")}</option>
 														{form.takenBy.map((person) => (
 															<option key={person} value={person}>
 																{person}

--- a/frontend/src/test/components/MedDetailModal.test.tsx
+++ b/frontend/src/test/components/MedDetailModal.test.tsx
@@ -778,24 +778,28 @@ describe("MedDetailModal intake schedule usage display", () => {
 		vi.clearAllMocks();
 	});
 
-	it("does not multiply usage by personCount when intakes have per-intake takenBy", () => {
+	it("shows the assigned person for every per-intake schedule row", () => {
 		// Two people at medication level, but each intake has its own takenBy
 		const med: Medication = {
 			...mockMedication,
 			takenBy: ["Alice", "Bob"],
 			blisters: [
-				{ usage: 1, every: 1, start: "2024-01-01T09:00:00" },
-				{ usage: 1, every: 1, start: "2024-01-01T21:00:00" },
+				{ usage: 1, every: 1, start: "2024-01-01T07:00:00" },
+				{ usage: 1, every: 1, start: "2024-01-01T20:00:00" },
 			],
 			intakes: [
-				{ usage: 1, every: 1, start: "2024-01-01T09:00:00", takenBy: "Alice", intakeRemindersEnabled: false },
-				{ usage: 1, every: 1, start: "2024-01-01T21:00:00", takenBy: "Bob", intakeRemindersEnabled: false },
+				{ usage: 1, every: 1, start: "2024-01-01T07:00:00", takenBy: "Alice", intakeRemindersEnabled: false },
+				{ usage: 1, every: 1, start: "2024-01-01T20:00:00", takenBy: "Bob", intakeRemindersEnabled: false },
 			],
 		};
 		render(<MedDetailModal {...defaultProps} selectedMed={med} />);
 
 		expect(screen.getAllByText("1 common.pill")).toHaveLength(2);
 		expect(screen.queryByText(/^2 common\.pills$/)).not.toBeInTheDocument();
+		const scheduleRows = document.querySelectorAll<HTMLElement>('[class*="med-schedule-row"]');
+		expect(scheduleRows).toHaveLength(2);
+		expect(within(scheduleRows[0]).getByText("Alice")).toBeInTheDocument();
+		expect(within(scheduleRows[1]).getByText("Bob")).toBeInTheDocument();
 	});
 
 	it("opens the user filter from per-intake person names", () => {

--- a/frontend/src/test/components/MobileEditModal.test.tsx
+++ b/frontend/src/test/components/MobileEditModal.test.tsx
@@ -1057,6 +1057,7 @@ describe("MobileEditModal optional fields", () => {
 		render(<MobileEditModal {...defaultProps} form={form} />);
 
 		expect(screen.getByText(/form\.blisters\.takenByIntake/i)).toBeInTheDocument();
+		expect(document.querySelector('.blister-row select option[value=""]')).toHaveTextContent("common.none");
 		expect(document.querySelector('.blister-row select option[value="John"]')).toBeInTheDocument();
 	});
 

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -339,9 +339,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -359,9 +356,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -379,9 +373,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -399,9 +390,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -419,9 +407,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -439,9 +424,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,9 +906,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -948,9 +927,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -972,9 +948,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -996,9 +969,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
Closes #950

## Summary
- Add a translated `None` option to the intake person selector in desktop and mobile medication editing.
- Preserve and verify per-intake person display in the medication schedule.
- Include all current local changes, including the three lockfiles.

## Lockfile investigation
The backend, frontend, and shared lockfile diffs are npm 11 normalization of optional native-package `libc` metadata. They do not change dependency versions, integrity hashes, root dependency declarations, or the local shared-package link. `npm install --package-lock-only` reproduced the diffs exactly, and `npm ci --ignore-scripts --no-audit --no-fund` succeeded for all three packages. They are harmless but valid refreshed lockfiles and are included as requested.

## Validation
- Focused frontend tests: 137 passed
- Repository check: passed
- Repository build: passed
- Release preflight for v1.30.3: passed
- npm ci: shared, backend, frontend passed