### PR TITLE
chore: prepare v1.31.0 release

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.30.4",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.30.4",
+      "version": "1.31.0",
       "dependencies": {
         "@fastify/cookie": "^11.1.1",
         "@fastify/cors": "^11.3.0",
@@ -44,7 +44,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.30.4",
+      "version": "1.31.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.30.4",
+  "version": "1.31.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.30.4
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.31.0
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.30.4
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.31.0
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.30.4",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.30.4",
+      "version": "1.31.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
@@ -43,7 +43,7 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.30.4",
+      "version": "1.31.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.30.4",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.30.4",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.30.4",
+      "version": "1.31.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.30.4",
+  "version": "1.31.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Prepare the v1.31.0 release for the secure local password recovery feature.

- Align backend, frontend, and shared package versions with `v1.31.0`
- Update all root package-lock workspace metadata to the same version
- Pin production backend and frontend Docker Compose images to `1.31.0`

## Local validation

- `npm run release:preflight -- --tag v1.31.0 --static-only`: passed
- `npm run lint`: passed with no errors or fixable warnings
- `npm run check`: passed
- `git diff --check`: passed

Closes #956