### PR TITLE
feat: apply as-needed effects to stock projections

### DIFF
--- a/backend/src/routes/doses.ts
+++ b/backend/src/routes/doses.ts
@@ -6,6 +6,7 @@ import { db } from "../db/client.js";
 import { doseTracking, intakeJournal, medications, type shareTokens, userSettings } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import { getActiveAsNeededStockEffectMilli } from "../services/as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "../services/current-stock.js";
 import { markDoseTakenForUser } from "../services/dose-tracking-service.js";
 import {
@@ -327,12 +328,14 @@ async function isDoseOutOfStock(options: {
 		: parsedDose.timestampMs;
 
 	const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, options.userId));
+	const asNeededStockEffectMilli = await getActiveAsNeededStockEffectMilli(db, options.userId, medication.id);
 	const stockBeforeDoseMs = Math.max(0, scheduledOccurrenceMs - 1);
 	return (
 		computeMedicationCurrentStock({
 			medication,
 			doses,
 			stockCalculationMode: options.stockCalculationMode,
+			asNeededStockEffectMilli,
 			nowMs: stockBeforeDoseMs,
 		}) <= 0
 	);

--- a/backend/src/routes/medications.ts
+++ b/backend/src/routes/medications.ts
@@ -7,6 +7,10 @@ import { getDataDir } from "../db/path-utils.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { getAnonymousUserId, isReadOnlyApiKeyRequest, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import {
+	getActiveAsNeededStockEffectMilli,
+	getActiveAsNeededStockEffectsMilli,
+} from "../services/as-needed-intakes-service.js";
 import { computeMedicationCurrentStockRaw } from "../services/current-stock.js";
 import { normalizeDateTime, parseIntakesWithUnits } from "../services/medications-service.js";
 import { calculatePlannerDemandRows } from "../services/planner-demand.js";
@@ -522,6 +526,11 @@ export async function medicationRoutes(app: FastifyInstance) {
 				? eq(medications.userId, userId)
 				: and(eq(medications.userId, userId), eq(medications.isObsolete, false));
 			const rows = await db.select().from(medications).where(whereClause).orderBy(medications.id);
+			const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
+				db,
+				userId,
+				rows.map((row) => row.id)
+			);
 			return rows.map((row) => {
 				const intakes = parseIntakesWithUnits(row);
 
@@ -553,7 +562,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 					// Legacy blisters format (for backward compat with frontend during transition)
 					blisters: intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start })),
 					hasRegularSchedule: intakes.length > 0,
-					asNeededStockEffect: 0,
+					asNeededStockEffect: (asNeededEffects.get(row.id) ?? 0) / 1000,
 					imageUrl: row.imageUrl,
 					expiryDate: row.expiryDate,
 					notes: row.notes,
@@ -853,6 +862,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 					: {};
 
 				let dosesForProjection: Array<typeof doseTracking.$inferSelect> = [];
+				let asNeededStockEffectMilli = 0;
 				let stockCalculationMode: "automatic" | "manual" = "automatic";
 				let stockBeforeTransition = 0;
 				if (crossesZeroScheduleBoundary && !stockFieldsChanged) {
@@ -865,10 +875,12 @@ export async function medicationRoutes(app: FastifyInstance) {
 						.from(userSettings)
 						.where(eq(userSettings.userId, userId));
 					stockCalculationMode = settings?.stockCalculationMode === "manual" ? "manual" : "automatic";
+					asNeededStockEffectMilli = await getActiveAsNeededStockEffectMilli(transactionDb, userId, idNum);
 					stockBeforeTransition = computeMedicationCurrentStockRaw({
 						medication: current,
 						doses: dosesForProjection,
 						stockCalculationMode,
+						asNeededStockEffectMilli,
 						nowMs: changedAt.getTime(),
 					});
 				}
@@ -922,6 +934,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 					medication: updated,
 					doses: dosesForProjection,
 					stockCalculationMode,
+					asNeededStockEffectMilli,
 					nowMs: changedAt.getTime(),
 				});
 				const scheduleStockRebaseMilli =
@@ -938,6 +951,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 
 			if (!transition) return reply.notFound();
 			const result = [transition.medication];
+			const asNeededStockEffect = (await getActiveAsNeededStockEffectMilli(db, userId, result[0].id)) / 1000;
 
 			// ---------------------------------------------------------------
 			// Migrate dose tracking IDs when intake schedule changes
@@ -1084,7 +1098,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 				intakes,
 				blisters: intakes.map((i) => ({ usage: i.usage, every: i.every, start: i.start })),
 				hasRegularSchedule: intakes.length > 0,
-				asNeededStockEffect: 0,
+				asNeededStockEffect,
 				imageUrl: result[0].imageUrl,
 				expiryDate: result[0].expiryDate,
 				notes: result[0].notes,

--- a/backend/src/routes/share.ts
+++ b/backend/src/routes/share.ts
@@ -5,6 +5,7 @@ import { db } from "../db/client.js";
 import { doseTracking, medications, shareTokens, userSettings, users } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import { getActiveAsNeededStockEffectsMilli } from "../services/as-needed-intakes-service.js";
 import { buildSharedMedicationOverview } from "../services/coverage.js";
 import {
 	getPublicShareContext,
@@ -353,14 +354,21 @@ export async function shareRoutes(app: FastifyInstance) {
 
 			const meds = await getActiveMedicationsForPerson(share.userId, share.takenBy);
 			const medicationsWithBlisters = meds.map((medication) => toSharedScheduleMedication(medication, share.takenBy));
-
 			const shareMedicationOverview = settings?.shareMedicationOverview ?? false;
+			const asNeededStockEffectsMilli = shareMedicationOverview
+				? await getActiveAsNeededStockEffectsMilli(
+						db,
+						share.userId,
+						meds.map((medication) => medication.id)
+					)
+				: new Map<number, number>();
 			const medicationOverview = shareMedicationOverview
 				? buildSharedMedicationOverview({
 						medications: meds,
 						doses: await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId)),
 						thresholdDays: settings?.lowStockDays ?? 30,
 						shareTakenBy: share.takenBy,
+						asNeededStockEffectsMilli,
 					})
 				: null;
 
@@ -445,6 +453,11 @@ export async function shareRoutes(app: FastifyInstance) {
 			const [owner] = await db.select({ username: users.username }).from(users).where(eq(users.id, share.userId));
 
 			const meds = await getActiveMedicationsForPerson(share.userId, share.takenBy);
+			const asNeededStockEffectsMilli = await getActiveAsNeededStockEffectsMilli(
+				db,
+				share.userId,
+				meds.map((medication) => medication.id)
+			);
 
 			const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId));
 
