### PR TITLE
fix: resolve frontend undici security advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2916,13 +2916,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,8 +71,5 @@
     "typescript": "^6.0.3",
     "vite": "^8.2.1",
     "vitest": "^4.1.0"
-  },
-  "overrides": {
-    "undici": "7.28.0"
   }
 }


### PR DESCRIPTION
Closes #1010

## Summary

- remove the stale `undici@7.28.0` root override
- resolve the `jsdom@30.0.1` development dependency to patched `undici@8.10.0`
- remediate Dependabot alerts #72–#76 without dismissing any alert

## Validation

- clean frontend install
- dependency resolution and audit inspection
- frontend type check and build
- CI frontend test suite: 75 files, 1,129 tests

Out of scope: the separate dev-only `nanoid` audit finding, which has no current Dependabot alert.