### PR TITLE
fix: resolve postcss lockfile conflict

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2352,9 +2352,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes #998

Replaces Dependabot PR #995 with a conflict-free update of `postcss` to 8.5.26.

Scope is limited to `frontend/package-lock.json`.