@@ -453,6 +466,7 @@ export async function shareRoutes(app: FastifyInstance) {
 				doses,
 				thresholdDays: settings?.lowStockDays ?? 30,
 				shareTakenBy: share.takenBy,
+				asNeededStockEffectsMilli,
 			});
 
 			return {

--- a/backend/src/services/as-needed-intakes-service.ts
+++ b/backend/src/services/as-needed-intakes-service.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { getAsNeededQuantityProfile, normalizeAsNeededQuantityMilli } from "@medassist/shared";
-import { and, eq, sql } from "drizzle-orm";
-import { withImmediateWriteTransaction } from "../db/client.js";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { type db, withImmediateWriteTransaction } from "../db/client.js";
 import { asNeededIntakeEvents, doseTracking, medications, userSettings } from "../db/schema.js";
 import { normalizeMedicationSchedule } from "../utils/scheduler-utils.js";
 import { computeMedicationCurrentStockRaw } from "./current-stock.js";
@@ -10,6 +10,7 @@ export type AsNeededLifecycle = "active_no_schedule" | "active_scheduled" | "end
 export type AsNeededEligibilityReason = "eligible" | "has_regular_schedule" | "ended" | "obsolete";
 
 type MedicationRow = typeof medications.$inferSelect;
+type Database = typeof db;
 
 export class AsNeededIntakeError extends Error {
 	constructor(
@@ -76,6 +77,47 @@ export function getAsNeededLifecycle(
 	return { lifecycle: "active_no_schedule", eligible: true, reason: "eligible" };
 }
 
+export async function getActiveAsNeededStockEffectMilli(
+	database: Database,
+	userId: number,
+	medicationId: number
+): Promise<number> {
+	const [row] = await database
+		.select({ total: sql<number>`coalesce(sum(${asNeededIntakeEvents.stockEffectMilli}), 0)` })
+		.from(asNeededIntakeEvents)
+		.where(
+			and(
+				eq(asNeededIntakeEvents.userId, userId),
+				eq(asNeededIntakeEvents.medicationId, medicationId),
+				eq(asNeededIntakeEvents.status, "active")
+			)
+		);
+	return Number(row?.total ?? 0);
+}
+
+export async function getActiveAsNeededStockEffectsMilli(
+	database: Database,
+	userId: number,
+	medicationIds: number[]
+): Promise<Map<number, number>> {
+	if (medicationIds.length === 0) return new Map();
+	const rows = await database
+		.select({
+			medicationId: asNeededIntakeEvents.medicationId,
+			total: sql<number>`coalesce(sum(${asNeededIntakeEvents.stockEffectMilli}), 0)`,
+		})
+		.from(asNeededIntakeEvents)
+		.where(
+			and(
+				eq(asNeededIntakeEvents.userId, userId),
+				eq(asNeededIntakeEvents.status, "active"),
+				inArray(asNeededIntakeEvents.medicationId, medicationIds)
+			)
+		)
+		.groupBy(asNeededIntakeEvents.medicationId);
+	return new Map(rows.map((row) => [row.medicationId, Number(row.total ?? 0)]));
+}
+
 export async function createAsNeededIntake(input: {
 	userId: number;
 	medicationId: number;
@@ -137,24 +179,15 @@ export async function createAsNeededIntake(input: {
 			.from(userSettings)
 			.where(eq(userSettings.userId, input.userId));
 		const doses = await transactionDb.select().from(doseTracking).where(eq(doseTracking.userId, input.userId));
-		const [effectRow] = await transactionDb
-			.select({ total: sql<number>`coalesce(sum(${asNeededIntakeEvents.stockEffectMilli}), 0)` })
-			.from(asNeededIntakeEvents)
-			.where(
-				and(
-					eq(asNeededIntakeEvents.userId, input.userId),
-					eq(asNeededIntakeEvents.medicationId, input.medicationId),
-					eq(asNeededIntakeEvents.status, "active")
-				)
-			);
-		const scheduledStockMilli = Math.round(
+		const activeEffectMilli = await getActiveAsNeededStockEffectMilli(transactionDb, input.userId, input.medicationId);
+		const currentStockMilli = Math.round(
 			computeMedicationCurrentStockRaw({
 				medication,
 				doses,
 				stockCalculationMode: settings?.stockCalculationMode === "manual" ? "manual" : "automatic",
+				asNeededStockEffectMilli: activeEffectMilli,
 			}) * 1000
 		);
-		const currentStockMilli = Math.max(0, scheduledStockMilli - Number(effectRow?.total ?? 0));
 		if (profile.measurable && (!Number.isSafeInteger(currentStockMilli) || currentStockMilli < 0)) {
 			throw new AsNeededIntakeError("STOCK_UNRESOLVABLE", "Current stock cannot be resolved safely");
 		}

--- a/backend/src/services/coverage.ts
+++ b/backend/src/services/coverage.ts
@@ -141,8 +141,9 @@ export function buildSharedMedicationOverview(options: {
 	doses: DoseRow[];
 	thresholdDays: number;
 	shareTakenBy?: string;
+	asNeededStockEffectsMilli?: Map<number, number>;
 }): SharedMedicationOverviewItem[] {
-	const { medications: medicationRows, doses, thresholdDays, shareTakenBy } = options;
+	const { medications: medicationRows, doses, thresholdDays, shareTakenBy, asNeededStockEffectsMilli } = options;
 
 	const dosesByMedication = new Map<number, DoseRow[]>();
 	for (const dose of doses) {
@@ -165,7 +166,11 @@ export function buildSharedMedicationOverview(options: {
 		const capacity = computeCapacity(medication);
 		const dailyDoseRate = computeDailyDoseRate(intakes, medication);
 		const takenAmount = computeTakenAmount(medication, schedule.intakes, intakes, dosesByMedication);
-		const rawCurrentStock = capacity + (medication.stockAdjustment ?? 0) - takenAmount;
+		const rawCurrentStock =
+			capacity +
+			(medication.stockAdjustment ?? 0) -
+			takenAmount -
+			(asNeededStockEffectsMilli?.get(medication.id) ?? 0) / 1000;
 		const currentStock = Math.max(0, Math.floor(rawCurrentStock));
 		const daysLeft = dailyDoseRate > 0 ? Math.floor(currentStock / dailyDoseRate) : null;
 		const depletionDate =

--- a/backend/src/services/current-stock.ts
+++ b/backend/src/services/current-stock.ts
@@ -19,6 +19,7 @@ type CurrentStockOptions = {
 	medication: MedicationRow;
 	doses: DoseRow[];
 	stockCalculationMode: "automatic" | "manual";
+	asNeededStockEffectMilli?: number;
 	nowMs?: number;
 };
 
@@ -32,7 +33,7 @@ function getDoseTakenAtMs(dose: DoseRow): number {
 }
 
 export function computeMedicationCurrentStockRaw(options: CurrentStockOptions): number {
-	const { medication, doses, stockCalculationMode, nowMs = Date.now() } = options;
+	const { medication, doses, stockCalculationMode, asNeededStockEffectMilli = 0, nowMs = Date.now() } = options;
 
 	const schedule = normalizeMedicationSchedule(medication);
 	const intakes = schedule.intakes;
@@ -127,7 +128,10 @@ export function computeMedicationCurrentStockRaw(options: CurrentStockOptions): 
 		});
 	}
 
-	return Math.max(0, baseStock + (medication.scheduleStockRebaseMilli ?? 0) / 1000 - consumed);
+	return Math.max(
+		0,
+		baseStock + (medication.scheduleStockRebaseMilli ?? 0) / 1000 - consumed - asNeededStockEffectMilli / 1000
+	);
 }
 
 export function computeMedicationCurrentStock(options: CurrentStockOptions): number {

--- a/backend/src/services/dose-tracking-service.ts
+++ b/backend/src/services/dose-tracking-service.ts
@@ -3,6 +3,7 @@ import { db } from "../db/client.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { parseDoseId } from "../utils/dose-id.js";
 import { normalizeMedicationIntakes, parseLocalDateTime } from "../utils/scheduler-utils.js";
+import { getActiveAsNeededStockEffectMilli } from "./as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 
 export type DoseTrackingSource = "manual" | "automatic" | "notification";
@@ -105,6 +106,7 @@ async function isDoseOutOfStock(options: { userId: number; doseId: string }): Pr
 		: parsedDose.timestampMs;
 
 	const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, options.userId));
+	const asNeededStockEffectMilli = await getActiveAsNeededStockEffectMilli(db, options.userId, medication.id);
 	const stockBeforeDoseMs = Math.max(0, scheduledOccurrenceMs - 1);
 
 	return (
@@ -112,6 +114,7 @@ async function isDoseOutOfStock(options: { userId: number; doseId: string }): Pr
 			medication,
 			doses,
 			stockCalculationMode,
+			asNeededStockEffectMilli,
 			nowMs: stockBeforeDoseMs,
 		}) <= 0
 	);

--- a/backend/src/services/intake-reminder-scheduler.ts
+++ b/backend/src/services/intake-reminder-scheduler.ts
@@ -31,6 +31,7 @@ import {
 	parseIntakeReminderState,
 	type UpcomingIntake,
 } from "../utils/scheduler-utils.js";
+import { getActiveAsNeededStockEffectsMilli } from "./as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 import {
 	createNotificationActionContext,
@@ -162,6 +163,11 @@ async function autoMarkDueIntakesAsTaken(
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, settings.userId), eq(doseTracking.dismissed, false)));
+	const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
+		db,
+		settings.userId,
+		rows.map((medication) => medication.id)
+	);
 
 	let inserted = 0;
 
@@ -182,6 +188,7 @@ async function autoMarkDueIntakesAsTaken(
 			medication: med,
 			doses: trackedDoses,
 			stockCalculationMode: settings.stockCalculationMode,
+			asNeededStockEffectMilli: asNeededEffects.get(med.id) ?? 0,
 			nowMs: now.getTime(),
 		});
 		if (remainingStock <= 0) {
@@ -516,6 +523,11 @@ export async function checkAndSendIntakeRemindersForUser(
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, settings.userId), eq(doseTracking.dismissed, false)));
+	const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
+		db,
+		settings.userId,
+		reminderEntries.map((entry) => entry.med.id)
+	);
 
 	const reminderEntriesWithStock = reminderEntries.map((entry) => ({
 		...entry,
@@ -523,6 +535,7 @@ export async function checkAndSendIntakeRemindersForUser(
 			medication: entry.med,
 			doses: trackedDoses,
 			stockCalculationMode: settings.stockCalculationMode,
+			asNeededStockEffectMilli: asNeededEffects.get(entry.med.id) ?? 0,
 			nowMs: now.getTime(),
 		}),
 	}));

