### PR TITLE
feat: allow local ntfy notification targets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,9 +147,6 @@ EXPIRY_WARNING_DAYS=30            # Days before expiry to show yellow warning
 # Push notifications (Shoutrrr URL)
 # DEFAULT_SHOUTRRR_ENABLED=false
 # DEFAULT_SHOUTRRR_URL=
-# Optional exact hostnames for trusted self-hosted ntfy services that resolve to RFC1918 addresses.
-# HTTPS ntfy targets only; direct IPs, localhost, .local, .internal, and .lan names remain blocked.
-# TRUSTED_PRIVATE_NOTIFICATION_HOSTS=ntfy.local.danielvolz.org
 # DEFAULT_SHOUTRRR_STOCK_REMINDERS=true
 # DEFAULT_SHOUTRRR_INTAKE_REMINDERS=true
 # DEFAULT_SHOUTRRR_PRESCRIPTION_REMINDERS=true

--- a/backend/src/plugins/env-schema.ts
+++ b/backend/src/plugins/env-schema.ts
@@ -1,4 +1,3 @@
-import { isIP } from "node:net";
 import { z } from "zod";
 import { parseBoolEnv, parseIntEnv, parseStringListEnv } from "../utils/env-parsing.js";
 import { DEFAULT_CORS_ORIGINS, DEFAULT_RATE_LIMIT_MAX } from "../utils/server-config.js";
@@ -24,35 +23,6 @@ function intEnv(options: { defaultValue: number; min?: number; max?: number }) {
 		.transform((value) => parseIntEnv(value, options));
 }
 
