### PR TITLE
fix(ci): publish test status for governance changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ on:
       - 'biome.json'
       - '.github/workflows/test.yml'
       - '.github/workflows/e2e.yml'
+      - 'AGENTS.md'
+      - '.github/copilot-instructions.md'
+      - '.github/agents/**'
+      - '.github/skills/**'
+      - '.github/prompts/**'
 
 # Minimal permissions for security
 permissions:


### PR DESCRIPTION
Closes #1000

Triggers the Test workflow for governance-only changes so the required legacy `Playwright E2E` status is published while existing relevance filters continue to skip product validations.