### PR TITLE
feat: support zero-schedule medications

### DIFF
--- a/backend/drizzle/0021_add_schedule_stock_rebase.sql
+++ b/backend/drizzle/0021_add_schedule_stock_rebase.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `medications` ADD `schedule_stock_rebase_milli` integer DEFAULT 0 NOT NULL;

--- a/backend/drizzle/meta/0021_snapshot.json
+++ b/backend/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1743 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4b0ce26b-e7ea-46b7-9e1e-4108b3e73670",
+  "prevId": "f9887559-2086-4368-96b0-9cd12e646197",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'write'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dose_tracking": {
+      "name": "dose_tracking",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dose_id": {
+          "name": "dose_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s','now'))"
+        },
+        "marked_by": {
+          "name": "marked_by",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "taken_source": {
+          "name": "taken_source",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dose_tracking_user_id_dose_id_unique": {
+          "name": "dose_tracking_user_id_dose_id_unique",
+          "columns": [
+            "user_id",
+            "dose_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "dose_tracking_user_id_users_id_fk": {
+          "name": "dose_tracking_user_id_users_id_fk",
+          "tableFrom": "dose_tracking",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "intake_journal": {
+      "name": "intake_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dose_tracking_id": {
+          "name": "dose_tracking_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "intake_journal_dose_tracking_id_unique": {
+          "name": "intake_journal_dose_tracking_id_unique",
+          "columns": [
+            "dose_tracking_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "intake_journal_user_id_users_id_fk": {
+          "name": "intake_journal_user_id_users_id_fk",
+          "tableFrom": "intake_journal",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_journal_dose_tracking_id_dose_tracking_id_fk": {
+          "name": "intake_journal_dose_tracking_id_dose_tracking_id_fk",
+          "tableFrom": "intake_journal",
+          "tableTo": "dose_tracking",
+          "columnsFrom": [
+            "dose_tracking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_journal_medication_id_medications_id_fk": {
+          "name": "intake_journal_medication_id_medications_id_fk",
+          "tableFrom": "intake_journal",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "medications": {
+      "name": "medications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generic_name": {
+          "name": "generic_name",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "taken_by_json": {
+          "name": "taken_by_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "package_type": {
+          "name": "package_type",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'blister'"
+        },
+        "medication_form": {
+          "name": "medication_form",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'tablet'"
+        },
+        "pill_form": {
+          "name": "pill_form",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifecycle_category": {
+          "name": "lifecycle_category",
+          "type": "text(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'refill_when_empty'"
+        },
+        "package_amount_value": {
+          "name": "package_amount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "package_amount_unit": {
+          "name": "package_amount_unit",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ml'"
+        },
+        "pack_count": {
+          "name": "pack_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "blisters_per_pack": {
+          "name": "blisters_per_pack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "pills_per_blister": {
+          "name": "pills_per_blister",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_pills": {
+          "name": "total_pills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "loose_tablets": {
+          "name": "loose_tablets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_adjustment": {
+          "name": "stock_adjustment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "schedule_stock_rebase_milli": {
+          "name": "schedule_stock_rebase_milli",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_stock_correction_at": {
+          "name": "last_stock_correction_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pill_weight_mg": {
+          "name": "pill_weight_mg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dose_unit": {
+          "name": "dose_unit",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'mg'"
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "every_json": {
+          "name": "every_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "start_json": {
+          "name": "start_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "intakes_json": {
+          "name": "intakes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intake_reminders_enabled": {
+          "name": "intake_reminders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "medication_start_date": {
+          "name": "medication_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "medication_end_date": {
+          "name": "medication_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_mark_obsolete_after_end_date": {
+          "name": "auto_mark_obsolete_after_end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_obsolete": {
+          "name": "is_obsolete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "obsolete_at": {
+          "name": "obsolete_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prescription_enabled": {
+          "name": "prescription_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prescription_authorized_refills": {
+          "name": "prescription_authorized_refills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prescription_remaining_refills": {
+          "name": "prescription_remaining_refills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prescription_low_refill_threshold": {
+          "name": "prescription_low_refill_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "prescription_expiry_date": {
+          "name": "prescription_expiry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissed_until": {
+          "name": "dismissed_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medications_user_id_users_id_fk": {
+          "name": "medications_user_id_users_id_fk",
+          "tableFrom": "medications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_action_groups": {
+      "name": "notification_action_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ntfy_original_message_id": {
+          "name": "ntfy_original_message_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "dose_ids_json": {
+          "name": "dose_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_action": {
+          "name": "resolved_action",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "notification_action_groups_group_key_unique": {
+          "name": "notification_action_groups_group_key_unique",
+          "columns": [
+            "group_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_action_groups_user_id_users_id_fk": {
+          "name": "notification_action_groups_user_id_users_id_fk",
+          "tableFrom": "notification_action_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_action_tokens": {
+      "name": "notification_action_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "notification_action_tokens_token_hash_unique": {
+          "name": "notification_action_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_action_tokens_group_id_notification_action_groups_id_fk": {
+          "name": "notification_action_tokens_group_id_notification_action_groups_id_fk",
+          "tableFrom": "notification_action_tokens",
+          "tableTo": "notification_action_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "password_reset_tokens_user_id_idx": {
+          "name": "password_reset_tokens_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "password_reset_tokens_expires_at_idx": {
+          "name": "password_reset_tokens_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refill_history": {
+      "name": "refill_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "packs_added": {
+          "name": "packs_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "loose_pills_added": {
+          "name": "loose_pills_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "used_prescription": {
+          "name": "used_prescription",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "refill_date": {
+          "name": "refill_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s','now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refill_history_medication_id_medications_id_fk": {
+          "name": "refill_history_medication_id_medications_id_fk",
+          "tableFrom": "refill_history",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refill_history_user_id_users_id_fk": {
+          "name": "refill_history_user_id_users_id_fk",
+          "tableFrom": "refill_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_id_unique": {
+          "name": "refresh_tokens_token_id_unique",
+          "columns": [
+            "token_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_tokens": {
+      "name": "share_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taken_by": {
+          "name": "taken_by",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_days": {
+          "name": "schedule_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "allow_journal_notes": {
+          "name": "allow_journal_notes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_mark_taken": {
+          "name": "allow_mark_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_tokens_token_unique": {
+          "name": "share_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_tokens_user_id_users_id_fk": {
+          "name": "share_tokens_user_id_users_id_fk",
+          "tableFrom": "share_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_stock_reminders": {
+          "name": "email_stock_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_intake_reminders": {
+          "name": "email_intake_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_prescription_reminders": {
+          "name": "email_prescription_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "shoutrrr_enabled": {
+          "name": "shoutrrr_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "shoutrrr_url": {
+          "name": "shoutrrr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shoutrrr_stock_reminders": {
+          "name": "shoutrrr_stock_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "shoutrrr_intake_reminders": {
+          "name": "shoutrrr_intake_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "shoutrrr_prescription_reminders": {
+          "name": "shoutrrr_prescription_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reminder_days_before": {
+          "name": "reminder_days_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 7
+        },
+        "repeat_daily_reminders": {
+          "name": "repeat_daily_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_reminders_for_taken_doses": {
+          "name": "skip_reminders_for_taken_doses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "repeat_reminders_enabled": {
+          "name": "repeat_reminders_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reminder_repeat_interval_minutes": {
+          "name": "reminder_repeat_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "max_nagging_reminders": {
+          "name": "max_nagging_reminders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "low_stock_days": {
+          "name": "low_stock_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "normal_stock_days": {
+          "name": "normal_stock_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 90
+        },
+        "high_stock_days": {
+          "name": "high_stock_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 180
+        },
+        "expiry_warning_days": {
+          "name": "expiry_warning_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 90
+        },
+        "language": {
+          "name": "language",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "stock_calculation_mode": {
+          "name": "stock_calculation_mode",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'automatic'"
+        },
+        "share_stock_status": {
+          "name": "share_stock_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "share_medication_overview": {
+          "name": "share_medication_overview",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "upcoming_today_only": {
+          "name": "upcoming_today_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "share_schedule_today_only": {
+          "name": "share_schedule_today_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "swap_dashboard_main_sections": {
+          "name": "swap_dashboard_main_sections",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_auto_email_sent": {
+          "name": "last_auto_email_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_notification_type": {
+          "name": "last_notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_notification_channel": {
+          "name": "last_notification_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminder_med_name": {
+          "name": "last_reminder_med_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminder_taken_by": {
+          "name": "last_reminder_taken_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stock_reminder_sent": {
+          "name": "last_stock_reminder_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stock_reminder_channel": {
+          "name": "last_stock_reminder_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_stock_reminder_med_names": {
+          "name": "last_stock_reminder_med_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_prescription_reminder_sent": {
+          "name": "last_prescription_reminder_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_prescription_reminder_channel": {
+          "name": "last_prescription_reminder_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_prescription_reminder_med_names": {
+          "name": "last_prescription_reminder_med_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_version": {
+          "name": "credential_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_email_lower_unique": {
+          "name": "users_email_lower_unique",
+          "columns": [
+            "lower(\"email\")"
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"email\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "users_email_lower_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784389672478,
       "tag": "0020_add_password_reset_recovery",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1786733801274,
+      "tag": "0021_add_schedule_stock_rebase",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync } from "node:fs";
-import { type Client, createClient } from "@libsql/client";
+import { type Client, createClient, type Transaction } from "@libsql/client";
 import dotenv from "dotenv";
 import { drizzle } from "drizzle-orm/libsql";
 import { parseBoolEnv } from "../utils/env-parsing.js";
@@ -65,6 +65,58 @@ try {
 }
 
 export const db = drizzle(client);
+
+let immediateWriteTail = Promise.resolve();
+
+function reserveImmediateWriteTurn(): Promise<() => void> {
+	const previousTurn = immediateWriteTail;
+	let releaseTurn: () => void = () => undefined;
+	immediateWriteTail = new Promise<void>((resolve) => {
+		releaseTurn = resolve;
+	});
+
+	return previousTurn.then(() => releaseTurn);
+}
+
+/**
+ * Run a callback in a process-local FIFO BEGIN IMMEDIATE transaction.
+ *
+ * libSQL opens another file connection for each overlapping transaction call, so the queue must cover
+ * acquisition through commit/rollback. External-process contention is attempted once and propagates
+ * SQLITE_BUSY; retrying BEGIN while another writer commits can itself destabilize that commit.
+ */
+export async function withImmediateWriteTransaction<T>(
+	operation: (transactionDb: typeof db) => Promise<T>
+): Promise<T> {
+	const releaseTurn = await reserveImmediateWriteTurn();
+	let transaction: Transaction | undefined;
+
+	try {
+		transaction = await client.transaction("write");
+		const transactionDb = drizzle(transaction as unknown as Client);
+		const result = await operation(transactionDb);
+		await transaction.commit();
+		return result;
+	} catch (error) {
+		if (transaction && !transaction.closed) {
+			await transaction.rollback();
+		}
+		// The SQLite client can leave a failed BEGIN IMMEDIATE statement active on its
+		// reusable connection. Reconnect only when acquisition itself failed so the
+		// next FIFO writer is not poisoned, while preserving the original error.
+		if (!transaction) {
+			try {
+				await client.reconnect();
+			} catch {
+				// The original transaction-acquisition error is the actionable result.
+			}
+		}
+		throw error;
+	} finally {
+		transaction?.close();
+		releaseTurn();
+	}
+}
 
 // Auto-run migrations (self-healing database)
 async function runMigrations() {

--- a/backend/src/db/migration-utils.ts
+++ b/backend/src/db/migration-utils.ts
@@ -83,6 +83,7 @@ export async function runAlterMigrations(client: Client): Promise<{ success: boo
 		`ALTER TABLE dose_tracking ADD COLUMN taken_source text NOT NULL DEFAULT 'manual'`,
 		`ALTER TABLE user_settings ADD COLUMN stock_calculation_mode text NOT NULL DEFAULT 'automatic'`,
 		`ALTER TABLE medications ADD COLUMN stock_adjustment integer NOT NULL DEFAULT 0`,
+		`ALTER TABLE medications ADD COLUMN schedule_stock_rebase_milli integer NOT NULL DEFAULT 0`,
 		`ALTER TABLE medications ADD COLUMN last_stock_correction_at integer`,
 		`ALTER TABLE medications ADD COLUMN dismissed_until text`,
 		`ALTER TABLE medications ADD COLUMN is_obsolete integer NOT NULL DEFAULT 0`,

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -48,6 +48,7 @@ export const medications = sqliteTable("medications", {
 	totalPills: integer("total_pills"), // For bottle type: total capacity of the container
 	looseTablets: integer("loose_tablets").notNull().default(0), // For blister: extra loose pills; for bottle: current stock
 	stockAdjustment: integer("stock_adjustment").notNull().default(0), // Hidden offset from stock corrections
+	scheduleStockRebaseMilli: integer("schedule_stock_rebase_milli").notNull().default(0), // Exact thousandth-unit offset across zero-schedule transitions
 	lastStockCorrectionAt: integer("last_stock_correction_at", { mode: "timestamp" }), // When stock was last corrected - consumed doses before this don't count
 	pillWeightMg: integer("pill_weight_mg"),
 	doseUnit: text("dose_unit", { length: 20 }).default("mg"), // Unit for the dose (mg, g, mcg, ml, IU, etc.)

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -84,6 +84,7 @@ const inventorySchema = z.object({
 	totalPills: z.number().int().nullable().optional(), // For bottle type: total capacity
 	looseTablets: z.number().int().min(0).default(0),
 	stockAdjustment: z.number().int().default(0), // Manual stock correction
+	scheduleStockRebaseMilli: z.number().int().default(0),
 	packageType: z.enum(PACKAGE_TYPES).default("blister"),
 	packageAmountValue: z.number().int().min(0).default(0),
 	packageAmountUnit: z.enum(["ml", "g"]).default("ml"),
@@ -637,6 +638,7 @@ export async function exportRoutes(app: FastifyInstance) {
 						totalPills: med.totalPills ?? null,
 						looseTablets: med.looseTablets ?? 0,
 						stockAdjustment: med.stockAdjustment ?? 0,
+						scheduleStockRebaseMilli: med.scheduleStockRebaseMilli ?? 0,
 						packageType: normalizePackageType(med.packageType),
 						packageAmountValue: med.packageAmountValue ?? 0,
 						packageAmountUnit: (med.packageAmountUnit ?? "ml") as "ml" | "g",
@@ -1034,6 +1036,7 @@ export async function exportRoutes(app: FastifyInstance) {
 								looseTablets: med.inventory.looseTablets,
 								totalPills: med.inventory.totalPills ?? null,
 								stockAdjustment: med.inventory.stockAdjustment ?? 0,
+								scheduleStockRebaseMilli: med.inventory.scheduleStockRebaseMilli ?? 0,
 								lastStockCorrectionAt: med.lastStockCorrectionAt ? new Date(med.lastStockCorrectionAt) : null,
 								pillWeightMg: med.pillWeightMg || null,
 								doseUnit: med.doseUnit ?? "mg",

--- a/backend/src/routes/medications.ts
+++ b/backend/src/routes/medications.ts
@@ -2,11 +2,12 @@ import { resolve } from "node:path";
 import { and, eq, like } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { db } from "../db/client.js";
+import { db, withImmediateWriteTransaction } from "../db/client.js";
 import { getDataDir } from "../db/path-utils.js";
-import { doseTracking, medications } from "../db/schema.js";
+import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { getAnonymousUserId, isReadOnlyApiKeyRequest, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import { computeMedicationCurrentStockRaw } from "../services/current-stock.js";
 import { normalizeDateTime, parseIntakesWithUnits } from "../services/medications-service.js";
 import { calculatePlannerDemandRows } from "../services/planner-demand.js";
 import type { AuthUser } from "../types/fastify.js";
@@ -101,14 +102,16 @@ const medicationSchema = z
 		prescriptionExpiryDate: z.string().nullable().optional(),
 		intakeRemindersEnabled: z.boolean().default(false), // Medication-level (deprecated, kept for backward compat)
 		// Accept either new intakes format or legacy blisters format
-		intakes: z.array(intakeSchema).min(1).max(12).optional(),
+		intakes: z.array(intakeSchema).max(12).optional(),
 		blisters: z.array(blisterSchema).min(1).max(12).optional(), // Legacy format
 	})
 	.refine((data) => (data.name && data.name.length > 0) || (data.genericName && data.genericName.length > 0), {
 		message: "Either 'name' or 'genericName' must be provided",
 		path: ["name"],
 	})
-	.refine((data) => data.intakes || data.blisters, { message: "Either 'intakes' or 'blisters' must be provided" })
+	.refine((data) => data.intakes !== undefined || data.blisters !== undefined, {
+		message: "Either 'intakes' or 'blisters' must be provided",
+	})
 	.refine(
 		(data) => {
 			const startDate = data.medicationStartDate ?? "";
@@ -278,8 +281,8 @@ const medicationBodyOpenApiSchema = {
 		prescriptionLowRefillThreshold: { type: "integer", minimum: 0 },
 		prescriptionExpiryDate: { type: ["string", "null"] },
 		intakeRemindersEnabled: { type: "boolean" },
-		intakes: { type: "array", items: intakeOpenApiSchema },
-		blisters: { type: "array", items: blisterOpenApiSchema },
+		intakes: { type: "array", maxItems: 12, items: intakeOpenApiSchema },
+		blisters: { type: "array", minItems: 1, maxItems: 12, items: blisterOpenApiSchema },
 	},
 	description:
 		"Medication payload. Runtime validation allows defaults and legacy shapes; provide either intakes or legacy blisters.",
@@ -341,6 +344,7 @@ const medicationResponseSchema = {
 		totalPills: { type: ["number", "null"] },
 		looseTablets: { type: "number" },
 		stockAdjustment: { type: "number" },
+		scheduleStockRebaseMilli: { type: "integer" },
 		lastStockCorrectionAt: { type: ["string", "null"] },
 		pillWeightMg: { type: ["number", "null"] },
 		doseUnit: { type: "string" },
@@ -349,6 +353,8 @@ const medicationResponseSchema = {
 		autoMarkObsoleteAfterEndDate: { type: "boolean" },
 		intakes: { type: "array", items: intakeOpenApiSchema },
 		blisters: { type: "array", items: blisterOpenApiSchema },
+		hasRegularSchedule: { type: "boolean" },
+		asNeededStockEffect: { type: "number" },
 		imageUrl: { type: ["string", "null"] },
 		expiryDate: { type: ["string", "null"] },
 		notes: { type: ["string", "null"] },
@@ -420,6 +426,7 @@ const stockAdjustmentResponseSchema = {
 	properties: {
 		id: { type: "number" },
 		stockAdjustment: { type: "number" },
+		scheduleStockRebaseMilli: { type: "integer" },
 		lastStockCorrectionAt: { type: "string" },
 		updatedAt: { type: "string", format: "date-time" },
 	},
@@ -535,6 +542,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 					totalPills: row.totalPills ?? null,
 					looseTablets: row.looseTablets ?? 0,
 					stockAdjustment: row.stockAdjustment ?? 0,
+					scheduleStockRebaseMilli: row.scheduleStockRebaseMilli ?? 0,
 					lastStockCorrectionAt: row.lastStockCorrectionAt?.toISOString() ?? null,
 					pillWeightMg: row.pillWeightMg,
 					doseUnit: row.doseUnit ?? "mg",
@@ -544,6 +552,8 @@ export async function medicationRoutes(app: FastifyInstance) {
 					intakes, // New unified format with per-intake takenBy
 					// Legacy blisters format (for backward compat with frontend during transition)
 					blisters: intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start })),
+					hasRegularSchedule: intakes.length > 0,
+					asNeededStockEffect: 0,
 					imageUrl: row.imageUrl,
 					expiryDate: row.expiryDate,
 					notes: row.notes,
@@ -616,9 +626,9 @@ export async function medicationRoutes(app: FastifyInstance) {
 
 			// Convert to unified intakes format
 			let intakes: Intake[];
-			if (inputIntakes) {
+			if (inputIntakes !== undefined) {
 				intakes = inputIntakes.map((intake) => normalizeIntake(intake));
-			} else if (inputBlisters) {
+			} else if (inputBlisters !== undefined) {
 				intakes = inputBlisters.map((blister) =>
 					normalizeIntake(
 						{
@@ -697,6 +707,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 				totalPills: inserted.totalPills ?? null,
 				looseTablets: inserted.looseTablets,
 				stockAdjustment: inserted.stockAdjustment ?? 0,
+				scheduleStockRebaseMilli: inserted.scheduleStockRebaseMilli ?? 0,
 				lastStockCorrectionAt: inserted.lastStockCorrectionAt?.toISOString() ?? null,
 				pillWeightMg: inserted.pillWeightMg,
 				doseUnit: inserted.doseUnit ?? "mg",
@@ -705,6 +716,8 @@ export async function medicationRoutes(app: FastifyInstance) {
 				autoMarkObsoleteAfterEndDate: inserted.autoMarkObsoleteAfterEndDate ?? true,
 				intakes,
 				blisters: intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start })),
+				hasRegularSchedule: intakes.length > 0,
+				asNeededStockEffect: 0,
 				imageUrl: inserted.imageUrl,
 				expiryDate: inserted.expiryDate,
 				notes: inserted.notes,
@@ -787,9 +800,9 @@ export async function medicationRoutes(app: FastifyInstance) {
 
 			// Convert to unified intakes format
 			let intakes: Intake[];
-			if (inputIntakes) {
+			if (inputIntakes !== undefined) {
 				intakes = inputIntakes.map((intake) => normalizeIntake(intake));
-			} else if (inputBlisters) {
+			} else if (inputBlisters !== undefined) {
 				intakes = inputBlisters.map((blister) =>
 					normalizeIntake(
 						{
@@ -813,71 +826,135 @@ export async function medicationRoutes(app: FastifyInstance) {
 			const startJson = JSON.stringify(intakes.map((s) => s.start));
 			const takenByJson = JSON.stringify(takenBy || []);
 
-			// If stock-defining fields changed, reset stockAdjustment so the new
-			// base stock reflects actual inventory.  This prevents the old
-			// correction offset from skewing the total after an edit.
-			const stockFieldsChanged =
-				existing.packCount !== packCount ||
-				existing.blistersPerPack !== blistersPerPack ||
-				existing.pillsPerBlister !== pillsPerBlister ||
-				(existing.looseTablets ?? 0) !== (looseTablets ?? 0);
+			const transition = await withImmediateWriteTransaction(async (transactionDb) => {
+				const [current] = await transactionDb
+					.select()
+					.from(medications)
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)));
+				if (!current) return null;
 
-			const stockResetFields = stockFieldsChanged ? { stockAdjustment: 0, lastStockCorrectionAt: new Date() } : {};
+				const oldIntakes = parseIntakesWithUnits(current);
+				const crossesZeroScheduleBoundary = (oldIntakes.length === 0) !== (intakes.length === 0);
+				const hasScheduleOnBothSides = oldIntakes.length > 0 && intakes.length > 0;
+				const normalizedPackageType = normalizePackageType(packageType);
+				const normalizedTotalPills = totalPills || null;
+				const stockFieldsChanged =
+					current.packCount !== packCount ||
+					current.blistersPerPack !== blistersPerPack ||
+					current.pillsPerBlister !== pillsPerBlister ||
+					(current.looseTablets ?? 0) !== (looseTablets ?? 0) ||
+					normalizePackageType(current.packageType) !== normalizedPackageType ||
+					(current.totalPills ?? null) !== normalizedTotalPills ||
+					(current.packageAmountValue ?? 0) !== packageAmountValue ||
+					(current.packageAmountUnit ?? "ml") !== packageAmountUnit;
+				const changedAt = new Date();
+				const stockResetFields = stockFieldsChanged
+					? { stockAdjustment: 0, scheduleStockRebaseMilli: 0, lastStockCorrectionAt: changedAt }
+					: {};
 
-			const result = await db
-				.update(medications)
-				.set({
-					name,
-					genericName: genericName || null,
-					takenByJson,
-					medicationForm: medicationForm ?? "tablet",
-					pillForm: normalizedPillForm,
-					lifecycleCategory: lifecycleCategory ?? "refill_when_empty",
-					packageType: normalizePackageType(packageType),
-					packCount,
-					blistersPerPack,
-					pillsPerBlister,
-					totalPills: totalPills || null,
-					packageAmountValue,
-					packageAmountUnit,
-					looseTablets,
-					pillWeightMg: pillWeightMg || null,
-					doseUnit: doseUnit ?? "mg",
-					medicationStartDate: medicationStartDate ?? "",
-					medicationEndDate: medicationEndDate || null,
-					autoMarkObsoleteAfterEndDate: autoMarkObsoleteAfterEndDate ?? true,
-					expiryDate: expiryDate || null,
-					notes: notes || null,
-					prescriptionEnabled: prescriptionEnabled ?? false,
-					prescriptionAuthorizedRefills: prescriptionEnabled ? (prescriptionAuthorizedRefills ?? null) : null,
-					prescriptionRemainingRefills: prescriptionEnabled ? (prescriptionRemainingRefills ?? null) : null,
-					prescriptionLowRefillThreshold: prescriptionLowRefillThreshold ?? 1,
-					prescriptionExpiryDate: prescriptionExpiryDate || null,
-					intakeRemindersEnabled: intakeRemindersEnabled ?? false,
-					intakesJson,
-					usageJson,
-					everyJson,
-					startJson,
-					updatedAt: new Date(),
-					...stockResetFields,
-				})
-				.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
-				.returning();
+				let dosesForProjection: Array<typeof doseTracking.$inferSelect> = [];
+				let stockCalculationMode: "automatic" | "manual" = "automatic";
+				let stockBeforeTransition = 0;
+				if (crossesZeroScheduleBoundary && !stockFieldsChanged) {
+					dosesForProjection = await transactionDb
+						.select()
+						.from(doseTracking)
+						.where(and(eq(doseTracking.userId, userId), like(doseTracking.doseId, `${idNum}-%`)));
+					const [settings] = await transactionDb
+						.select({ stockCalculationMode: userSettings.stockCalculationMode })
+						.from(userSettings)
+						.where(eq(userSettings.userId, userId));
+					stockCalculationMode = settings?.stockCalculationMode === "manual" ? "manual" : "automatic";
+					stockBeforeTransition = computeMedicationCurrentStockRaw({
+						medication: current,
+						doses: dosesForProjection,
+						stockCalculationMode,
+						nowMs: changedAt.getTime(),
+					});
+				}
 
-			if (!result.length) return reply.notFound();
+				const [updated] = await transactionDb
+					.update(medications)
+					.set({
+						name,
+						genericName: genericName || null,
+						takenByJson,
+						medicationForm: medicationForm ?? "tablet",
+						pillForm: normalizedPillForm,
+						lifecycleCategory: lifecycleCategory ?? "refill_when_empty",
+						packageType: normalizedPackageType,
+						packCount,
+						blistersPerPack,
+						pillsPerBlister,
+						totalPills: normalizedTotalPills,
+						packageAmountValue,
+						packageAmountUnit,
+						looseTablets,
+						pillWeightMg: pillWeightMg || null,
+						doseUnit: doseUnit ?? "mg",
+						medicationStartDate: medicationStartDate ?? "",
+						medicationEndDate: medicationEndDate || null,
+						autoMarkObsoleteAfterEndDate: autoMarkObsoleteAfterEndDate ?? true,
+						expiryDate: expiryDate || null,
+						notes: notes || null,
+						prescriptionEnabled: prescriptionEnabled ?? false,
+						prescriptionAuthorizedRefills: prescriptionEnabled ? (prescriptionAuthorizedRefills ?? null) : null,
+						prescriptionRemainingRefills: prescriptionEnabled ? (prescriptionRemainingRefills ?? null) : null,
+						prescriptionLowRefillThreshold: prescriptionLowRefillThreshold ?? 1,
+						prescriptionExpiryDate: prescriptionExpiryDate || null,
+						intakeRemindersEnabled: intakeRemindersEnabled ?? false,
+						intakesJson,
+						usageJson,
+						everyJson,
+						startJson,
+						updatedAt: changedAt,
+						...stockResetFields,
+					})
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
+					.returning();
+
+				if (!updated) return null;
+				if (!crossesZeroScheduleBoundary || stockFieldsChanged) {
+					return { medication: updated, oldIntakes, hasScheduleOnBothSides };
+				}
+
+				const stockAfterTransition = computeMedicationCurrentStockRaw({
+					medication: updated,
+					doses: dosesForProjection,
+					stockCalculationMode,
+					nowMs: changedAt.getTime(),
+				});
+				const scheduleStockRebaseMilli =
+					(current.scheduleStockRebaseMilli ?? 0) + Math.round((stockBeforeTransition - stockAfterTransition) * 1000);
+				const [rebased] = await transactionDb
+					.update(medications)
+					.set({ scheduleStockRebaseMilli })
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
+					.returning();
+				if (!rebased) throw new Error("Medication disappeared during schedule stock rebase");
+
+				return { medication: rebased, oldIntakes, hasScheduleOnBothSides };
+			});
+
+			if (!transition) return reply.notFound();
+			const result = [transition.medication];
 
 			// ---------------------------------------------------------------
 			// Migrate dose tracking IDs when intake schedule changes
 			// ---------------------------------------------------------------
-			const oldIntakes = parseIntakesWithUnits(existing);
+			const oldIntakes = transition.oldIntakes;
 
 			// Get all dose tracking entries for this medication
-			const allDoses = await db
-				.select()
-				.from(doseTracking)
-				.where(and(eq(doseTracking.userId, userId), like(doseTracking.doseId, `${idNum}-%`)));
+			const allDoses = transition.hasScheduleOnBothSides
+				? await db
+						.select()
+						.from(doseTracking)
+						.where(and(eq(doseTracking.userId, userId), like(doseTracking.doseId, `${idNum}-%`)))
+				: [];
 
-			if (allDoses.length > 0) {
+			// A zero schedule is a snapshot boundary: keep historical dose IDs untouched instead of
+			// reinterpreting or deleting them against a schedule that did not exist when they were recorded.
+			if (transition.hasScheduleOnBothSides && allDoses.length > 0) {
 				// Build migration map: for each intake index, map old dateOnlyMs → new dateOnlyMs
 				const now = new Date();
 				const migrationEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
@@ -997,6 +1074,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 				totalPills: result[0].totalPills ?? null,
 				looseTablets: result[0].looseTablets,
 				stockAdjustment: result[0].stockAdjustment ?? 0,
+				scheduleStockRebaseMilli: result[0].scheduleStockRebaseMilli ?? 0,
 				lastStockCorrectionAt: result[0].lastStockCorrectionAt?.toISOString() ?? null,
 				pillWeightMg: result[0].pillWeightMg,
 				doseUnit: result[0].doseUnit ?? "mg",
@@ -1005,6 +1083,8 @@ export async function medicationRoutes(app: FastifyInstance) {
 				autoMarkObsoleteAfterEndDate: result[0].autoMarkObsoleteAfterEndDate ?? true,
 				intakes,
 				blisters: intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start })),
+				hasRegularSchedule: intakes.length > 0,
+				asNeededStockEffect: 0,
 				imageUrl: result[0].imageUrl,
 				expiryDate: result[0].expiryDate,
 				notes: result[0].notes,
@@ -1177,6 +1257,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 
 			const updateFields: {
 				stockAdjustment: number;
+				scheduleStockRebaseMilli: number;
 				lastStockCorrectionAt: Date;
 				updatedAt: Date;
 				looseTablets?: number;
@@ -1185,6 +1266,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 				packCount?: number;
 			} = {
 				stockAdjustment,
+				scheduleStockRebaseMilli: 0,
 				lastStockCorrectionAt: new Date(),
 				updatedAt: new Date(),
 			};
@@ -1221,6 +1303,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 			return {
 				id: result[0].id,
 				stockAdjustment: result[0].stockAdjustment ?? 0,
+				scheduleStockRebaseMilli: result[0].scheduleStockRebaseMilli ?? 0,
 				lastStockCorrectionAt: result[0].lastStockCorrectionAt?.toISOString() ?? null,
 				updatedAt: normalizeDateTime(result[0].updatedAt),
 			};

--- a/backend/src/services/current-stock.ts
+++ b/backend/src/services/current-stock.ts
@@ -10,8 +10,17 @@ import {
 	parseLocalDateTime,
 } from "../utils/scheduler-utils.js";
 
-type MedicationRow = typeof medications.$inferSelect;
+type MedicationRow = Omit<typeof medications.$inferSelect, "scheduleStockRebaseMilli"> & {
+	scheduleStockRebaseMilli?: number | null;
+};
 type DoseRow = typeof doseTracking.$inferSelect;
+
+type CurrentStockOptions = {
+	medication: MedicationRow;
+	doses: DoseRow[];
+	stockCalculationMode: "automatic" | "manual";
+	nowMs?: number;
+};
 
 function getDoseTakenAtMs(dose: DoseRow): number {
 	const rawTakenAt = Number(dose.takenAt);
@@ -22,12 +31,7 @@ function getDoseTakenAtMs(dose: DoseRow): number {
 	return new Date(dose.takenAt).getTime();
 }
 
-export function computeMedicationCurrentStock(options: {
-	medication: MedicationRow;
-	doses: DoseRow[];
-	stockCalculationMode: "automatic" | "manual";
-	nowMs?: number;
-}): number {
+export function computeMedicationCurrentStockRaw(options: CurrentStockOptions): number {
 	const { medication, doses, stockCalculationMode, nowMs = Date.now() } = options;
 
 	const schedule = normalizeMedicationSchedule(medication);
@@ -123,5 +127,9 @@ export function computeMedicationCurrentStock(options: {
 		});
 	}
 
-	return Math.max(0, Math.floor(baseStock - consumed));
+	return Math.max(0, baseStock + (medication.scheduleStockRebaseMilli ?? 0) / 1000 - consumed);
+}
+
+export function computeMedicationCurrentStock(options: CurrentStockOptions): number {
+	return Math.floor(computeMedicationCurrentStockRaw(options));
 }

--- a/backend/src/test/coverage-service.test.ts
+++ b/backend/src/test/coverage-service.test.ts
@@ -26,6 +26,7 @@ function medication(overrides: Partial<MedicationRow> = {}): MedicationRow {
 		totalPills: null,
 		looseTablets: 0,
 		stockAdjustment: 0,
+		scheduleStockRebaseMilli: 0,
 		lastStockCorrectionAt: null,
 		pillWeightMg: null,
 		doseUnit: "mg",

--- a/backend/src/test/current-stock-service.test.ts
+++ b/backend/src/test/current-stock-service.test.ts
@@ -185,22 +185,22 @@ describe("computeMedicationCurrentStock", () => {
 		expect(malformedScheduleStock).toBe(5);
 	});
 
-	it.each(["automatic", "manual"] as const)(
-		"applies exact schedule rebases before rounding in %s mode",
-		(stockCalculationMode) => {
-			const rebasedMedication = medication({
-				packCount: 0,
-				looseTablets: 10,
-				scheduleStockRebaseMilli: -1500,
-				intakesJson: "[]",
-				usageJson: "[]",
-				everyJson: "[]",
-				startJson: "[]",
-			});
-			const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
+	it.each([
+		"automatic",
+		"manual",
+	] as const)("applies exact schedule rebases before rounding in %s mode", (stockCalculationMode) => {
+		const rebasedMedication = medication({
+			packCount: 0,
+			looseTablets: 10,
+			scheduleStockRebaseMilli: -1500,
+			intakesJson: "[]",
+			usageJson: "[]",
+			everyJson: "[]",
+			startJson: "[]",
+		});
+		const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
 
-			expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
-			expect(computeMedicationCurrentStock(options)).toBe(8);
-		}
-	);
+		expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
+		expect(computeMedicationCurrentStock(options)).toBe(8);
+	});
 });

--- a/backend/src/test/current-stock-service.test.ts
+++ b/backend/src/test/current-stock-service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { doseTracking, medications } from "../db/schema.js";
-import { computeMedicationCurrentStock } from "../services/current-stock.js";
+import { computeMedicationCurrentStock, computeMedicationCurrentStockRaw } from "../services/current-stock.js";
 import { buildDoseId } from "../utils/dose-id.js";
 
 type MedicationRow = typeof medications.$inferSelect;
@@ -25,6 +25,7 @@ function medication(overrides: Partial<MedicationRow> = {}): MedicationRow {
 		totalPills: null,
 		looseTablets: 0,
 		stockAdjustment: 0,
+		scheduleStockRebaseMilli: 0,
 		lastStockCorrectionAt: null,
 		pillWeightMg: null,
 		doseUnit: "mg",
@@ -183,4 +184,23 @@ describe("computeMedicationCurrentStock", () => {
 		expect(legacyStock).toBe(3);
 		expect(malformedScheduleStock).toBe(5);
 	});
+
+	it.each(["automatic", "manual"] as const)(
+		"applies exact schedule rebases before rounding in %s mode",
+		(stockCalculationMode) => {
+			const rebasedMedication = medication({
+				packCount: 0,
+				looseTablets: 10,
+				scheduleStockRebaseMilli: -1500,
+				intakesJson: "[]",
+				usageJson: "[]",
+				everyJson: "[]",
+				startJson: "[]",
+			});
+			const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
+
+			expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
+			expect(computeMedicationCurrentStock(options)).toBe(8);
+		}
+	);
 });

--- a/backend/src/test/database.test.ts
+++ b/backend/src/test/database.test.ts
@@ -316,6 +316,15 @@ describe("Database Client Utilities", () => {
 			expect(result.errors).toHaveLength(0);
 		});
 
+		it("keeps the schedule stock rebase column backward-compatible", async () => {
+			const result = await runAlterMigrations(client);
+			expect(result.success).toBe(true);
+
+			const columns = await client.execute("PRAGMA table_info(medications)");
+			const rebaseColumn = columns.rows.find((column) => column.name === "schedule_stock_rebase_milli");
+			expect(rebaseColumn).toMatchObject({ notnull: 1, dflt_value: "0" });
+		});
+
 		it("should be idempotent", async () => {
 			await runAlterMigrations(client);
 			const result = await runAlterMigrations(client);

--- a/backend/src/test/db-client.test.ts
+++ b/backend/src/test/db-client.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 type ClientTestOptions = {
 	dirWritable?: boolean;
 	authEnabled?: boolean;
+	client?: Record<string, unknown>;
 };
 
 async function loadDbClientModule(options: ClientTestOptions = {}) {
@@ -25,7 +26,7 @@ async function loadDbClientModule(options: ClientTestOptions = {}) {
 	const dotenvConfig = vi.fn();
 	vi.doMock("dotenv", () => ({ default: { config: dotenvConfig } }));
 
-	const createClient = vi.fn().mockReturnValue({ execute: vi.fn() });
+	const createClient = vi.fn().mockReturnValue(options.client ?? { execute: vi.fn() });
 	vi.doMock("@libsql/client", () => ({ createClient }));
 
 	const drizzle = vi.fn().mockReturnValue({ __db: true });
@@ -103,6 +104,27 @@ afterEach(() => {
 });
 
 describe("db/client bootstrap", () => {
+	it("releases the FIFO writer turn after a callback failure", async () => {
+		const firstTransaction = { commit: vi.fn(), rollback: vi.fn(), close: vi.fn(), closed: false };
+		const secondTransaction = { commit: vi.fn(), rollback: vi.fn(), close: vi.fn(), closed: false };
+		const client = {
+			execute: vi.fn(),
+			transaction: vi.fn().mockResolvedValueOnce(firstTransaction).mockResolvedValueOnce(secondTransaction),
+		};
+		const { modulePromise } = await loadDbClientModule({ client });
+		const mod = await modulePromise;
+		const first = mod.withImmediateWriteTransaction(async () => {
+			throw new Error("callback failed");
+		});
+		const second = mod.withImmediateWriteTransaction(async () => "next writer");
+
+		await expect(first).rejects.toThrow("callback failed");
+		await expect(second).resolves.toBe("next writer");
+		expect(client.transaction).toHaveBeenCalledTimes(2);
+		expect(firstTransaction.rollback).toHaveBeenCalledTimes(1);
+		expect(secondTransaction.commit).toHaveBeenCalledTimes(1);
+	});
+
 	it("initializes db and runs migrations when directory is writable", async () => {
 		const { modulePromise, mocks } = await loadDbClientModule({ dirWritable: true, authEnabled: false });
 		const mod = await modulePromise;

--- a/backend/src/test/domain-safety.test.ts
+++ b/backend/src/test/domain-safety.test.ts
@@ -49,6 +49,8 @@ const { testClient, testDb, testDbPath, mockedEnv } = vi.hoisted(() => {
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>): Promise<T> =>
+		operation(testDb),
 }));
 
 vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));

--- a/backend/src/test/e2e-routes.test.ts
+++ b/backend/src/test/e2e-routes.test.ts
@@ -26,6 +26,8 @@ const { testClient, testDb, testDbPath } = vi.hoisted(() => {
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>): Promise<T> =>
+		operation(testDb),
 }));
 
 vi.mock("../plugins/env.js", () => ({
@@ -2707,6 +2709,74 @@ describe("E2E Tests with Real Routes", () => {
 			expect(med.stockAdjustment).toBe(-5);
 		});
 
+		it("keeps raw stock and historical dose identities stable across schedule-to-zero-to-schedule edits", async () => {
+			await testClient.execute({
+				sql: "INSERT INTO user_settings (user_id, stock_calculation_mode) VALUES (?, ?)",
+				args: [userId, "manual"],
+			});
+			const schedule = [{ usage: 1, every: 1, start: "2026-01-01T08:00:00" }];
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: {
+					name: "Schedule boundary med",
+					packCount: 0,
+					blistersPerPack: 1,
+					pillsPerBlister: 1,
+					looseTablets: 10,
+					intakes: schedule,
+				},
+			});
+			expect(createResponse.statusCode).toBe(200);
+			const medId = createResponse.json().id as number;
+			const historicalDoseId = `${medId}-0-${new Date("2026-01-02T00:00:00.000Z").getTime()}`;
+			await testClient.execute({
+				sql: "INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed, taken_source) VALUES (?, ?, ?, 0, 'manual')",
+				args: [userId, historicalDoseId, Math.floor(new Date("2026-01-02T08:05:00.000Z").getTime() / 1000)],
+			});
+
+			const update = async (intakes: typeof schedule) =>
+				app.inject({
+					method: "PUT",
+					url: `/medications/${medId}`,
+					payload: {
+						name: "Schedule boundary med",
+						packCount: 0,
+						blistersPerPack: 1,
+						pillsPerBlister: 1,
+						looseTablets: 10,
+						intakes,
+					},
+				});
+
+			const removed = await update([]);
+			expect(removed.statusCode).toBe(200);
+			let stored = await testClient.execute({
+				sql: "SELECT intakes_json, usage_json, every_json, start_json, schedule_stock_rebase_milli FROM medications WHERE id = ?",
+				args: [medId],
+			});
+			expect(stored.rows[0]).toMatchObject({
+				intakes_json: "[]",
+				usage_json: "[]",
+				every_json: "[]",
+				start_json: "[]",
+				schedule_stock_rebase_milli: -1000,
+			});
+
+			const restored = await update([{ usage: 2, every: 1, start: "2026-01-01T20:00:00" }]);
+			expect(restored.statusCode).toBe(200);
+			stored = await testClient.execute({
+				sql: "SELECT schedule_stock_rebase_milli FROM medications WHERE id = ?",
+				args: [medId],
+			});
+			expect(stored.rows[0].schedule_stock_rebase_milli).toBe(1000);
+			const doses = await testClient.execute({
+				sql: "SELECT dose_id FROM dose_tracking WHERE user_id = ?",
+				args: [userId],
+			});
+			expect(doses.rows).toEqual([expect.objectContaining({ dose_id: historicalDoseId })]);
+		});
+
 		it("should not count phantom consumption in planner after stock correction", async () => {
 			// Create medication: 1 pack × 14 blisters × 14 pills = 196 pills total
 			// Schedule: 1 pill daily starting far in the past
@@ -3350,56 +3420,59 @@ describe("E2E Tests with Real Routes", () => {
 				expectedLooseTablets: 3,
 				expectedPersistedCapacity: 12,
 			},
-		])("should refill $name correctly after stock correction to zero", async ({
-			payload,
-			zeroPayload,
-			refillPayload,
-			expectedTotalPills,
-			expectedPackCount,
-			expectedLooseTablets,
-			expectedPersistedCapacity,
-		}) => {
-			const createResponse = await app.inject({
-				method: "POST",
-				url: "/medications",
+		])(
+			"should refill $name correctly after stock correction to zero",
+			async ({
 				payload,
-			});
-			expect(createResponse.statusCode).toBe(200);
-			const medId = createResponse.json().id;
+				zeroPayload,
+				refillPayload,
+				expectedTotalPills,
+				expectedPackCount,
+				expectedLooseTablets,
+				expectedPersistedCapacity,
+			}) => {
+				const createResponse = await app.inject({
+					method: "POST",
+					url: "/medications",
+					payload,
+				});
+				expect(createResponse.statusCode).toBe(200);
+				const medId = createResponse.json().id;
 
-			const zeroResponse = await app.inject({
-				method: "PATCH",
-				url: `/medications/${medId}/stock-adjustment`,
-				payload: zeroPayload,
-			});
-			expect(zeroResponse.statusCode).toBe(200);
+				const zeroResponse = await app.inject({
+					method: "PATCH",
+					url: `/medications/${medId}/stock-adjustment`,
+					payload: zeroPayload,
+				});
+				expect(zeroResponse.statusCode).toBe(200);
 
-			const refillResponse = await app.inject({
-				method: "POST",
-				url: `/medications/${medId}/refill`,
-				payload: refillPayload,
-			});
-			expect(refillResponse.statusCode).toBe(200);
-			const refillData = refillResponse.json();
-			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
-			expect(refillData.newStock.packCount).toBe(expectedPackCount);
-			expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
+				const refillResponse = await app.inject({
+					method: "POST",
+					url: `/medications/${medId}/refill`,
+					payload: refillPayload,
+				});
+				expect(refillResponse.statusCode).toBe(200);
+				const refillData = refillResponse.json();
+				expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+				expect(refillData.newStock.packCount).toBe(expectedPackCount);
+				expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
 
-			const medsResponse = await app.inject({ method: "GET", url: "/medications" });
-			expect(medsResponse.statusCode).toBe(200);
-			const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
-			expect(med).toBeTruthy();
-			expect(med.packCount).toBe(expectedPackCount);
-			expect(med.looseTablets).toBe(expectedLooseTablets);
-			expect(med.stockAdjustment).toBe(0);
-			if (typeof expectedPersistedCapacity === "number") {
-				if (med.packageType === "tube" || med.packageType === "liquid_container") {
-					expect(med.packageAmountValue).toBe(expectedPersistedCapacity);
-				} else {
-					expect(med.totalPills).toBe(expectedPersistedCapacity);
+				const medsResponse = await app.inject({ method: "GET", url: "/medications" });
+				expect(medsResponse.statusCode).toBe(200);
+				const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
+				expect(med).toBeTruthy();
+				expect(med.packCount).toBe(expectedPackCount);
+				expect(med.looseTablets).toBe(expectedLooseTablets);
+				expect(med.stockAdjustment).toBe(0);
+				if (typeof expectedPersistedCapacity === "number") {
+					if (med.packageType === "tube" || med.packageType === "liquid_container") {
+						expect(med.packageAmountValue).toBe(expectedPersistedCapacity);
+					} else {
+						expect(med.totalPills).toBe(expectedPersistedCapacity);
+					}
 				}
 			}
-		});
+		);
 
 		it("should create and return bottle type medication", async () => {
 			const response = await app.inject({
@@ -3460,22 +3533,22 @@ describe("E2E Tests with Real Routes", () => {
 			expect(data.looseTablets).toBe(180);
 		});
 
-		it.each(discreteContainerMedications)("should create and return $label type medication", async ({
-			payload,
-			expectedDoseUnit,
-		}) => {
-			const response = await app.inject({
-				method: "POST",
-				url: "/medications",
-				payload,
-			});
+		it.each(discreteContainerMedications)(
+			"should create and return $label type medication",
+			async ({ payload, expectedDoseUnit }) => {
+				const response = await app.inject({
+					method: "POST",
+					url: "/medications",
+					payload,
+				});
 
-			expect(response.statusCode).toBe(200);
-			const data = response.json();
-			expect(data.packageType).toBe(payload.packageType);
-			expect(data.doseUnit).toBe(expectedDoseUnit);
-			expect(data.looseTablets).toBe(payload.looseTablets);
-		});
+				expect(response.statusCode).toBe(200);
+				const data = response.json();
+				expect(data.packageType).toBe(payload.packageType);
+				expect(data.doseUnit).toBe(expectedDoseUnit);
+				expect(data.looseTablets).toBe(payload.looseTablets);
+			}
+		);
 
 		it("should return packageType and ml-based stock semantics in shared schedule for liquid_container", async () => {
 			await app.inject({
@@ -3670,71 +3743,74 @@ describe("E2E Tests with Real Routes", () => {
 				expectedPersistedTotalPills: 110,
 				expectedStockAdjustment: 0,
 			},
-		])("should refill from the persisted stock baseline after prior consumption for $name", async ({
-			payload,
-			refillPayload,
-			expectedVisibleStockBeforeRefill,
-			expectedQuantityAdded,
-			expectedResponsePacksAdded,
-			expectedAmountPerPackage,
-			expectedPackCount,
-			expectedLooseTablets,
-			expectedTotalPills,
-			expectedPersistedTotalPills,
-			expectedStockAdjustment,
-		}) => {
-			await testClient.execute({
-				sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
-				args: [userId],
-			});
-
-			const createResponse = await app.inject({
-				method: "POST",
-				url: "/medications",
+		])(
+			"should refill from the persisted stock baseline after prior consumption for $name",
+			async ({
 				payload,
-			});
-			expect(createResponse.statusCode).toBe(200);
-			const medId = createResponse.json().id;
-
-			for (let day = 1; day <= 6; day += 1) {
-				const doseDateOnlyMs = new Date(`2025-01-0${day}T00:00:00.000Z`).getTime();
-				const takenAtMs = new Date(`2025-01-0${day}T10:00:00.000Z`).getTime();
-				await testClient.execute({
-					sql: `INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed)
-					      VALUES (?, ?, ?, 0)`,
-					args: [userId, `${medId}-0-${doseDateOnlyMs}`, takenAtMs],
-				});
-			}
-
-			const refillResponse = await app.inject({
-				method: "POST",
-				url: `/medications/${medId}/refill`,
-				payload: refillPayload,
-			});
-
-			expect(refillResponse.statusCode).toBe(200);
-			const refillData = refillResponse.json();
-			await expectRefillInvariants({
-				medId,
-				refillData,
-				visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
+				refillPayload,
+				expectedVisibleStockBeforeRefill,
 				expectedQuantityAdded,
-				expectedPacksAdded: expectedResponsePacksAdded,
+				expectedResponsePacksAdded,
 				expectedAmountPerPackage,
-			});
-			expect(refillData.newStock.packCount).toBe(expectedPackCount);
-			expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
-			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+				expectedPackCount,
+				expectedLooseTablets,
+				expectedTotalPills,
+				expectedPersistedTotalPills,
+				expectedStockAdjustment,
+			}) => {
+				await testClient.execute({
+					sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
+					args: [userId],
+				});
 
-			const medsResponse = await app.inject({ method: "GET", url: "/medications" });
-			expect(medsResponse.statusCode).toBe(200);
-			const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
-			expect(med).toBeTruthy();
-			expect(med.packCount).toBe(expectedPackCount);
-			expect(med.looseTablets).toBe(expectedLooseTablets);
-			expect(med.totalPills).toBe(expectedPersistedTotalPills);
-			expect(med.stockAdjustment).toBe(expectedStockAdjustment);
-		});
+				const createResponse = await app.inject({
+					method: "POST",
+					url: "/medications",
+					payload,
+				});
+				expect(createResponse.statusCode).toBe(200);
+				const medId = createResponse.json().id;
+
+				for (let day = 1; day <= 6; day += 1) {
+					const doseDateOnlyMs = new Date(`2025-01-0${day}T00:00:00.000Z`).getTime();
+					const takenAtMs = new Date(`2025-01-0${day}T10:00:00.000Z`).getTime();
+					await testClient.execute({
+						sql: `INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed)
+					      VALUES (?, ?, ?, 0)`,
+						args: [userId, `${medId}-0-${doseDateOnlyMs}`, takenAtMs],
+					});
+				}
+
+				const refillResponse = await app.inject({
+					method: "POST",
+					url: `/medications/${medId}/refill`,
+					payload: refillPayload,
+				});
+
+				expect(refillResponse.statusCode).toBe(200);
+				const refillData = refillResponse.json();
+				await expectRefillInvariants({
+					medId,
+					refillData,
+					visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
+					expectedQuantityAdded,
+					expectedPacksAdded: expectedResponsePacksAdded,
+					expectedAmountPerPackage,
+				});
+				expect(refillData.newStock.packCount).toBe(expectedPackCount);
+				expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
+				expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+
+				const medsResponse = await app.inject({ method: "GET", url: "/medications" });
+				expect(medsResponse.statusCode).toBe(200);
+				const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
+				expect(med).toBeTruthy();
+				expect(med.packCount).toBe(expectedPackCount);
+				expect(med.looseTablets).toBe(expectedLooseTablets);
+				expect(med.totalPills).toBe(expectedPersistedTotalPills);
+				expect(med.stockAdjustment).toBe(expectedStockAdjustment);
+			}
+		);
 
 		it("should refill tube stock from the corrected visible baseline", async () => {
 			await testClient.execute({
@@ -3966,65 +4042,68 @@ describe("E2E Tests with Real Routes", () => {
 				expectedTotalPills: 160,
 				expectedAmountPerPackage: 40,
 			},
-		])("should derive amount-based refill counts and decrement prescription remaining refills for $name", async ({
-			payload,
-			refillPayload,
-			expectedVisibleStockBeforeRefill,
-			expectedPacksAdded,
-			expectedLooseAdded,
-			expectedRemainingRefills,
-			expectedTotalPills,
-			expectedAmountPerPackage,
-		}) => {
-			await testClient.execute({
-				sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
-				args: [userId],
-			});
-
-			const createResponse = await app.inject({
-				method: "POST",
-				url: "/medications",
+		])(
+			"should derive amount-based refill counts and decrement prescription remaining refills for $name",
+			async ({
 				payload,
-			});
-			expect(createResponse.statusCode).toBe(200);
-			const medId = createResponse.json().id;
-
-			const refillResponse = await app.inject({
-				method: "POST",
-				url: `/medications/${medId}/refill`,
-				payload: refillPayload,
-			});
-
-			expect(refillResponse.statusCode).toBe(200);
-			const refillData = refillResponse.json();
-			await expectRefillInvariants({
-				medId,
-				refillData,
-				visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
-				expectedQuantityAdded: expectedLooseAdded,
+				refillPayload,
+				expectedVisibleStockBeforeRefill,
 				expectedPacksAdded,
+				expectedLooseAdded,
+				expectedRemainingRefills,
+				expectedTotalPills,
 				expectedAmountPerPackage,
-			});
-			expect(refillData.refill.packsAdded).toBe(expectedPacksAdded);
-			expect(refillData.refill.loosePillsAdded).toBe(expectedLooseAdded);
-			expect(refillData.refill.quantityAdded).toBe(expectedLooseAdded);
-			expect(refillData.refill.totalPillsAdded).toBe(expectedLooseAdded);
-			expect(refillData.prescription.used).toBe(true);
-			expect(refillData.prescription.remainingRefills).toBe(expectedRemainingRefills);
-			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+			}) => {
+				await testClient.execute({
+					sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
+					args: [userId],
+				});
 
-			const historyResponse = await app.inject({
-				method: "GET",
-				url: `/medications/${medId}/refills`,
-			});
-			expect(historyResponse.statusCode).toBe(200);
-			expect(historyResponse.json()[0]).toMatchObject({
-				packsAdded: expectedPacksAdded,
-				loosePillsAdded: expectedLooseAdded,
-				quantityAdded: expectedLooseAdded,
-				usedPrescription: true,
-			});
-		});
+				const createResponse = await app.inject({
+					method: "POST",
+					url: "/medications",
+					payload,
+				});
+				expect(createResponse.statusCode).toBe(200);
+				const medId = createResponse.json().id;
+
+				const refillResponse = await app.inject({
+					method: "POST",
+					url: `/medications/${medId}/refill`,
+					payload: refillPayload,
+				});
+
+				expect(refillResponse.statusCode).toBe(200);
+				const refillData = refillResponse.json();
+				await expectRefillInvariants({
+					medId,
+					refillData,
+					visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
+					expectedQuantityAdded: expectedLooseAdded,
+					expectedPacksAdded,
+					expectedAmountPerPackage,
+				});
+				expect(refillData.refill.packsAdded).toBe(expectedPacksAdded);
+				expect(refillData.refill.loosePillsAdded).toBe(expectedLooseAdded);
+				expect(refillData.refill.quantityAdded).toBe(expectedLooseAdded);
+				expect(refillData.refill.totalPillsAdded).toBe(expectedLooseAdded);
+				expect(refillData.prescription.used).toBe(true);
+				expect(refillData.prescription.remainingRefills).toBe(expectedRemainingRefills);
+				expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+
+				const historyResponse = await app.inject({
+					method: "GET",
+					url: `/medications/${medId}/refills`,
+				});
+				expect(historyResponse.statusCode).toBe(200);
+				expect(historyResponse.json()[0]).toMatchObject({
+					packsAdded: expectedPacksAdded,
+					loosePillsAdded: expectedLooseAdded,
+					quantityAdded: expectedLooseAdded,
+					usedPrescription: true,
+				});
+			}
+		);
 
 		it("should keep tube refill additive and preserve amount baseline", async () => {
 			const createResponse = await app.inject({

--- a/backend/src/test/e2e-routes.test.ts
+++ b/backend/src/test/e2e-routes.test.ts
@@ -3420,59 +3420,56 @@ describe("E2E Tests with Real Routes", () => {
 				expectedLooseTablets: 3,
 				expectedPersistedCapacity: 12,
 			},
-		])(
-			"should refill $name correctly after stock correction to zero",
-			async ({
+		])("should refill $name correctly after stock correction to zero", async ({
+			payload,
+			zeroPayload,
+			refillPayload,
+			expectedTotalPills,
+			expectedPackCount,
+			expectedLooseTablets,
+			expectedPersistedCapacity,
+		}) => {
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
 				payload,
-				zeroPayload,
-				refillPayload,
-				expectedTotalPills,
-				expectedPackCount,
-				expectedLooseTablets,
-				expectedPersistedCapacity,
-			}) => {
-				const createResponse = await app.inject({
-					method: "POST",
-					url: "/medications",
-					payload,
-				});
-				expect(createResponse.statusCode).toBe(200);
-				const medId = createResponse.json().id;
+			});
+			expect(createResponse.statusCode).toBe(200);
+			const medId = createResponse.json().id;
 
-				const zeroResponse = await app.inject({
-					method: "PATCH",
-					url: `/medications/${medId}/stock-adjustment`,
-					payload: zeroPayload,
-				});
-				expect(zeroResponse.statusCode).toBe(200);
+			const zeroResponse = await app.inject({
+				method: "PATCH",
+				url: `/medications/${medId}/stock-adjustment`,
+				payload: zeroPayload,
+			});
+			expect(zeroResponse.statusCode).toBe(200);
 
-				const refillResponse = await app.inject({
-					method: "POST",
-					url: `/medications/${medId}/refill`,
-					payload: refillPayload,
-				});
-				expect(refillResponse.statusCode).toBe(200);
-				const refillData = refillResponse.json();
-				expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
-				expect(refillData.newStock.packCount).toBe(expectedPackCount);
-				expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
+			const refillResponse = await app.inject({
+				method: "POST",
+				url: `/medications/${medId}/refill`,
+				payload: refillPayload,
+			});
+			expect(refillResponse.statusCode).toBe(200);
+			const refillData = refillResponse.json();
+			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+			expect(refillData.newStock.packCount).toBe(expectedPackCount);
+			expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
 
-				const medsResponse = await app.inject({ method: "GET", url: "/medications" });
-				expect(medsResponse.statusCode).toBe(200);
-				const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
-				expect(med).toBeTruthy();
-				expect(med.packCount).toBe(expectedPackCount);
-				expect(med.looseTablets).toBe(expectedLooseTablets);
-				expect(med.stockAdjustment).toBe(0);
-				if (typeof expectedPersistedCapacity === "number") {
-					if (med.packageType === "tube" || med.packageType === "liquid_container") {
-						expect(med.packageAmountValue).toBe(expectedPersistedCapacity);
-					} else {
-						expect(med.totalPills).toBe(expectedPersistedCapacity);
-					}
+			const medsResponse = await app.inject({ method: "GET", url: "/medications" });
+			expect(medsResponse.statusCode).toBe(200);
+			const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
+			expect(med).toBeTruthy();
+			expect(med.packCount).toBe(expectedPackCount);
+			expect(med.looseTablets).toBe(expectedLooseTablets);
+			expect(med.stockAdjustment).toBe(0);
+			if (typeof expectedPersistedCapacity === "number") {
+				if (med.packageType === "tube" || med.packageType === "liquid_container") {
+					expect(med.packageAmountValue).toBe(expectedPersistedCapacity);
+				} else {
+					expect(med.totalPills).toBe(expectedPersistedCapacity);
 				}
 			}
-		);
+		});
 
 		it("should create and return bottle type medication", async () => {
 			const response = await app.inject({
@@ -3533,22 +3530,22 @@ describe("E2E Tests with Real Routes", () => {
 			expect(data.looseTablets).toBe(180);
 		});
 
-		it.each(discreteContainerMedications)(
-			"should create and return $label type medication",
-			async ({ payload, expectedDoseUnit }) => {
-				const response = await app.inject({
-					method: "POST",
-					url: "/medications",
-					payload,
-				});
+		it.each(discreteContainerMedications)("should create and return $label type medication", async ({
+			payload,
+			expectedDoseUnit,
+		}) => {
+			const response = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload,
+			});
 
-				expect(response.statusCode).toBe(200);
-				const data = response.json();
-				expect(data.packageType).toBe(payload.packageType);
-				expect(data.doseUnit).toBe(expectedDoseUnit);
-				expect(data.looseTablets).toBe(payload.looseTablets);
-			}
-		);
+			expect(response.statusCode).toBe(200);
+			const data = response.json();
+			expect(data.packageType).toBe(payload.packageType);
+			expect(data.doseUnit).toBe(expectedDoseUnit);
+			expect(data.looseTablets).toBe(payload.looseTablets);
+		});
 
 		it("should return packageType and ml-based stock semantics in shared schedule for liquid_container", async () => {
 			await app.inject({
@@ -3743,74 +3740,71 @@ describe("E2E Tests with Real Routes", () => {
 				expectedPersistedTotalPills: 110,
 				expectedStockAdjustment: 0,
 			},
-		])(
-			"should refill from the persisted stock baseline after prior consumption for $name",
-			async ({
+		])("should refill from the persisted stock baseline after prior consumption for $name", async ({
+			payload,
+			refillPayload,
+			expectedVisibleStockBeforeRefill,
+			expectedQuantityAdded,
+			expectedResponsePacksAdded,
+			expectedAmountPerPackage,
+			expectedPackCount,
+			expectedLooseTablets,
+			expectedTotalPills,
+			expectedPersistedTotalPills,
+			expectedStockAdjustment,
+		}) => {
+			await testClient.execute({
+				sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
+				args: [userId],
+			});
+
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
 				payload,
-				refillPayload,
-				expectedVisibleStockBeforeRefill,
-				expectedQuantityAdded,
-				expectedResponsePacksAdded,
-				expectedAmountPerPackage,
-				expectedPackCount,
-				expectedLooseTablets,
-				expectedTotalPills,
-				expectedPersistedTotalPills,
-				expectedStockAdjustment,
-			}) => {
+			});
+			expect(createResponse.statusCode).toBe(200);
+			const medId = createResponse.json().id;
+
+			for (let day = 1; day <= 6; day += 1) {
+				const doseDateOnlyMs = new Date(`2025-01-0${day}T00:00:00.000Z`).getTime();
+				const takenAtMs = new Date(`2025-01-0${day}T10:00:00.000Z`).getTime();
 				await testClient.execute({
-					sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
-					args: [userId],
-				});
-
-				const createResponse = await app.inject({
-					method: "POST",
-					url: "/medications",
-					payload,
-				});
-				expect(createResponse.statusCode).toBe(200);
-				const medId = createResponse.json().id;
-
-				for (let day = 1; day <= 6; day += 1) {
-					const doseDateOnlyMs = new Date(`2025-01-0${day}T00:00:00.000Z`).getTime();
-					const takenAtMs = new Date(`2025-01-0${day}T10:00:00.000Z`).getTime();
-					await testClient.execute({
-						sql: `INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed)
+					sql: `INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed)
 					      VALUES (?, ?, ?, 0)`,
-						args: [userId, `${medId}-0-${doseDateOnlyMs}`, takenAtMs],
-					});
-				}
-
-				const refillResponse = await app.inject({
-					method: "POST",
-					url: `/medications/${medId}/refill`,
-					payload: refillPayload,
+					args: [userId, `${medId}-0-${doseDateOnlyMs}`, takenAtMs],
 				});
-
-				expect(refillResponse.statusCode).toBe(200);
-				const refillData = refillResponse.json();
-				await expectRefillInvariants({
-					medId,
-					refillData,
-					visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
-					expectedQuantityAdded,
-					expectedPacksAdded: expectedResponsePacksAdded,
-					expectedAmountPerPackage,
-				});
-				expect(refillData.newStock.packCount).toBe(expectedPackCount);
-				expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
-				expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
-
-				const medsResponse = await app.inject({ method: "GET", url: "/medications" });
-				expect(medsResponse.statusCode).toBe(200);
-				const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
-				expect(med).toBeTruthy();
-				expect(med.packCount).toBe(expectedPackCount);
-				expect(med.looseTablets).toBe(expectedLooseTablets);
-				expect(med.totalPills).toBe(expectedPersistedTotalPills);
-				expect(med.stockAdjustment).toBe(expectedStockAdjustment);
 			}
-		);
+
+			const refillResponse = await app.inject({
+				method: "POST",
+				url: `/medications/${medId}/refill`,
+				payload: refillPayload,
+			});
+
+			expect(refillResponse.statusCode).toBe(200);
+			const refillData = refillResponse.json();
+			await expectRefillInvariants({
+				medId,
+				refillData,
+				visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
+				expectedQuantityAdded,
+				expectedPacksAdded: expectedResponsePacksAdded,
+				expectedAmountPerPackage,
+			});
+			expect(refillData.newStock.packCount).toBe(expectedPackCount);
+			expect(refillData.newStock.looseTablets).toBe(expectedLooseTablets);
+			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
+
+			const medsResponse = await app.inject({ method: "GET", url: "/medications" });
+			expect(medsResponse.statusCode).toBe(200);
+			const med = medsResponse.json().find((item: Record<string, unknown>) => item.id === medId);
+			expect(med).toBeTruthy();
+			expect(med.packCount).toBe(expectedPackCount);
+			expect(med.looseTablets).toBe(expectedLooseTablets);
+			expect(med.totalPills).toBe(expectedPersistedTotalPills);
+			expect(med.stockAdjustment).toBe(expectedStockAdjustment);
+		});
 
 		it("should refill tube stock from the corrected visible baseline", async () => {
 			await testClient.execute({
@@ -4042,68 +4036,65 @@ describe("E2E Tests with Real Routes", () => {
 				expectedTotalPills: 160,
 				expectedAmountPerPackage: 40,
 			},
-		])(
-			"should derive amount-based refill counts and decrement prescription remaining refills for $name",
-			async ({
+		])("should derive amount-based refill counts and decrement prescription remaining refills for $name", async ({
+			payload,
+			refillPayload,
+			expectedVisibleStockBeforeRefill,
+			expectedPacksAdded,
+			expectedLooseAdded,
+			expectedRemainingRefills,
+			expectedTotalPills,
+			expectedAmountPerPackage,
+		}) => {
+			await testClient.execute({
+				sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
+				args: [userId],
+			});
+
+			const createResponse = await app.inject({
+				method: "POST",
+				url: "/medications",
 				payload,
-				refillPayload,
-				expectedVisibleStockBeforeRefill,
+			});
+			expect(createResponse.statusCode).toBe(200);
+			const medId = createResponse.json().id;
+
+			const refillResponse = await app.inject({
+				method: "POST",
+				url: `/medications/${medId}/refill`,
+				payload: refillPayload,
+			});
+
+			expect(refillResponse.statusCode).toBe(200);
+			const refillData = refillResponse.json();
+			await expectRefillInvariants({
+				medId,
+				refillData,
+				visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
+				expectedQuantityAdded: expectedLooseAdded,
 				expectedPacksAdded,
-				expectedLooseAdded,
-				expectedRemainingRefills,
-				expectedTotalPills,
 				expectedAmountPerPackage,
-			}) => {
-				await testClient.execute({
-					sql: `INSERT OR REPLACE INTO user_settings (user_id, stock_calculation_mode) VALUES (?, 'manual')`,
-					args: [userId],
-				});
+			});
+			expect(refillData.refill.packsAdded).toBe(expectedPacksAdded);
+			expect(refillData.refill.loosePillsAdded).toBe(expectedLooseAdded);
+			expect(refillData.refill.quantityAdded).toBe(expectedLooseAdded);
+			expect(refillData.refill.totalPillsAdded).toBe(expectedLooseAdded);
+			expect(refillData.prescription.used).toBe(true);
+			expect(refillData.prescription.remainingRefills).toBe(expectedRemainingRefills);
+			expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
 
-				const createResponse = await app.inject({
-					method: "POST",
-					url: "/medications",
-					payload,
-				});
-				expect(createResponse.statusCode).toBe(200);
-				const medId = createResponse.json().id;
-
-				const refillResponse = await app.inject({
-					method: "POST",
-					url: `/medications/${medId}/refill`,
-					payload: refillPayload,
-				});
-
-				expect(refillResponse.statusCode).toBe(200);
-				const refillData = refillResponse.json();
-				await expectRefillInvariants({
-					medId,
-					refillData,
-					visibleStockBeforeRefill: expectedVisibleStockBeforeRefill,
-					expectedQuantityAdded: expectedLooseAdded,
-					expectedPacksAdded,
-					expectedAmountPerPackage,
-				});
-				expect(refillData.refill.packsAdded).toBe(expectedPacksAdded);
-				expect(refillData.refill.loosePillsAdded).toBe(expectedLooseAdded);
-				expect(refillData.refill.quantityAdded).toBe(expectedLooseAdded);
-				expect(refillData.refill.totalPillsAdded).toBe(expectedLooseAdded);
-				expect(refillData.prescription.used).toBe(true);
-				expect(refillData.prescription.remainingRefills).toBe(expectedRemainingRefills);
-				expect(refillData.newStock.totalPills).toBe(expectedTotalPills);
-
-				const historyResponse = await app.inject({
-					method: "GET",
-					url: `/medications/${medId}/refills`,
-				});
-				expect(historyResponse.statusCode).toBe(200);
-				expect(historyResponse.json()[0]).toMatchObject({
-					packsAdded: expectedPacksAdded,
-					loosePillsAdded: expectedLooseAdded,
-					quantityAdded: expectedLooseAdded,
-					usedPrescription: true,
-				});
-			}
-		);
+			const historyResponse = await app.inject({
+				method: "GET",
+				url: `/medications/${medId}/refills`,
+			});
+			expect(historyResponse.statusCode).toBe(200);
+			expect(historyResponse.json()[0]).toMatchObject({
+				packsAdded: expectedPacksAdded,
+				loosePillsAdded: expectedLooseAdded,
+				quantityAdded: expectedLooseAdded,
+				usedPrescription: true,
+			});
+		});
 
 		it("should keep tube refill additive and preserve amount baseline", async () => {
 			const createResponse = await app.inject({

--- a/backend/src/test/integration.test.ts
+++ b/backend/src/test/integration.test.ts
@@ -21,6 +21,8 @@ const { testClient, testDb } = vi.hoisted(() => {
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>): Promise<T> =>
+		operation(testDb),
 }));
 
 vi.mock("../plugins/env.js", () => ({

--- a/backend/src/test/routes-real.test.ts
+++ b/backend/src/test/routes-real.test.ts
@@ -32,6 +32,8 @@ const { testClient, testDb, testDbPath, mockedEnv, nodemailerSendMail, fetchMock
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>): Promise<T> =>
+		operation(testDb),
 }));
 
 vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));

--- a/backend/src/test/zero-schedule-concurrency.test.ts
+++ b/backend/src/test/zero-schedule-concurrency.test.ts
@@ -124,61 +124,61 @@ describe.sequential("zero-schedule production write serialization", () => {
 		rmSync(dataDir, { force: true, recursive: true });
 	});
 
-	it.each<StockMode>(["automatic", "manual"])(
-		"serializes simultaneous schedule boundary writes and preserves raw %s stock",
-		async (stockCalculationMode) => {
-			await db.delete(doseTracking);
-			await db.delete(medications);
-			await db.delete(userSettings);
-			await db.insert(userSettings).values({ userId, stockCalculationMode });
+	it.each<StockMode>([
+		"automatic",
+		"manual",
+	])("serializes simultaneous schedule boundary writes and preserves raw %s stock", async (stockCalculationMode) => {
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		await db.delete(userSettings);
+		await db.insert(userSettings).values({ userId, stockCalculationMode });
 
-			const start = scheduleStart();
-			const created = await app.inject({
-				method: "POST",
-				url: "/medications",
-				payload: medicationPayload([{ usage: 1, every: 1, start }]),
-			});
-			expect(created.statusCode).toBe(200);
-			const medicationId = created.json().id as number;
-			const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
-			await db.insert(doseTracking).values({
-				userId,
-				doseId: historicalDoseId,
-				takenAt: new Date(),
-				markedBy: "history",
-				takenSource: "manual",
-			});
+		const start = scheduleStart();
+		const created = await app.inject({
+			method: "POST",
+			url: "/medications",
+			payload: medicationPayload([{ usage: 1, every: 1, start }]),
+		});
+		expect(created.statusCode).toBe(200);
+		const medicationId = created.json().id as number;
+		const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
+		await db.insert(doseTracking).values({
+			userId,
+			doseId: historicalDoseId,
+			takenAt: new Date(),
+			markedBy: "history",
+			takenSource: "manual",
+		});
 
-			const [beforeMedication] = await db.select().from(medications);
-			const beforeDoses = await db.select().from(doseTracking);
-			const expectedRawStock = computeMedicationCurrentStockRaw({
-				medication: beforeMedication,
-				doses: beforeDoses,
-				stockCalculationMode,
-			});
+		const [beforeMedication] = await db.select().from(medications);
+		const beforeDoses = await db.select().from(doseTracking);
+		const expectedRawStock = computeMedicationCurrentStockRaw({
+			medication: beforeMedication,
+			doses: beforeDoses,
+			stockCalculationMode,
+		});
 
-			const [toUnscheduled, toScheduled] = await Promise.all([
-				app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
-				app.inject({
-					method: "PUT",
-					url: `/medications/${medicationId}`,
-					payload: medicationPayload([{ usage: 2, every: 1, start }]),
-				}),
-			]);
+		const [toUnscheduled, toScheduled] = await Promise.all([
+			app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
+			app.inject({
+				method: "PUT",
+				url: `/medications/${medicationId}`,
+				payload: medicationPayload([{ usage: 2, every: 1, start }]),
+			}),
+		]);
 
-			expect(toUnscheduled.statusCode).toBe(200);
-			expect(toScheduled.statusCode).toBe(200);
-			const [persisted] = await db.select().from(medications);
-			const persistedDoses = await db.select().from(doseTracking);
-			expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
-			expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
-			expect(
-				computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
-			).toBe(expectedRawStock);
-			expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
-			expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
-		}
-	);
+		expect(toUnscheduled.statusCode).toBe(200);
+		expect(toScheduled.statusCode).toBe(200);
+		const [persisted] = await db.select().from(medications);
+		const persistedDoses = await db.select().from(doseTracking);
+		expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
+		expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
+		expect(
+			computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
+		).toBe(expectedRawStock);
+		expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
+		expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
+	});
 
 	it("returns the original bounded SQLITE_BUSY from an independent writer and releases the FIFO queue", async () => {
 		const databaseUrl = `file:${resolve(dataDir, "medassist-ng.db")}`;

--- a/backend/src/test/zero-schedule-concurrency.test.ts
+++ b/backend/src/test/zero-schedule-concurrency.test.ts
@@ -1,0 +1,231 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// This suite deliberately imports the production database client after pointing it at a
+// dedicated on-disk database. Route suites normally mock db/client, which cannot exercise
+// the production FIFO writer queue or contention between independent SQLite connections.
+const dataDir = mkdtempSync(join(tmpdir(), "medassist-zero-schedule-concurrency-"));
+process.env.DATA_DIR = dataDir;
+process.env.DOTENV_PATH = join(dataDir, "missing.env");
+process.env.NODE_ENV = "test";
+process.env.AUTH_ENABLED = "false";
+process.env.OIDC_ENABLED = "false";
+process.env.LOG_LEVEL = "silent";
+
+const [
+	{ default: Fastify },
+	{ default: sensible },
+	{ sql },
+	{ documentationSchemaAjv },
+	dbClient,
+	schema,
+	auth,
+	medicationRoutesModule,
+	stock,
+] = await Promise.all([
+	import("fastify"),
+	import("@fastify/sensible"),
+	import("drizzle-orm"),
+	import("../utils/documentation-schema-keywords.js"),
+	import("../db/client.js"),
+	import("../db/schema.js"),
+	import("../plugins/auth.js"),
+	import("../routes/medications.js"),
+	import("../services/current-stock.js"),
+]);
+
+const { db, migrationsReady, withImmediateWriteTransaction } = dbClient;
+const { doseTracking, medications, userSettings } = schema;
+const { getAnonymousUserId } = auth;
+const { medicationRoutes } = medicationRoutesModule;
+const { computeMedicationCurrentStockRaw } = stock;
+
+type StockMode = "automatic" | "manual";
+
+function scheduleStart(): string {
+	return "2099-01-02T08:00:00";
+}
+
+function medicationPayload(intakes: Array<{ usage: number; every: number; start: string }>) {
+	return {
+		name: "Concurrency medicine",
+		genericName: null,
+		takenBy: [],
+		medicationForm: "tablet",
+		pillForm: "tablet",
+		lifecycleCategory: "refill_when_empty",
+		packageType: "blister",
+		packCount: 1,
+		blistersPerPack: 1,
+		pillsPerBlister: 10,
+		packageAmountValue: 0,
+		packageAmountUnit: "ml",
+		totalPills: null,
+		looseTablets: 0,
+		pillWeightMg: null,
+		doseUnit: "mg",
+		medicationStartDate: "",
+		medicationEndDate: null,
+		autoMarkObsoleteAfterEndDate: true,
+		expiryDate: null,
+		notes: null,
+		prescriptionEnabled: false,
+		prescriptionAuthorizedRefills: null,
+		prescriptionRemainingRefills: null,
+		prescriptionLowRefillThreshold: 1,
+		prescriptionExpiryDate: null,
+		intakeRemindersEnabled: false,
+		intakes,
+	};
+}
+
+async function waitForChildLine(child: ReturnType<typeof spawn>, expected: string): Promise<void> {
+	let received = "";
+	await Promise.race([
+		new Promise<void>((resolve, reject) => {
+			child.stdout?.on("data", (chunk: Buffer) => {
+				received += chunk.toString();
+				if (received.includes(expected)) resolve();
+			});
+			child.once("error", reject);
+			child.once("exit", (code) => reject(new Error(`lock holder exited before ready (${code}): ${received}`)));
+		}),
+		new Promise<void>((_, reject) =>
+			setTimeout(() => reject(new Error("timed out waiting for independent lock holder")), 3000)
+		),
+	]);
+}
+
+async function releaseChild(child: ReturnType<typeof spawn>): Promise<void> {
+	child.stdin?.end("release\n");
+	const [code] = await once(child, "exit");
+	expect(code).toBe(0);
+}
+
+describe.sequential("zero-schedule production write serialization", () => {
+	let app: Awaited<ReturnType<typeof Fastify>>;
+	let userId: number;
+
+	beforeAll(async () => {
+		await migrationsReady;
+		app = Fastify({ logger: false, ajv: documentationSchemaAjv });
+		await app.register(sensible);
+		await app.register(medicationRoutes);
+		await app.ready();
+		userId = await getAnonymousUserId();
+	});
+
+	afterAll(async () => {
+		await app.close();
+		rmSync(dataDir, { force: true, recursive: true });
+	});
+
+	it.each<StockMode>(["automatic", "manual"])(
+		"serializes simultaneous schedule boundary writes and preserves raw %s stock",
+		async (stockCalculationMode) => {
+			await db.delete(doseTracking);
+			await db.delete(medications);
+			await db.delete(userSettings);
+			await db.insert(userSettings).values({ userId, stockCalculationMode });
+
+			const start = scheduleStart();
+			const created = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: medicationPayload([{ usage: 1, every: 1, start }]),
+			});
+			expect(created.statusCode).toBe(200);
+			const medicationId = created.json().id as number;
+			const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
+			await db.insert(doseTracking).values({
+				userId,
+				doseId: historicalDoseId,
+				takenAt: new Date(),
+				markedBy: "history",
+				takenSource: "manual",
+			});
+
+			const [beforeMedication] = await db.select().from(medications);
+			const beforeDoses = await db.select().from(doseTracking);
+			const expectedRawStock = computeMedicationCurrentStockRaw({
+				medication: beforeMedication,
+				doses: beforeDoses,
+				stockCalculationMode,
+			});
+
+			const [toUnscheduled, toScheduled] = await Promise.all([
+				app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
+				app.inject({
+					method: "PUT",
+					url: `/medications/${medicationId}`,
+					payload: medicationPayload([{ usage: 2, every: 1, start }]),
+				}),
+			]);
+
+			expect(toUnscheduled.statusCode).toBe(200);
+			expect(toScheduled.statusCode).toBe(200);
+			const [persisted] = await db.select().from(medications);
+			const persistedDoses = await db.select().from(doseTracking);
+			expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
+			expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
+			expect(
+				computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
+			).toBe(expectedRawStock);
+			expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
+			expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
+		}
+	);
+
+	it("returns the original bounded SQLITE_BUSY from an independent writer and releases the FIFO queue", async () => {
+		const databaseUrl = `file:${resolve(dataDir, "medassist-ng.db")}`;
+		const child = spawn(
+			process.execPath,
+			[
+				"--input-type=module",
+				"--eval",
+				`import { createClient } from "@libsql/client";
+const client = createClient({ url: process.env.MEDASSIST_LOCK_DB_URL });
+const transaction = await client.transaction("write");
+process.stdout.write("locked\\n");
+process.stdin.once("data", async () => {
+	await transaction.commit();
+	transaction.close();
+	await client.close();
+	process.exitCode = 0;
+});`,
+			],
+			{
+				cwd: resolve(process.cwd()),
+				env: { ...process.env, MEDASSIST_LOCK_DB_URL: databaseUrl },
+				stdio: ["pipe", "pipe", "pipe"],
+			}
+		);
+
+		await waitForChildLine(child, "locked\n");
+		const failure = await Promise.race([
+			withImmediateWriteTransaction(async (transactionDb) => {
+				await transactionDb.run(sql`UPDATE medications SET notes = 'blocked'`);
+			}),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("production write helper hung on SQLITE_BUSY")), 3000)
+			),
+		]).then(
+			() => null,
+			(error: unknown) => error
+		);
+		expect(failure).toBeInstanceOf(Error);
+		expect((failure as Error).message).toMatch(/SQLITE_BUSY|database is locked/i);
+
+		await releaseChild(child);
+		await expect(
+			withImmediateWriteTransaction(async (transactionDb) => {
+				await transactionDb.run(sql`UPDATE medications SET notes = 'written after lock'`);
+				return "queued writer completed";
+			})
+		).resolves.toBe("queued writer completed");
+	});
+});


### PR DESCRIPTION
Closes #1012

## Summary

- allow medications with an explicit empty intake schedule
- preserve exact stock across zero/nonzero schedule transitions with an additive SQLite migration
- retain historic dose IDs and existing API/export contracts
- serialize SQLite migration initialization to avoid process-local `BEGIN IMMEDIATE` races and recover connections after failed acquisition

## Validation

- shared build
- focused zero-schedule and concurrency coverage
- full backend suite: 46 files, 896 tests
- root lint, check, build, and diff check

Slice 1 only. Slice 2 is intentionally excluded.