--- a/backend/src/services/medications-service.ts
+++ b/backend/src/services/medications-service.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/scheduler-utils.js";
 
 export { normalizeDateTime } from "../utils/date-time.js";
+export { getActiveAsNeededStockEffectMilli, getActiveAsNeededStockEffectsMilli } from "./as-needed-intakes-service.js";
 
 function isIntakeUnit(value: unknown): value is "ml" | "tsp" | "tbsp" {
 	return value === "ml" || value === "tsp" || value === "tbsp";

--- a/backend/src/services/planner-demand.ts
+++ b/backend/src/services/planner-demand.ts
@@ -3,6 +3,7 @@ import { db } from "../db/client.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { isAmountBasedPackageType, isTubePackageType, normalizePackageType } from "../utils/package-profiles.js";
 import { normalizeIntakeUsageForStock, normalizeMedicationSchedule } from "../utils/scheduler-utils.js";
+import { getActiveAsNeededStockEffectsMilli } from "./as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 import { calculateUsageInRange, parseIntakesWithUnits } from "./medications-service.js";
 
@@ -63,6 +64,11 @@ export async function calculatePlannerDemandRows(options: PlannerDemandOptions):
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, userId), eq(doseTracking.dismissed, false)));
+	const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
+		db,
+		userId,
+		rows.map((row) => row.id)
+	);
 
 	return rows.map((row) => {
 		const intakes = parseIntakesWithUnits(row);
@@ -98,6 +104,7 @@ export async function calculatePlannerDemandRows(options: PlannerDemandOptions):
 					medication: row,
 					doses: takenDoses,
 					stockCalculationMode,
+					asNeededStockEffectMilli: asNeededEffects.get(row.id) ?? 0,
 					nowMs: now.getTime(),
 				});
 		const effectivePlannerStart = includeUntilStart ? now : startDate;

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -207,18 +207,15 @@ describe.sequential("as-needed intake service", () => {
 		["ended", { endDate: "2000-01-01" }, undefined, "NOT_ELIGIBLE"],
 		["obsolete", { isObsolete: true }, undefined, "NOT_ELIGIBLE"],
 		["unassigned person", { people: ["Ava"] }, "Ben", "INVALID_PERSON"],
-	] as const)(
-		"rejects %s medication eligibility without an anchor or event",
-		async (_case, options, personName, code) => {
-			const medicationId = await seedMedication(options);
-			await expectCode(
-				createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
-				code
-			);
-			expect(await eventCount()).toBe(0);
-			expect((await db.select().from(doseTracking)).length).toBe(0);
-		}
-	);
+	] as const)("rejects %s medication eligibility without an anchor or event", async (_case, options, personName, code) => {
+		const medicationId = await seedMedication(options);
+		await expectCode(
+			createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
+			code
+		);
+		expect(await eventCount()).toBe(0);
+		expect((await db.select().from(doseTracking)).length).toBe(0);
+	});
 
 	it.each([
 		["insufficient stock", { stock: 1 }, 2, "INSUFFICIENT_STOCK"],

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -24,7 +24,12 @@ const [{ db, migrationsReady }, schema, service] = await Promise.all([
 	import("../services/as-needed-intakes-service.js"),
 ]);
 const { asNeededIntakeEvents, doseTracking, medications, userSettings, users } = schema;
-const { createAsNeededIntake, reverseAsNeededIntake } = service;
+const {
+	createAsNeededIntake,
+	getActiveAsNeededStockEffectMilli,
+	getActiveAsNeededStockEffectsMilli,
+	reverseAsNeededIntake,
+} = service;
 
 const __filename = fileURLToPath(import.meta.url);
 const migrationsFolder = resolve(dirname(__filename), "../../drizzle");
@@ -161,20 +166,59 @@ describe.sequential("as-needed intake service", () => {
 		expect(await eventCount()).toBe(2);
 	});
 
+	it("aggregates active effects per owner and medication while retaining reversed and zero-effect rows as zero", async () => {
+		const ownerMedicationId = await seedMedication({ stock: 5 });
+		const otherMedicationId = await seedMedication({ userId: 2, stock: 5 });
+		const active = await createAsNeededIntake({
+			userId: 1,
+			medicationId: ownerMedicationId,
+			quantity: 1,
+			idempotencyKey: intentKey(),
+		});
+		const reversed = await createAsNeededIntake({
+			userId: 1,
+			medicationId: ownerMedicationId,
+			quantity: 1,
+			idempotencyKey: intentKey(),
+		});
+		await reverseAsNeededIntake({
+			userId: 1,
+			eventId: reversed.eventId,
+			expectedRevision: 1,
+			idempotencyKey: intentKey(),
+		});
+		await createAsNeededIntake({
+			userId: 2,
+			medicationId: otherMedicationId,
+			quantity: 1,
+			idempotencyKey: intentKey(),
+		});
+		expect(await getActiveAsNeededStockEffectMilli(db, 1, ownerMedicationId)).toBe(active.stockEffectMilli);
+		expect(await getActiveAsNeededStockEffectsMilli(db, 1, [ownerMedicationId, otherMedicationId])).toEqual(
+			new Map([[ownerMedicationId, active.stockEffectMilli]])
+		);
+		const topicalId = await seedMedication({ form: "topical", packageType: "tube", stock: 0 });
+		await createAsNeededIntake({ userId: 1, medicationId: topicalId, quantity: 1, idempotencyKey: intentKey() });
+		expect(await getActiveAsNeededStockEffectMilli(db, 1, topicalId)).toBe(0);
+	});
+
 	it.each([
 		["scheduled", { intakes: [{ usage: 1, every: 1, start: "2099-01-01T08:00:00" }] }, undefined, "NOT_ELIGIBLE"],
 		["ended", { endDate: "2000-01-01" }, undefined, "NOT_ELIGIBLE"],
 		["obsolete", { isObsolete: true }, undefined, "NOT_ELIGIBLE"],
 		["unassigned person", { people: ["Ava"] }, "Ben", "INVALID_PERSON"],
-	] as const)("rejects %s medication eligibility without an anchor or event", async (_case, options, personName, code) => {
-		const medicationId = await seedMedication(options);
-		await expectCode(
-			createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
-			code
-		);
-		expect(await eventCount()).toBe(0);
-		expect((await db.select().from(doseTracking)).length).toBe(0);
-	});
+	] as const)(
+		"rejects %s medication eligibility without an anchor or event",
+		async (_case, options, personName, code) => {
+			const medicationId = await seedMedication(options);
+			await expectCode(
+				createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
+				code
+			);
+			expect(await eventCount()).toBe(0);
+			expect((await db.select().from(doseTracking)).length).toBe(0);
+		}
+	);
 
 	it.each([
 		["insufficient stock", { stock: 1 }, 2, "INSUFFICIENT_STOCK"],

--- a/backend/src/test/coverage-service.test.ts
+++ b/backend/src/test/coverage-service.test.ts
@@ -127,6 +127,17 @@ describe("buildSharedMedicationOverview", () => {
 		]);
 	});
 
