### PR TITLE
fix: trigger E2E after successful Test workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,7 @@ on:
 
 # Minimal permissions for security
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -36,11 +37,18 @@ jobs:
         if: needs.changes.outputs.e2e_relevant != 'true'
         run: echo "No E2E-relevant changes detected; required check passes without running Playwright."
 
-      - name: Checkout repository
+      - name: Download tested source
         if: needs.changes.outputs.e2e_relevant == 'true'
-        uses: actions/checkout@v7
+        uses: actions/download-artifact@v8
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          name: e2e-source
+          path: ${{ runner.temp }}/e2e-source
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract tested source
+        if: needs.changes.outputs.e2e_relevant == 'true'
+        run: tar -xzf "$RUNNER_TEMP/e2e-source/e2e-source.tar.gz" -C "$GITHUB_WORKSPACE"
 
       - name: Setup Node.js
         if: needs.changes.outputs.e2e_relevant == 'true'
@@ -129,11 +137,18 @@ jobs:
         if: needs.changes.outputs.e2e_relevant != 'true'
         run: echo "No E2E-relevant changes detected; required check passes without running Playwright data tests."
 
-      - name: Checkout repository
+      - name: Download tested source
         if: needs.changes.outputs.e2e_relevant == 'true'
-        uses: actions/checkout@v7
+        uses: actions/download-artifact@v8
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          name: e2e-source
+          path: ${{ runner.temp }}/e2e-source
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract tested source
+        if: needs.changes.outputs.e2e_relevant == 'true'
+        run: tar -xzf "$RUNNER_TEMP/e2e-source/e2e-source.tar.gz" -C "$GITHUB_WORKSPACE"
 
       - name: Setup Node.js
         if: needs.changes.outputs.e2e_relevant == 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,19 +1,15 @@
 name: E2E Tests
 
 on:
-  workflow_run:
-    workflows: ["Test"]
-    types: [completed]
+  workflow_call:
 
 # Minimal permissions for security
 permissions:
-  actions: read
   contents: read
 
 jobs:
   changes:
     name: Detect E2E relevance
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,18 +33,9 @@ jobs:
         if: needs.changes.outputs.e2e_relevant != 'true'
         run: echo "No E2E-relevant changes detected; required check passes without running Playwright."
 
-      - name: Download tested source
+      - name: Checkout repository
         if: needs.changes.outputs.e2e_relevant == 'true'
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-source
-          path: ${{ runner.temp }}/e2e-source
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Extract tested source
-        if: needs.changes.outputs.e2e_relevant == 'true'
-        run: tar -xzf "$RUNNER_TEMP/e2e-source/e2e-source.tar.gz" -C "$GITHUB_WORKSPACE"
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         if: needs.changes.outputs.e2e_relevant == 'true'
@@ -137,18 +124,9 @@ jobs:
         if: needs.changes.outputs.e2e_relevant != 'true'
         run: echo "No E2E-relevant changes detected; required check passes without running Playwright data tests."
 
-      - name: Download tested source
+      - name: Checkout repository
         if: needs.changes.outputs.e2e_relevant == 'true'
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-source
-          path: ${{ runner.temp }}/e2e-source
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Extract tested source
-        if: needs.changes.outputs.e2e_relevant == 'true'
-        run: tar -xzf "$RUNNER_TEMP/e2e-source/e2e-source.tar.gz" -C "$GITHUB_WORKSPACE"
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         if: needs.changes.outputs.e2e_relevant == 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,11 @@ name: E2E Tests
 
 on:
   workflow_call:
+    inputs:
+      run_e2e:
+        required: false
+        type: boolean
+        default: false
 
 # Minimal permissions for security
 permissions:
@@ -18,7 +23,7 @@ jobs:
       e2e_relevant: ${{ steps.filter.outputs.e2e_relevant }}
     steps:
       - id: filter
