### PR TITLE
fix: remediate Swagger UI static dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1154,9 +1154,9 @@
       "license": "MIT"
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.2.tgz",
+      "integrity": "sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==",
       "funding": [
         {
           "type": "github",
@@ -1170,28 +1170,13 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
         "@fastify/send": "^4.0.0",
-        "content-disposition": "^1.0.1",
-        "fastify-plugin": "^5.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
       }
-    },
-    "node_modules/@fastify/static/node_modules/fastify-plugin": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@fastify/swagger": {
       "version": "9.8.1",
@@ -2632,9 +2617,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/backend/package.json
+++ b/backend/package.json
@@ -59,6 +59,7 @@
   "overrides": {
     "@esbuild-kit/esm-loader": "2.6.5",
     "@esbuild-kit/core-utils": "3.3.2",
+    "@fastify/static": "10.1.2",
     "esbuild": "0.28.1"
   }
 }

--- a/backend/src/test/api-docs.test.ts
+++ b/backend/src/test/api-docs.test.ts
@@ -92,11 +92,35 @@ describe("OpenAPI docs protection", () => {
 		try {
 			const docsResponse = await app.inject({ method: "GET", url: "/docs" });
 			const jsonResponse = await app.inject({ method: "GET", url: "/docs/json" });
+			const staticResponse = await app.inject({ method: "GET", url: "/docs/static/swagger-ui.css" });
 
 			expect(docsResponse.statusCode).toBe(401);
 			expect(docsResponse.json()).toEqual({ error: "Authentication required", code: "AUTH_REQUIRED" });
 			expect(jsonResponse.statusCode).toBe(401);
 			expect(jsonResponse.json()).toEqual({ error: "Authentication required", code: "AUTH_REQUIRED" });
+			expect(staticResponse.statusCode).toBe(401);
+			expect(staticResponse.json()).toEqual({ error: "Authentication required", code: "AUTH_REQUIRED" });
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("rejects anonymous Swagger assets and noncanonical docs paths when docs auth is required", async () => {
+		const app = await buildDocsApp({ docsEnabled: true, docsAuthRequired: true });
+
+		try {
+			for (const url of [
+				"//docs/static/swagger-ui.css",
+				"/docs//static/swagger-ui.css",
+				"/docs/%2e%2e/docs/static/swagger-ui.css",
+				"/docs/./static/swagger-ui.css",
+			]) {
+				const response = await app.inject({ method: "GET", url });
+
+				expect(response.statusCode, url).toBeGreaterThanOrEqual(400);
+				expect(response.body, url).not.toContain('"openapi"');
+				expect(response.body, url).not.toContain(".swagger-ui");
+			}
 		} finally {
 			await app.close();
 		}


### PR DESCRIPTION
## Summary

- Override Swagger UI's transitive `@fastify/static` dependency to `10.1.2` for Dependabot alert IDs 67 and 68.
- Regenerate the backend lockfile from current `main` dependency ranges.
- Cover anonymous Swagger API/CSS requests and duplicate-slash/dot-segment docs aliases while docs authentication is enabled.

## Local validation

- `CI=true npm run test:run -- src/test/api-docs.test.ts` (6 passed)
- `npx biome check package.json src/test/api-docs.test.ts`
- `npx tsc --noEmit`
- Clean isolated `npm install --ignore-scripts` plus `npm ls @fastify/static @fastify/swagger-ui --all`: only `@fastify/static@10.1.2` under Swagger UI

Closes #974

Addresses Dependabot alert IDs 67 and 68. Alert ID 70 is intentionally excluded pending an authenticated advisory applicability review; no React Router v8 upgrade is included.