-function trustedPrivateNotificationHostnamesEnv() {
-	return z
-		.string()
-		.optional()
-		.transform((value, context) => {
-			const hostnames = parseStringListEnv(value).map((entry) => entry.toLowerCase().replace(/\.$/, ""));
-			for (const hostname of hostnames) {
-				if (
-					!hostname ||
-					!/^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(hostname) ||
-					isIP(hostname) ||
-					hostname === "localhost" ||
-					hostname.endsWith(".localhost") ||
-					hostname.endsWith(".local") ||
-					hostname.endsWith(".internal") ||
-					hostname.endsWith(".lan") ||
-					hostname === "metadata.google.internal"
-				) {
-					context.addIssue({
-						code: "custom",
-						message: "TRUSTED_PRIVATE_NOTIFICATION_HOSTS must contain only non-localhost DNS hostnames",
-					});
-					return z.NEVER;
-				}
-			}
-			return hostnames;
-		});
-}
-
 export const EnvSchema = z.object({
 	NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
 	PORT: intEnv({ defaultValue: 3000, min: 1, max: 65535 }),
@@ -67,7 +37,6 @@ export const EnvSchema = z.object({
 	DOCS_AUTH_REQUIRED: optionalBoolEnv(),
 	MEDICATION_ENRICHMENT_STARTUP_REFRESH_ENABLED: optionalBoolEnv(),
 	RATE_LIMIT_MAX: intEnv({ defaultValue: DEFAULT_RATE_LIMIT_MAX, min: 1, max: 100_000 }),
-	TRUSTED_PRIVATE_NOTIFICATION_HOSTS: trustedPrivateNotificationHostnamesEnv(),
 	AUTH_ENABLED: boolEnv(false),
 	ALLOW_UNAUTHENTICATED: boolEnv(false),
 	REGISTRATION_ENABLED: boolEnv(false),

--- a/backend/src/routes/notification-actions.ts
+++ b/backend/src/routes/notification-actions.ts
@@ -136,7 +136,7 @@ async function clearNtfyNotificationSequence(userId: number, sequenceId: string)
 	const clearUrl = new URL(sanitized.url);
 	clearUrl.pathname = `${clearUrl.pathname.replace(/\/+$/, "")}/${encodeURIComponent(sequenceId)}/clear`;
 	const targetValidationError = await validateNotificationTargetUrl(clearUrl.toString(), {
-		allowTrustedPrivateNtfyHostname: sanitized.isNtfy,
+		allowLocalNtfyTarget: sanitized.isNtfy,
 	});
 	if (targetValidationError) {
 		throw new Error(targetValidationError);
@@ -182,7 +182,7 @@ async function deleteNtfyNotificationSequence(userId: number, sequenceId: string
 	const deleteUrl = new URL(sanitized.url);
 	deleteUrl.pathname = `${deleteUrl.pathname.replace(/\/+$/, "")}/${encodeURIComponent(normalizedSequenceId)}`;
 	const targetValidationError = await validateNotificationTargetUrl(deleteUrl.toString(), {
-		allowTrustedPrivateNtfyHostname: sanitized.isNtfy,
+		allowLocalNtfyTarget: sanitized.isNtfy,
 	});
 	if (targetValidationError) {
 		throw new Error(targetValidationError);

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -850,7 +850,7 @@ export async function sendShoutrrrNotification(
 		// This is an intentional feature: users configure their own external notification services
 		// lgtm [js/request-forgery]
 		const targetValidationError = await validateNotificationTargetUrl(targetUrl, {
-			allowTrustedPrivateNtfyHostname: isNtfy,
+			allowLocalNtfyTarget: isNtfy,
 		});
 		if (targetValidationError) {
 			return { success: false, error: targetValidationError };

--- a/backend/src/services/settings-service.ts
+++ b/backend/src/services/settings-service.ts
@@ -4,7 +4,6 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { userSettings } from "../db/schema.js";
 import type { Language } from "../i18n/translations.js";
-import { env } from "../plugins/env.js";
 import { parseBoolEnv, parseIntEnv } from "../utils/env-parsing.js";
 import { isNtfyNotificationUrl } from "./notifications/action-renderer.js";
 
@@ -221,14 +220,6 @@ function getRestrictedIpv4AddressError(address: [number, number, number, number]
 	return null;
 }
 
-function isRfc1918Ipv4Address(address: string): boolean {
-	const parsed = parseIpv4Address(address);
-	if (!parsed) return false;
-
-	const [a, b] = parsed;
-	return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
-}
-
 function parseIpv4MappedIpv6(hostname: string): [number, number, number, number] | null {
 	if (!hostname.startsWith("::ffff:")) return null;
 
@@ -306,12 +297,12 @@ export function validateNotificationHostname(hostnameRaw: string): string | null
 
 export async function validateNotificationTargetUrl(
 	urlStr: string,
-	options: { allowTrustedPrivateNtfyHostname?: boolean } = {}
+	options: { allowLocalNtfyTarget?: boolean } = {}
 ): Promise<string | null> {
 	try {
 		const parsed = new URL(urlStr);
 		const hostnameError = validateNotificationHostname(parsed.hostname);
-		if (hostnameError) {
+		if (hostnameError && !options.allowLocalNtfyTarget) {
 			return hostnameError;
 		}
 
@@ -320,15 +311,10 @@ export async function validateNotificationTargetUrl(
 			return null;
 		}
 
-		const allowTrustedPrivateNtfyHostname =
-			options.allowTrustedPrivateNtfyHostname &&
-			parsed.protocol === "https:" &&
-			(env.TRUSTED_PRIVATE_NOTIFICATION_HOSTS?.includes(hostname) ?? false);
-
 		const addresses = await lookup(hostname, { all: true, verbatim: true });
 		for (const { address } of addresses) {
 			const addressError = validateNotificationHostname(address);
-			if (addressError && !(allowTrustedPrivateNtfyHostname && isRfc1918Ipv4Address(address))) {
+			if (addressError && !options.allowLocalNtfyTarget) {
 				return resolvedPrivateNotificationTargetError;
 			}
 		}
@@ -373,7 +359,7 @@ export function sanitizeNotificationUrl(
 		}
 
 		const hostValidationError = validateNotificationHostname(parsed.hostname);
-		if (hostValidationError) {
+		if (hostValidationError && !isNtfy) {
 			return { error: hostValidationError };
 		}
 

--- a/backend/src/test/decomposition-services.test.ts
+++ b/backend/src/test/decomposition-services.test.ts
@@ -101,9 +101,6 @@ describe("settings-service decomposition regression", () => {
 		vi.doMock("../db/schema.js", () => ({ userSettings: { userId: "userId" } }));
 		const lookupMock = vi.fn();
 		vi.doMock("node:dns/promises", () => ({ lookup: lookupMock }));
-		vi.doMock("../plugins/env.js", () => ({
-			env: { TRUSTED_PRIVATE_NOTIFICATION_HOSTS: ["ntfy.local.danielvolz.org"] },
-		}));
 
 		const {
 			classifyTestEmailFailure,
@@ -140,11 +137,19 @@ describe("settings-service decomposition regression", () => {
 			isNtfy: true,
 			auth: { user: "user", pass: "pass" },
 		});
+		expect(sanitizeNotificationUrl("ntfy://localhost/medis")).toEqual({
+			url: "https://localhost/medis",
+			isNtfy: true,
+		});
+		expect(sanitizeNotificationUrl("ntfy://192.168.23.123/medis")).toEqual({
+			url: "https://192.168.23.123/medis",
+			isNtfy: true,
+		});
 
 		lookupMock.mockResolvedValue([{ address: "192.168.23.123", family: 4 }]);
 		expect(
 			await validateNotificationTargetUrl("https://ntfy.local.danielvolz.org/medis", {
-				allowTrustedPrivateNtfyHostname: true,
+				allowLocalNtfyTarget: true,
 			})
 		).toBeNull();
 		expect(await validateNotificationTargetUrl("https://ntfy.local.danielvolz.org/medis")).toContain(
@@ -152,39 +157,27 @@ describe("settings-service decomposition regression", () => {
 		);
 		expect(
 			await validateNotificationTargetUrl("https://untrusted.local.danielvolz.org/medis", {
-				allowTrustedPrivateNtfyHostname: true,
+				allowLocalNtfyTarget: true,
 			})
-		).toContain("resolves to a private IP");
+		).toBeNull();
 		expect(
 			await validateNotificationTargetUrl("http://ntfy.local.danielvolz.org/medis", {
-				allowTrustedPrivateNtfyHostname: true,
+				allowLocalNtfyTarget: true,
 			})
-		).toContain("resolves to a private IP");
+		).toBeNull();
 		expect(
 			await validateNotificationTargetUrl("https://192.168.23.123/medis", {
-				allowTrustedPrivateNtfyHostname: true,
+				allowLocalNtfyTarget: true,
 			})
-		).toContain("Private IP addresses are not allowed");
+		).toBeNull();
 
-		lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
-		expect(
-			await validateNotificationTargetUrl("https://ntfy.local.danielvolz.org/medis", {
-				allowTrustedPrivateNtfyHostname: true,
-			})
-		).toContain("resolves to a private IP");
-
-		lookupMock.mockResolvedValue([{ address: "::1", family: 6 }]);
-		expect(
-			await validateNotificationTargetUrl("https://ntfy.local.danielvolz.org/medis", {
-				allowTrustedPrivateNtfyHostname: true,
-			})
-		).toContain("resolves to a private IP");
-
-		lookupMock.mockResolvedValue([{ address: "fd00::1", family: 6 }]);
-		expect(
-			await validateNotificationTargetUrl("https://ntfy.local.danielvolz.org/medis", {
-				allowTrustedPrivateNtfyHostname: true,
-			})
-		).toContain("resolves to a private IP");
+		for (const address of ["169.254.169.254", "::1", "fd00::1"]) {
+			lookupMock.mockResolvedValue([{ address, family: address.includes(":") ? 6 : 4 }]);
+			expect(
+				await validateNotificationTargetUrl("https://ntfy.local.danielvolz.org/medis", {
+					allowLocalNtfyTarget: true,
+				})
+			).toBeNull();
+		}
 	});
 });

--- a/backend/src/test/env.test.ts
+++ b/backend/src/test/env.test.ts
@@ -274,22 +274,6 @@ describe("EnvSchema", () => {
 			expect(result.CORS_ORIGINS).toBe("http://a.com,http://b.com");
 		});
 	});
-
-	describe("TRUSTED_PRIVATE_NOTIFICATION_HOSTS", () => {
-		it("normalizes exact trusted notification hostnames", () => {
-			expect(
-				EnvSchema.parse({
-					TRUSTED_PRIVATE_NOTIFICATION_HOSTS: " NTFY.LOCAL.DANIELVOLZ.ORG., ntfy.example.com ",
-				}).TRUSTED_PRIVATE_NOTIFICATION_HOSTS
-			).toEqual(["ntfy.local.danielvolz.org", "ntfy.example.com"]);
-		});
-
-		it("rejects IP literals, local names, and wildcard values", () => {
-			for (const value of ["192.168.23.123", "localhost", "ntfy.local", "*.example.com"]) {
-				expect(() => EnvSchema.parse({ TRUSTED_PRIVATE_NOTIFICATION_HOSTS: value })).toThrow();
-			}
-		});
-	});
 });
 
 describe("Auth validation", () => {

--- a/backend/src/test/notification-actions-route.test.ts
+++ b/backend/src/test/notification-actions-route.test.ts
@@ -36,7 +36,6 @@ const { testClient, testDb, mockedEnv, fetchMock, lookupMock, mockLogger } = vi.
 			CORS_ORIGINS: "*",
 			PUBLIC_APP_URL: "https://app.example.com",
 			OPENAPI_DOCS_ENABLED: false,
-			TRUSTED_PRIVATE_NOTIFICATION_HOSTS: ["ntfy.local.danielvolz.org"],
 		},
 	};
 });
@@ -450,7 +449,7 @@ describe("notification action routes", () => {
 		expect(groupRow.rows).toEqual([expect.objectContaining({ ntfy_original_message_id: "ntfy-msg-3" })]);
 	});
 
-	it("allows a configured ntfy hostname that resolves to RFC1918 during action replacement and deletion", async () => {
+	it("allows local ntfy targets during action replacement and deletion", async () => {
 		lookupMock.mockResolvedValue([{ address: "192.168.23.123", family: 4 }]);
 		const userId = await createUser("notification-route-trusted-private-ntfy");
 		await insertNotificationMedication({ id: 5, userId, packCount: 1, looseTablets: 0 });

--- a/backend/src/test/routes-real.test.ts
+++ b/backend/src/test/routes-real.test.ts
@@ -469,6 +469,18 @@ describe("Real route coverage: settings/export/report", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it("sendShoutrrrNotification allows explicit local ntfy targets and blocks redirects", async () => {
+		fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: "ntfy-local-message-id" }) });
+
+		const result = await sendShoutrrrNotification("ntfy://localhost/medassist", "Title", "Message");
+
+		expect(result).toEqual({ success: true, providerMessageId: "ntfy-local-message-id" });
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://localhost/medassist",
+			expect.objectContaining({ method: "POST", redirect: "error" })
+		);
+	});
+
 	it("sendShoutrrrNotification handles ntfy auth and safe URL reconstruction", async () => {
 		fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: "ntfy-message-id" }) });
 

--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -23,7 +23,7 @@ When an ntfy intake action succeeds, MedAssist publishes the confirmation as the
 
 Outbound webhook targets are validated before delivery. Localhost, private-network IP ranges, link-local IPv6 addresses, and internal hostnames are rejected to keep notification delivery from becoming a server-side request path into the local network.
 
-For a self-hosted ntfy service with a DNS hostname that resolves to an RFC1918 address, the server operator may set `TRUSTED_PRIVATE_NOTIFICATION_HOSTS` to a comma-separated list of exact hostnames. This exception applies only to HTTPS ntfy targets after URL sanitization, including ntfy action updates and deletes. It does not allow direct IP URLs, localhost, `.local`, `.internal`, `.lan`, loopback, link-local, metadata, IPv6 private addresses, redirects, wildcard/suffix matches, or any unconfigured hostname.
+Self-hosted ntfy services may use public or local targets without additional server configuration. ntfy targets may use HTTP or HTTPS, direct IPs, localhost, internal hostnames, loopback, link-local, metadata, and private IPv6 addresses. This explicit local-target exception also applies to ntfy action updates and deletes. Other notification providers remain protected from local-network targets, and ntfy redirects remain blocked.
 
 ## Configuration
 
@@ -52,7 +52,6 @@ Push-related default variables:
 |----------|---------|-------------|
 | `DEFAULT_SHOUTRRR_ENABLED` | `false` | Enable push notifications by default |
 | `DEFAULT_SHOUTRRR_URL` | — | Default Shoutrrr URL |
-| `TRUSTED_PRIVATE_NOTIFICATION_HOSTS` | — | Exact trusted HTTPS ntfy hostnames allowed to resolve to RFC1918 IPv4 addresses |
 | `DEFAULT_SHOUTRRR_STOCK_REMINDERS` | `true` | Send stock reminders via push |
 | `DEFAULT_SHOUTRRR_INTAKE_REMINDERS` | `true` | Send intake reminders via push |
 | `DEFAULT_SHOUTRRR_PRESCRIPTION_REMINDERS` | `true` | Send prescription reminders via push |
@@ -66,6 +65,7 @@ For the full default-user-settings reference, see [DEFAULT_USER_SETTINGS.md](DEF
 ```text
 ntfy://ntfy.sh/your-topic
 ntfy://user:password@your-server.com/topic
+https://ntfy.local.danielvolz.org/medis
 ```
 
 ### Pushover


### PR DESCRIPTION
## Summary

- allow explicitly identified ntfy targets to reach local/private destinations without a server-side hostname allowlist
- keep SSRF validation for non-ntfy notification providers and preserve blocked redirects
- cover local ntfy delivery plus action replacement/deletion and remove the obsolete environment setting

## Validation

- `npm --prefix backend run test:run -- src/test/decomposition-services.test.ts src/test/env.test.ts src/test/notification-actions-route.test.ts src/test/routes-real.test.ts` (108 passed)
- `npm --prefix backend run test:run` (888 passed)
- `npm --prefix backend run check`
- `git diff --check`

Closes #1002