-        run: echo "e2e_relevant=true" >> "$GITHUB_OUTPUT"
+        run: echo "e2e_relevant=${{ inputs.run_e2e }}" >> "$GITHUB_OUTPUT"
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,16 +1,9 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'shared/**'
-      - 'package.json'
-      - 'release-policy.json'
-      - 'scripts/**'
-      - '.github/workflows/e2e.yml'
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
 
 # Minimal permissions for security
 permissions:
@@ -19,6 +12,7 @@ permissions:
 jobs:
   changes:
     name: Detect E2E relevance
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,18 +20,8 @@ jobs:
     outputs:
       e2e_relevant: ${{ steps.filter.outputs.e2e_relevant }}
     steps:
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            e2e_relevant:
-              - 'frontend/**'
-              - 'backend/**'
-              - 'shared/**'
-              - 'package.json'
-              - 'release-policy.json'
-              - 'scripts/**'
-              - '.github/workflows/e2e.yml'
+      - id: filter
+        run: echo "e2e_relevant=true" >> "$GITHUB_OUTPUT"
 
   e2e:
     name: Playwright E2E
@@ -55,6 +39,8 @@ jobs:
       - name: Checkout repository
         if: needs.changes.outputs.e2e_relevant == 'true'
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         if: needs.changes.outputs.e2e_relevant == 'true'
@@ -146,6 +132,8 @@ jobs:
       - name: Checkout repository
         if: needs.changes.outputs.e2e_relevant == 'true'
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         if: needs.changes.outputs.e2e_relevant == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/**'
       - 'biome.json'
       - '.github/workflows/test.yml'
+      - '.github/workflows/e2e.yml'
 
 # Minimal permissions for security
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,19 +52,7 @@ jobs:
               - 'scripts/**'
               - 'biome.json'
               - '.github/workflows/test.yml'
-
-      - name: Archive tested source
-        uses: actions/checkout@v7
-
-      - name: Create E2E source artifact
-        run: git archive --format=tar.gz --output="$RUNNER_TEMP/e2e-source.tar.gz" "$GITHUB_SHA"
-
-      - name: Upload E2E source artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-source
-          path: ${{ runner.temp }}/e2e-source.tar.gz
-          retention-days: 1
+              - '.github/workflows/e2e.yml'
 
   # =============================================================================
   # Backend Tests (always emits the required check context)
@@ -206,8 +194,11 @@ jobs:
 
   e2e:
     name: Playwright E2E
+    if: always()
     needs: [backend-test, frontend-build]
     uses: ./.github/workflows/e2e.yml
+    with:
+      run_e2e: ${{ needs.backend-test.result == 'success' && needs.frontend-build.result == 'success' }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,3 +210,4 @@ jobs:
     uses: ./.github/workflows/e2e.yml
     permissions:
       contents: read
+      pull-requests: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,19 @@ jobs:
               - 'biome.json'
               - '.github/workflows/test.yml'
 
+      - name: Archive tested source
+        uses: actions/checkout@v7
+
+      - name: Create E2E source artifact
+        run: git archive --format=tar.gz --output="$RUNNER_TEMP/e2e-source.tar.gz" "$GITHUB_SHA"
+
+      - name: Upload E2E source artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-source
+          path: ${{ runner.temp }}/e2e-source.tar.gz
+          retention-days: 1
+
   # =============================================================================
   # Backend Tests (always emits the required check context)
   # =============================================================================

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,3 +203,10 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage/
           retention-days: 7
+
+  e2e:
+    name: Playwright E2E
+    needs: [backend-test, frontend-build]
+    uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read


### PR DESCRIPTION
Closes #977

## Summary
- run Playwright through a reusable E2E workflow called by `Test`
- start E2E only after `Backend Tests` and `Frontend Build` succeed
- remove privileged `workflow_run` checkout and artifact handling

## Validation
- `actionlint .github/workflows/test.yml .github/workflows/e2e.yml`
- `git diff --check`