+	it("uses only the supplied aggregate effect for shared stock without exposing an event or anchor", () => {
+		const overview = buildSharedMedicationOverview({
+			medications: [medication({ packCount: 0, looseTablets: 2 })],
+			doses: [dose({ doseId: "as-needed:opaque-event-anchor" })],
+			thresholdDays: 3,
+			asNeededStockEffectsMilli: new Map([[1, 1500]]),
+		});
+		expect(overview).toEqual([expect.objectContaining({ currentStock: 0, daysLeft: 0 })]);
+		expect(overview[0]).not.toHaveProperty("eventId");
+	});
+
 	it("scopes dose deductions to the shared recipient without compacting dose indexes", () => {
 		const overview = buildSharedMedicationOverview({
 			medications: [

--- a/backend/src/test/current-stock-service.test.ts
+++ b/backend/src/test/current-stock-service.test.ts
@@ -185,22 +185,40 @@ describe("computeMedicationCurrentStock", () => {
 		expect(malformedScheduleStock).toBe(5);
 	});
 
-	it.each([
-		"automatic",
-		"manual",
-	] as const)("applies exact schedule rebases before rounding in %s mode", (stockCalculationMode) => {
-		const rebasedMedication = medication({
-			packCount: 0,
-			looseTablets: 10,
-			scheduleStockRebaseMilli: -1500,
-			intakesJson: "[]",
-			usageJson: "[]",
-			everyJson: "[]",
-			startJson: "[]",
-		});
-		const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
+	it.each(["automatic", "manual"] as const)(
+		"applies exact schedule rebases before rounding in %s mode",
+		(stockCalculationMode) => {
+			const rebasedMedication = medication({
+				packCount: 0,
+				looseTablets: 10,
+				scheduleStockRebaseMilli: -1500,
+				intakesJson: "[]",
+				usageJson: "[]",
+				everyJson: "[]",
+				startJson: "[]",
+			});
+			const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
 
-		expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
-		expect(computeMedicationCurrentStock(options)).toBe(8);
-	});
+			expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
+			expect(computeMedicationCurrentStock(options)).toBe(8);
+		}
+	);
+
+	it.each(["automatic", "manual"] as const)(
+		"subtracts exact active as-needed milli effects and retains scheduled-dose identity in %s mode",
+		(stockCalculationMode) => {
+			const scheduledDose = dose({ doseId: buildDoseId(7, 0, new Date("2026-03-10T00:00:00.000Z").getTime()) });
+			const anchor = dose({ id: 2, doseId: "as-needed:2dfe2cca-1b2e-4a2c-9c31-d5aa9f5b0dce" });
+			const options = {
+				medication: medication({ packCount: 0, looseTablets: 3 }),
+				doses: [scheduledDose, anchor],
+				stockCalculationMode,
+				asNeededStockEffectMilli: 1500,
+				nowMs: new Date("2026-03-10T12:00:00.000Z").getTime(),
+			};
+			expect(computeMedicationCurrentStockRaw(options)).toBe(0.5);
+			expect(computeMedicationCurrentStock(options)).toBe(0);
+			expect(computeMedicationCurrentStockRaw({ ...options, asNeededStockEffectMilli: 9_000 })).toBe(0);
+		}
+	);
 });

--- a/backend/src/test/current-stock-service.test.ts
+++ b/backend/src/test/current-stock-service.test.ts
@@ -185,40 +185,40 @@ describe("computeMedicationCurrentStock", () => {
 		expect(malformedScheduleStock).toBe(5);
 	});
 
-	it.each(["automatic", "manual"] as const)(
-		"applies exact schedule rebases before rounding in %s mode",
-		(stockCalculationMode) => {
-			const rebasedMedication = medication({
-				packCount: 0,
-				looseTablets: 10,
-				scheduleStockRebaseMilli: -1500,
-				intakesJson: "[]",
-				usageJson: "[]",
-				everyJson: "[]",
-				startJson: "[]",
-			});
-			const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
+	it.each([
+		"automatic",
+		"manual",
+	] as const)("applies exact schedule rebases before rounding in %s mode", (stockCalculationMode) => {
+		const rebasedMedication = medication({
+			packCount: 0,
+			looseTablets: 10,
+			scheduleStockRebaseMilli: -1500,
+			intakesJson: "[]",
+			usageJson: "[]",
+			everyJson: "[]",
+			startJson: "[]",
+		});
+		const options = { medication: rebasedMedication, doses: [], stockCalculationMode };
 
-			expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
-			expect(computeMedicationCurrentStock(options)).toBe(8);
-		}
-	);
+		expect(computeMedicationCurrentStockRaw(options)).toBe(8.5);
+		expect(computeMedicationCurrentStock(options)).toBe(8);
+	});
 
-	it.each(["automatic", "manual"] as const)(
-		"subtracts exact active as-needed milli effects and retains scheduled-dose identity in %s mode",
-		(stockCalculationMode) => {
-			const scheduledDose = dose({ doseId: buildDoseId(7, 0, new Date("2026-03-10T00:00:00.000Z").getTime()) });
-			const anchor = dose({ id: 2, doseId: "as-needed:2dfe2cca-1b2e-4a2c-9c31-d5aa9f5b0dce" });
-			const options = {
-				medication: medication({ packCount: 0, looseTablets: 3 }),
-				doses: [scheduledDose, anchor],
-				stockCalculationMode,
-				asNeededStockEffectMilli: 1500,
-				nowMs: new Date("2026-03-10T12:00:00.000Z").getTime(),
-			};
-			expect(computeMedicationCurrentStockRaw(options)).toBe(0.5);
-			expect(computeMedicationCurrentStock(options)).toBe(0);
-			expect(computeMedicationCurrentStockRaw({ ...options, asNeededStockEffectMilli: 9_000 })).toBe(0);
-		}
-	);
+	it.each([
+		"automatic",
+		"manual",
+	] as const)("subtracts exact active as-needed milli effects and retains scheduled-dose identity in %s mode", (stockCalculationMode) => {
+		const scheduledDose = dose({ doseId: buildDoseId(7, 0, new Date("2026-03-10T00:00:00.000Z").getTime()) });
+		const anchor = dose({ id: 2, doseId: "as-needed:2dfe2cca-1b2e-4a2c-9c31-d5aa9f5b0dce" });
+		const options = {
+			medication: medication({ packCount: 0, looseTablets: 3 }),
+			doses: [scheduledDose, anchor],
+			stockCalculationMode,
+			asNeededStockEffectMilli: 1500,
+			nowMs: new Date("2026-03-10T12:00:00.000Z").getTime(),
+		};
+		expect(computeMedicationCurrentStockRaw(options)).toBe(0.5);
+		expect(computeMedicationCurrentStock(options)).toBe(0);
+		expect(computeMedicationCurrentStockRaw({ ...options, asNeededStockEffectMilli: 9_000 })).toBe(0);
+	});
 });

--- a/backend/src/test/dose-tracking-service.test.ts
+++ b/backend/src/test/dose-tracking-service.test.ts
@@ -21,10 +21,29 @@ vi.mock("../db/client.js", () => ({
 const { dismissDosesForUser, markDoseTakenForUser } = await import("../services/dose-tracking-service.js");
 
 async function clearTables() {
+	await testClient.execute("DELETE FROM as_needed_intake_events");
 	await testClient.execute("DELETE FROM dose_tracking");
 	await testClient.execute("DELETE FROM medications");
 	await testClient.execute("DELETE FROM user_settings");
 	await testClient.execute("DELETE FROM users");
+}
+
+async function insertActiveAsNeededEffect(userId: number, medicationId: number, effectMilli: number) {
+	const anchor = await testClient.execute({
+		sql: "INSERT INTO dose_tracking (user_id, dose_id) VALUES (?, ?) RETURNING id",
+		args: [userId, `as-needed:service-guard-${medicationId}`],
+	});
+	await testClient.execute({
+		sql: "INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES (?, ?, ?, ?, 'key', 'fingerprint', 1, 1, ?, 'pills', ?)",
+		args: [
+			`service-guard-event-${medicationId}`,
+			userId,
+			medicationId,
+			Number(anchor.rows[0].id),
+			effectMilli,
+			effectMilli,
+		],
+	});
 }
 
 async function createUser(username: string) {
@@ -101,6 +120,16 @@ describe("dose-tracking-service", () => {
 		expect(rows.rows).toEqual([
 			expect.objectContaining({ dismissed: 0, taken_source: "notification", marked_by: null }),
 		]);
+	});
+
+	it("uses active owner as-needed effects in its stock guard", async () => {
+		const userId = await createUser("dose-service-as-needed");
+		await insertScheduledTestMedication(testClient, { id: 5, userId, packCount: 0, looseTablets: 1 });
+		await insertUserSettings(userId, "manual");
+		await insertActiveAsNeededEffect(userId, 5, 1000);
+		expect(
+			await markDoseTakenForUser({ userId, doseId: "5-0-1736064000000", source: "notification", markedBy: null })
+		).toEqual({ success: false, code: "OUT_OF_STOCK", message: "Medication is out of stock" });
 	});
 
 	it("is idempotent when the dose is already taken", async () => {

--- a/backend/src/test/doses.test.ts
+++ b/backend/src/test/doses.test.ts
@@ -41,6 +41,7 @@ const { doseRoutes } = await import("../routes/doses.js");
 
 async function clearTables() {
 	await testClient.execute("DELETE FROM intake_journal");
+	await testClient.execute("DELETE FROM as_needed_intake_events");
 	await testClient.execute("DELETE FROM dose_tracking");
 	await testClient.execute("DELETE FROM share_tokens");
 	await testClient.execute("DELETE FROM api_keys");
@@ -48,6 +49,24 @@ async function clearTables() {
 	await testClient.execute("DELETE FROM medications");
 	await testClient.execute("DELETE FROM user_settings");
 	await testClient.execute("DELETE FROM users");
+}
+
+async function insertActiveAsNeededEffect(userId: number, medicationId: number, effectMilli: number) {
+	const anchor = await testClient.execute({
+		sql: "INSERT INTO dose_tracking (user_id, dose_id) VALUES (?, ?) RETURNING id",
+		args: [userId, `as-needed:dose-guard-${medicationId}`],
+	});
+	await testClient.execute({
+		sql: "INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES (?, ?, ?, ?, 'key', 'fingerprint', 1, 1, ?, 'pills', ?)",
+		args: [
+			`dose-guard-event-${medicationId}`,
+			userId,
+			medicationId,
+			Number(anchor.rows[0].id),
+			effectMilli,
+			effectMilli,
+		],
+	});
 }
 
 async function createUser(username: string) {
@@ -324,6 +343,19 @@ describe("Dose Tracking API", () => {
 			});
 
 			expect(response.statusCode).toBe(409);
+			expect(response.json()).toEqual({ error: "Medication is out of stock", code: "OUT_OF_STOCK" });
+		});
+
+		it("rejects taking a scheduled dose when an active owner as-needed effect consumes the remaining stock", async () => {
+			await insertMedication({ id: 7, userId, packCount: 0, looseTablets: 1 });
+			await insertUserSettings(userId, "manual");
+			await insertActiveAsNeededEffect(userId, 7, 1000);
+			const response = await app.inject({
+				method: "POST",
+				url: "/doses/taken",
+				headers: { cookie: cookieHeader },
+				payload: { doseId: "7-0-1735344000000" },
+			});
 			expect(response.json()).toEqual({ error: "Medication is out of stock", code: "OUT_OF_STOCK" });
 		});
 

--- a/backend/src/test/intake-reminder-scheduler-actions.test.ts
+++ b/backend/src/test/intake-reminder-scheduler-actions.test.ts
@@ -8,6 +8,7 @@ const {
 	existsSyncMock,
 	readFileSyncMock,
 	writeFileSyncMock,
+	getActiveAsNeededStockEffectsMilliMock,
 } = vi.hoisted(() => ({
 	mockedEnv: {
 		PUBLIC_APP_URL: undefined as string | undefined,
@@ -19,6 +20,7 @@ const {
 	existsSyncMock: vi.fn(() => false),
 	readFileSyncMock: vi.fn(),
 	writeFileSyncMock: vi.fn(),
+	getActiveAsNeededStockEffectsMilliMock: vi.fn(async () => new Map<number, number>()),
 }));
 
 vi.mock("node:fs", () => ({
@@ -44,6 +46,10 @@ vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));
 vi.mock("../services/notification-actions-service.js", () => ({
 	createNotificationActionContext: createNotificationActionContextMock,
 	storeNotificationActionGroupNtfyMessageId: storeNotificationActionGroupNtfyMessageIdMock,
+}));
+
+vi.mock("../services/as-needed-intakes-service.js", () => ({
+	getActiveAsNeededStockEffectsMilli: getActiveAsNeededStockEffectsMilliMock,
 }));
 
 vi.mock("../services/notifications/delivery.js", () => ({

--- a/backend/src/test/intake-reminder-scheduler.test.ts
+++ b/backend/src/test/intake-reminder-scheduler.test.ts
@@ -2,11 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../db/client.js";
 import { checkAndSendIntakeRemindersForUser } from "../services/intake-reminder-scheduler.js";
 
+const { getActiveAsNeededStockEffectsMilliMock } = vi.hoisted(() => ({
+	getActiveAsNeededStockEffectsMilliMock: vi.fn(async () => new Map<number, number>()),
+}));
+
 vi.mock("../db/client.js", () => ({
 	db: {
 		select: vi.fn(),
 		insert: vi.fn(),
 	},
+}));
+
+vi.mock("../services/as-needed-intakes-service.js", () => ({
+	getActiveAsNeededStockEffectsMilli: getActiveAsNeededStockEffectsMilliMock,
 }));
 
 function createLogger() {
@@ -109,6 +117,8 @@ describe("checkAndSendIntakeRemindersForUser", () => {
 	let originalTz: string | undefined;
 
 	beforeEach(() => {
+		getActiveAsNeededStockEffectsMilliMock.mockReset();
+		getActiveAsNeededStockEffectsMilliMock.mockResolvedValue(new Map());
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(2026, 0, 5, 10, 30, 0));
 		originalTz = process.env.TZ;
@@ -141,6 +151,16 @@ describe("checkAndSendIntakeRemindersForUser", () => {
 			dismissed: false,
 		});
 		expect(logger.info).toHaveBeenCalledWith("[IntakeReminder] Auto-mark completed for userId=11: inserted=1");
+		expect(getActiveAsNeededStockEffectsMilliMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the active aggregate at the automatic reminder stock gate", async () => {
+		getActiveAsNeededStockEffectsMilliMock.mockResolvedValue(new Map([[7, 10_000]]));
+		const insertedRows = captureInsertedRows();
+		mockReminderQueries([createMedicationRow()]);
+		await runReminderCheck({}, createLogger());
+		expect(insertedRows).toHaveLength(0);
+		expect(getActiveAsNeededStockEffectsMilliMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not auto-mark due intakes when current stock is empty", async () => {

--- a/backend/src/test/planner-demand-service.test.ts
+++ b/backend/src/test/planner-demand-service.test.ts
@@ -157,4 +157,34 @@ describe("calculatePlannerDemandRows", () => {
 			loosePills: 118,
 		});
 	});
+
+	it.each(["automatic", "manual"] as const)(
+		"subtracts active owner effects from planner stock in %s mode",
+		async (stockCalculationMode) => {
+			await testClient.execute("INSERT INTO users (id, username) VALUES (1, 'planner-owner')");
+			await testClient.execute("INSERT INTO user_settings (user_id, stock_calculation_mode) VALUES (1, ?)", [
+				stockCalculationMode,
+			]);
+			await insertMedication({
+				id: 1,
+				userId: 1,
+				packCount: 0,
+				looseTablets: 3,
+				intakes: [{ usage: 1, every: 1, start: "2099-01-01T08:00:00.000Z" }],
+			});
+			await testClient.execute(
+				"INSERT INTO dose_tracking (id, user_id, dose_id) VALUES (1, 1, 'as-needed:planner-anchor')"
+			);
+			await testClient.execute(
+				"INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES ('planner-event', 1, 1, 1, 'key', 'fingerprint', 1, 1, 1500, 'pills', 1500)"
+			);
+			const [row] = await calculatePlannerDemandRows({
+				userId: 1,
+				startDate: fixedNow,
+				endDate: fixedNow,
+				now: fixedNow,
+			});
+			expect(row.currentPills).toBe(1);
+		}
+	);
 });

--- a/backend/src/test/planner-demand-service.test.ts
+++ b/backend/src/test/planner-demand-service.test.ts
@@ -158,33 +158,33 @@ describe("calculatePlannerDemandRows", () => {
 		});
 	});
 
-	it.each(["automatic", "manual"] as const)(
-		"subtracts active owner effects from planner stock in %s mode",
-		async (stockCalculationMode) => {
-			await testClient.execute("INSERT INTO users (id, username) VALUES (1, 'planner-owner')");
-			await testClient.execute("INSERT INTO user_settings (user_id, stock_calculation_mode) VALUES (1, ?)", [
-				stockCalculationMode,
-			]);
-			await insertMedication({
-				id: 1,
-				userId: 1,
-				packCount: 0,
-				looseTablets: 3,
-				intakes: [{ usage: 1, every: 1, start: "2099-01-01T08:00:00.000Z" }],
-			});
-			await testClient.execute(
-				"INSERT INTO dose_tracking (id, user_id, dose_id) VALUES (1, 1, 'as-needed:planner-anchor')"
-			);
-			await testClient.execute(
-				"INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES ('planner-event', 1, 1, 1, 'key', 'fingerprint', 1, 1, 1500, 'pills', 1500)"
-			);
-			const [row] = await calculatePlannerDemandRows({
-				userId: 1,
-				startDate: fixedNow,
-				endDate: fixedNow,
-				now: fixedNow,
-			});
-			expect(row.currentPills).toBe(1);
-		}
-	);
+	it.each([
+		"automatic",
+		"manual",
+	] as const)("subtracts active owner effects from planner stock in %s mode", async (stockCalculationMode) => {
+		await testClient.execute("INSERT INTO users (id, username) VALUES (1, 'planner-owner')");
+		await testClient.execute("INSERT INTO user_settings (user_id, stock_calculation_mode) VALUES (1, ?)", [
+			stockCalculationMode,
+		]);
+		await insertMedication({
+			id: 1,
+			userId: 1,
+			packCount: 0,
+			looseTablets: 3,
+			intakes: [{ usage: 1, every: 1, start: "2099-01-01T08:00:00.000Z" }],
+		});
+		await testClient.execute(
+			"INSERT INTO dose_tracking (id, user_id, dose_id) VALUES (1, 1, 'as-needed:planner-anchor')"
+		);
+		await testClient.execute(
+			"INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES ('planner-event', 1, 1, 1, 'key', 'fingerprint', 1, 1, 1500, 'pills', 1500)"
+		);
+		const [row] = await calculatePlannerDemandRows({
+			userId: 1,
+			startDate: fixedNow,
+			endDate: fixedNow,
+			now: fixedNow,
+		});
+		expect(row.currentPills).toBe(1);
+	});
 });

--- a/backend/src/test/routes-real.test.ts
+++ b/backend/src/test/routes-real.test.ts
@@ -61,11 +61,30 @@ const { reportRoutes } = await import("../routes/report.js");
 
 async function clearTables() {
 	await testClient.execute("DELETE FROM refill_history");
+	await testClient.execute("DELETE FROM as_needed_intake_events");
 	await testClient.execute("DELETE FROM dose_tracking");
 	await testClient.execute("DELETE FROM share_tokens");
 	await testClient.execute("DELETE FROM user_settings");
 	await testClient.execute("DELETE FROM medications");
 	await testClient.execute("DELETE FROM users");
+}
+
+async function insertActiveEffect(medicationId: number, effectMilli: number, userId = 1) {
+	const anchor = await testClient.execute({
+		sql: "INSERT INTO dose_tracking (user_id, dose_id) VALUES (?, ?) RETURNING id",
+		args: [userId, `as-needed:route-${medicationId}-${effectMilli}`],
+	});
+	await testClient.execute({
+		sql: "INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES (?, ?, ?, ?, 'key', 'fingerprint', 1, 1, ?, 'pills', ?)",
+		args: [
+			`route-event-${medicationId}-${effectMilli}`,
+			userId,
+			medicationId,
+			Number(anchor.rows[0].id),
+			effectMilli,
+			effectMilli,
+		],
+	});
 }
 
 async function seedAnonymousUser() {
@@ -263,6 +282,21 @@ describe("Real route coverage: settings/export/report", () => {
 				intakeRemindersEnabled: true,
 			})
 		);
+	});
+
+	it("GET /medications exposes only the owner's active aggregate effect", async () => {
+		const medicationId = await seedMedication("Aggregate med");
+		await insertActiveEffect(medicationId, 1500);
+		const otherOwner = await testClient.execute("INSERT INTO users (username) VALUES ('other') RETURNING id");
+		const otherId = Number(otherOwner.rows[0].id);
+		const otherMedication = await testClient.execute({
+			sql: "INSERT INTO medications (user_id, name) VALUES (?, 'other medication') RETURNING id",
+			args: [otherId],
+		});
+		await insertActiveEffect(Number(otherMedication.rows[0].id), 9000, otherId);
+		const response = await app.inject({ method: "GET", url: "/medications" });
+		expect(response.json()).toEqual([expect.objectContaining({ id: medicationId, asNeededStockEffect: 1.5 })]);
+		expect(JSON.stringify(response.json())).not.toContain("route-event");
 	});
 
 	it("PUT /settings disables repeatDailyReminders when no stock reminder channel exists", async () => {

--- a/backend/src/test/share-hardening.test.ts
+++ b/backend/src/test/share-hardening.test.ts
@@ -53,11 +53,23 @@ const { shareRoutes } = await import("../routes/share.js");
 
 async function clearTables() {
 	await testClient.execute("DELETE FROM intake_journal");
+	await testClient.execute("DELETE FROM as_needed_intake_events");
 	await testClient.execute("DELETE FROM dose_tracking");
 	await testClient.execute("DELETE FROM share_tokens");
 	await testClient.execute("DELETE FROM medications");
 	await testClient.execute("DELETE FROM user_settings");
 	await testClient.execute("DELETE FROM users");
+}
+
+async function insertActiveEffect(medicationId: number, effectMilli: number) {
+	const anchor = await testClient.execute({
+		sql: "INSERT INTO dose_tracking (user_id, dose_id) VALUES (1, ?) RETURNING id",
+		args: [`as-needed:share-${medicationId}`],
+	});
+	await testClient.execute({
+		sql: "INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES ('share-event', 1, ?, ?, 'key', 'fingerprint', 1, 1, ?, 'pills', ?)",
+		args: [medicationId, Number(anchor.rows[0].id), effectMilli, effectMilli],
+	});
 }
 
 async function createOwner() {
@@ -252,6 +264,18 @@ describe("share link hardening", () => {
 		expect(overview.language).toBe("en");
 		expect(JSON.stringify(overview)).not.toContain("Bob");
 		expect(overview.medications[0].daysLeft).toBe(2);
+	});
+
+	it("reduces shared overview stock by the aggregate without disclosing the event or anchor", async () => {
+		await testClient.execute("INSERT INTO user_settings (user_id, share_medication_overview) VALUES (1, 1)");
+		const medicationId = await insertMedication();
+		await insertActiveEffect(medicationId, 1500);
+		await insertShareToken({ token: "abcdef0123456789" });
+		const response = await app.inject({ method: "GET", url: "/share/abcdef0123456789/overview" });
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().medications[0].currentStock).toBe(8);
+		expect(JSON.stringify(response.json())).not.toContain("share-event");
+		expect(JSON.stringify(response.json())).not.toContain("as-needed:share");
 	});
 
 	it("does not write plaintext share tokens to logs", async () => {

--- a/backend/src/test/zero-schedule-concurrency.test.ts
+++ b/backend/src/test/zero-schedule-concurrency.test.ts
@@ -124,61 +124,61 @@ describe.sequential("zero-schedule production write serialization", () => {
 		rmSync(dataDir, { force: true, recursive: true });
 	});
 
-	it.each<StockMode>(["automatic", "manual"])(
-		"serializes simultaneous schedule boundary writes and preserves raw %s stock",
-		async (stockCalculationMode) => {
-			await db.delete(doseTracking);
-			await db.delete(medications);
-			await db.delete(userSettings);
-			await db.insert(userSettings).values({ userId, stockCalculationMode });
+	it.each<StockMode>([
+		"automatic",
+		"manual",
+	])("serializes simultaneous schedule boundary writes and preserves raw %s stock", async (stockCalculationMode) => {
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		await db.delete(userSettings);
+		await db.insert(userSettings).values({ userId, stockCalculationMode });
 
-			const start = scheduleStart();
-			const created = await app.inject({
-				method: "POST",
-				url: "/medications",
-				payload: medicationPayload([{ usage: 1, every: 1, start }]),
-			});
-			expect(created.statusCode).toBe(200);
-			const medicationId = created.json().id as number;
-			const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
-			await db.insert(doseTracking).values({
-				userId,
-				doseId: historicalDoseId,
-				takenAt: new Date(),
-				markedBy: "history",
-				takenSource: "manual",
-			});
+		const start = scheduleStart();
+		const created = await app.inject({
+			method: "POST",
+			url: "/medications",
+			payload: medicationPayload([{ usage: 1, every: 1, start }]),
+		});
+		expect(created.statusCode).toBe(200);
+		const medicationId = created.json().id as number;
+		const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
+		await db.insert(doseTracking).values({
+			userId,
+			doseId: historicalDoseId,
+			takenAt: new Date(),
+			markedBy: "history",
+			takenSource: "manual",
+		});
 
-			const [beforeMedication] = await db.select().from(medications);
-			const beforeDoses = await db.select().from(doseTracking);
-			const expectedRawStock = computeMedicationCurrentStockRaw({
-				medication: beforeMedication,
-				doses: beforeDoses,
-				stockCalculationMode,
-			});
+		const [beforeMedication] = await db.select().from(medications);
+		const beforeDoses = await db.select().from(doseTracking);
+		const expectedRawStock = computeMedicationCurrentStockRaw({
+			medication: beforeMedication,
+			doses: beforeDoses,
+			stockCalculationMode,
+		});
 
-			const [toUnscheduled, toScheduled] = await Promise.all([
-				app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
-				app.inject({
-					method: "PUT",
-					url: `/medications/${medicationId}`,
-					payload: medicationPayload([{ usage: 2, every: 1, start }]),
-				}),
-			]);
+		const [toUnscheduled, toScheduled] = await Promise.all([
+			app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
+			app.inject({
+				method: "PUT",
+				url: `/medications/${medicationId}`,
+				payload: medicationPayload([{ usage: 2, every: 1, start }]),
+			}),
+		]);
 
-			expect(toUnscheduled.statusCode).toBe(200);
-			expect(toScheduled.statusCode).toBe(200);
-			const [persisted] = await db.select().from(medications);
-			const persistedDoses = await db.select().from(doseTracking);
-			expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
-			expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
-			expect(
-				computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
-			).toBe(expectedRawStock);
-			expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
-			expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
-		}
-	);
+		expect(toUnscheduled.statusCode).toBe(200);
+		expect(toScheduled.statusCode).toBe(200);
+		const [persisted] = await db.select().from(medications);
+		const persistedDoses = await db.select().from(doseTracking);
+		expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
+		expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
+		expect(
+			computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
+		).toBe(expectedRawStock);
+		expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
+		expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
+	});
 
 	it("returns the original bounded SQLITE_BUSY from an independent writer and releases the FIFO queue", async () => {
 		const databaseUrl = `file:${resolve(dataDir, "medassist-ng.db")}`;

--- a/backend/src/test/zero-schedule-concurrency.test.ts
+++ b/backend/src/test/zero-schedule-concurrency.test.ts
@@ -39,7 +39,7 @@ const [
 ]);
 
 const { db, migrationsReady, withImmediateWriteTransaction } = dbClient;
-const { doseTracking, medications, userSettings } = schema;
+const { asNeededIntakeEvents, doseTracking, medications, userSettings } = schema;
 const { getAnonymousUserId } = auth;
 const { medicationRoutes } = medicationRoutesModule;
 const { computeMedicationCurrentStockRaw } = stock;
@@ -124,61 +124,61 @@ describe.sequential("zero-schedule production write serialization", () => {
 		rmSync(dataDir, { force: true, recursive: true });
 	});
 
-	it.each<StockMode>([
-		"automatic",
-		"manual",
-	])("serializes simultaneous schedule boundary writes and preserves raw %s stock", async (stockCalculationMode) => {
-		await db.delete(doseTracking);
-		await db.delete(medications);
-		await db.delete(userSettings);
-		await db.insert(userSettings).values({ userId, stockCalculationMode });
+	it.each<StockMode>(["automatic", "manual"])(
+		"serializes simultaneous schedule boundary writes and preserves raw %s stock",
+		async (stockCalculationMode) => {
+			await db.delete(doseTracking);
+			await db.delete(medications);
+			await db.delete(userSettings);
+			await db.insert(userSettings).values({ userId, stockCalculationMode });
 
-		const start = scheduleStart();
-		const created = await app.inject({
-			method: "POST",
-			url: "/medications",
-			payload: medicationPayload([{ usage: 1, every: 1, start }]),
-		});
-		expect(created.statusCode).toBe(200);
-		const medicationId = created.json().id as number;
-		const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
-		await db.insert(doseTracking).values({
-			userId,
-			doseId: historicalDoseId,
-			takenAt: new Date(),
-			markedBy: "history",
-			takenSource: "manual",
-		});
+			const start = scheduleStart();
+			const created = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: medicationPayload([{ usage: 1, every: 1, start }]),
+			});
+			expect(created.statusCode).toBe(200);
+			const medicationId = created.json().id as number;
+			const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
+			await db.insert(doseTracking).values({
+				userId,
+				doseId: historicalDoseId,
+				takenAt: new Date(),
+				markedBy: "history",
+				takenSource: "manual",
+			});
 
-		const [beforeMedication] = await db.select().from(medications);
-		const beforeDoses = await db.select().from(doseTracking);
-		const expectedRawStock = computeMedicationCurrentStockRaw({
-			medication: beforeMedication,
-			doses: beforeDoses,
-			stockCalculationMode,
-		});
+			const [beforeMedication] = await db.select().from(medications);
+			const beforeDoses = await db.select().from(doseTracking);
+			const expectedRawStock = computeMedicationCurrentStockRaw({
+				medication: beforeMedication,
+				doses: beforeDoses,
+				stockCalculationMode,
+			});
 
-		const [toUnscheduled, toScheduled] = await Promise.all([
-			app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
-			app.inject({
-				method: "PUT",
-				url: `/medications/${medicationId}`,
-				payload: medicationPayload([{ usage: 2, every: 1, start }]),
-			}),
-		]);
+			const [toUnscheduled, toScheduled] = await Promise.all([
+				app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
+				app.inject({
+					method: "PUT",
+					url: `/medications/${medicationId}`,
+					payload: medicationPayload([{ usage: 2, every: 1, start }]),
+				}),
+			]);
 
-		expect(toUnscheduled.statusCode).toBe(200);
-		expect(toScheduled.statusCode).toBe(200);
-		const [persisted] = await db.select().from(medications);
-		const persistedDoses = await db.select().from(doseTracking);
-		expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
-		expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
-		expect(
-			computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
-		).toBe(expectedRawStock);
-		expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
-		expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
-	});
+			expect(toUnscheduled.statusCode).toBe(200);
+			expect(toScheduled.statusCode).toBe(200);
+			const [persisted] = await db.select().from(medications);
+			const persistedDoses = await db.select().from(doseTracking);
+			expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
+			expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
+			expect(
+				computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
+			).toBe(expectedRawStock);
+			expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
+			expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
+		}
+	);
 
 	it("returns the original bounded SQLITE_BUSY from an independent writer and releases the FIFO queue", async () => {
 		const databaseUrl = `file:${resolve(dataDir, "medassist-ng.db")}`;
@@ -227,5 +227,58 @@ process.stdin.once("data", async () => {
 				return "queued writer completed";
 			})
 		).resolves.toBe("queued writer completed");
+	});
+
+	it("preserves the aggregate-reduced raw stock across both zero-schedule boundaries", async () => {
+		await db.delete(asNeededIntakeEvents);
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		const created = await app.inject({
+			method: "POST",
+			url: "/medications",
+			payload: medicationPayload([{ usage: 1, every: 1, start: scheduleStart() }]),
+		});
+		const medicationId = created.json().id as number;
+		const [anchor] = await db
+			.insert(doseTracking)
+			.values({ userId, doseId: "as-needed:rebase-effect" })
+			.returning({ id: doseTracking.id });
+		await db.insert(asNeededIntakeEvents).values({
+			eventId: "rebase-effect",
+			userId,
+			medicationId,
+			doseTrackingId: anchor.id,
+			idempotencyKeyHash: "key",
+			requestFingerprint: "fingerprint",
+			occurredAt: new Date(),
+			recordedAt: new Date(),
+			quantityMilli: 1500,
+			quantityUnit: "pills",
+			stockEffectMilli: 1500,
+		});
+		const before = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
+		const raw = computeMedicationCurrentStockRaw({
+			medication: before[0],
+			doses: await db.select().from(doseTracking),
+			stockCalculationMode: "manual",
+			asNeededStockEffectMilli: 1500,
+		});
+		for (const intakes of [[], [{ usage: 2, every: 1, start: scheduleStart() }]]) {
+			const response = await app.inject({
+				method: "PUT",
+				url: `/medications/${medicationId}`,
+				payload: medicationPayload(intakes),
+			});
+			expect(response.statusCode).toBe(200);
+			const [persisted] = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
+			expect(
+				computeMedicationCurrentStockRaw({
+					medication: persisted,
+					doses: await db.select().from(doseTracking),
+					stockCalculationMode: "manual",
+					asNeededStockEffectMilli: 1500,
+				})
+			).toBe(raw);
+		}
 	});
 });


### PR DESCRIPTION
Closes #1023

## Summary

- apply the owner- and medication-scoped aggregate of active as-needed effects after scheduled stock projections
- expose the aggregate through medication, dose, planner, reminder, coverage, and share projections without disclosing event or anchor details
- preserve active-only, zero/reversed-event, public-floor, and zero-schedule semantics

## Scope boundary

Backend-only Slice 3B. No event routes, schema changes, frontend work, cutoff/refill changes, or event-detail disclosure. Depends on merged #1014 and unlocks #1022.

## Validation

- focused backend coverage: 8 files, 69 tests
- full backend suite: 47 files, 914 tests
- direct medication/share/rebase follow-up route and share coverage: 52 tests
- zero-schedule concurrency: 4 tests
- backend check and diff check; root lint, check, and build passed before the test-only follow-up