### PR TITLE
feat: isolate as-needed anchors during physical stock edits

### DIFF
--- a/backend/src/routes/medications.ts
+++ b/backend/src/routes/medications.ts
@@ -8,8 +8,10 @@ import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { getAnonymousUserId, isReadOnlyApiKeyRequest, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
 import {
+	deleteAsNeededAnchorsForMedication,
 	getActiveAsNeededStockEffectMilli,
 	getActiveAsNeededStockEffectsMilli,
+	neutralizeAsNeededStockEffects,
 } from "../services/as-needed-intakes-service.js";
 import { computeMedicationCurrentStockRaw } from "../services/current-stock.js";
 import { normalizeDateTime, parseIntakesWithUnits } from "../services/medications-service.js";
@@ -926,6 +928,9 @@ export async function medicationRoutes(app: FastifyInstance) {
 					.returning();
 
 				if (!updated) return null;
+				if (stockFieldsChanged) {
+					await neutralizeAsNeededStockEffects(transactionDb, userId, idNum, changedAt);
+				}
 				if (!crossesZeroScheduleBoundary || stockFieldsChanged) {
 					return { medication: updated, oldIntakes, hasScheduleOnBothSides };
 				}
@@ -1232,13 +1237,6 @@ export async function medicationRoutes(app: FastifyInstance) {
 
 			const userId = await getUserId(req, reply);
 
-			// Verify ownership
-			const [existing] = await db
-				.select()
-				.from(medications)
-				.where(and(eq(medications.id, idNum), eq(medications.userId, userId)));
-			if (!existing) return reply.notFound();
-
 			const { stockAdjustment, looseTablets, totalPills, packageAmountValue, packCount } = req.body as {
 				stockAdjustment: number;
 				looseTablets?: number;
@@ -1269,57 +1267,69 @@ export async function medicationRoutes(app: FastifyInstance) {
 				return reply.badRequest("packCount must be a non-negative integer");
 			}
 
-			const updateFields: {
-				stockAdjustment: number;
-				scheduleStockRebaseMilli: number;
-				lastStockCorrectionAt: Date;
-				updatedAt: Date;
-				looseTablets?: number;
-				totalPills?: number | null;
-				packageAmountValue?: number;
-				packCount?: number;
-			} = {
-				stockAdjustment,
-				scheduleStockRebaseMilli: 0,
-				lastStockCorrectionAt: new Date(),
-				updatedAt: new Date(),
-			};
+			const corrected = await withImmediateWriteTransaction(async (transactionDb) => {
+				const correctionAt = new Date();
+				const [existing] = await transactionDb
+					.select()
+					.from(medications)
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)));
+				if (!existing) return null;
 
-			const packageType = normalizePackageType(existing.packageType);
-			const allowsAmountBaseUpdate = isTubePackageType(packageType) || isLiquidContainerPackageType(packageType);
-			const allowsDiscreteCapacityUpdate = isDiscreteCountPackageType(packageType);
-			if (allowsAmountBaseUpdate) {
-				const normalizedAmountBase = looseTablets ?? totalPills;
-				if (normalizedAmountBase !== undefined) {
-					updateFields.totalPills = normalizedAmountBase;
-					updateFields.looseTablets = normalizedAmountBase;
+				const updateFields: {
+					stockAdjustment: number;
+					scheduleStockRebaseMilli: number;
+					lastStockCorrectionAt: Date;
+					updatedAt: Date;
+					looseTablets?: number;
+					totalPills?: number | null;
+					packageAmountValue?: number;
+					packCount?: number;
+				} = {
+					stockAdjustment,
+					scheduleStockRebaseMilli: 0,
+					lastStockCorrectionAt: correctionAt,
+					updatedAt: correctionAt,
+				};
+
+				const packageType = normalizePackageType(existing.packageType);
+				const allowsAmountBaseUpdate = isTubePackageType(packageType) || isLiquidContainerPackageType(packageType);
+				const allowsDiscreteCapacityUpdate = isDiscreteCountPackageType(packageType);
+				if (allowsAmountBaseUpdate) {
+					const normalizedAmountBase = looseTablets ?? totalPills;
+					if (normalizedAmountBase !== undefined) {
+						updateFields.totalPills = normalizedAmountBase;
+						updateFields.looseTablets = normalizedAmountBase;
+					}
+					if (packageAmountValue !== undefined && packageAmountValue > 0) {
+						updateFields.packageAmountValue = packageAmountValue;
+					}
 				}
-				if (packageAmountValue !== undefined && packageAmountValue > 0) {
-					updateFields.packageAmountValue = packageAmountValue;
+				if (allowsDiscreteCapacityUpdate && totalPills !== undefined && totalPills > 0) {
+					updateFields.totalPills = totalPills;
 				}
-			}
-			if (allowsDiscreteCapacityUpdate && totalPills !== undefined && totalPills > 0) {
-				updateFields.totalPills = totalPills;
-			}
-			if (packCount !== undefined) updateFields.packCount = packCount;
-			if (!allowsAmountBaseUpdate && looseTablets !== undefined) {
-				updateFields.looseTablets = looseTablets;
-			}
+				if (packCount !== undefined) updateFields.packCount = packCount;
+				if (!allowsAmountBaseUpdate && looseTablets !== undefined) {
+					updateFields.looseTablets = looseTablets;
+				}
 
-			const result = await db
-				.update(medications)
-				.set(updateFields)
-				.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
-				.returning();
+				const [result] = await transactionDb
+					.update(medications)
+					.set(updateFields)
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
+					.returning();
+				if (!result) return null;
+				await neutralizeAsNeededStockEffects(transactionDb, userId, idNum, correctionAt);
+				return result;
+			});
 
-			if (!result.length) return reply.notFound();
+			if (!corrected) return reply.notFound();
 
 			return {
-				id: result[0].id,
-				stockAdjustment: result[0].stockAdjustment ?? 0,
-				scheduleStockRebaseMilli: result[0].scheduleStockRebaseMilli ?? 0,
-				lastStockCorrectionAt: result[0].lastStockCorrectionAt?.toISOString() ?? null,
-				updatedAt: normalizeDateTime(result[0].updatedAt),
+				id: corrected.id,
+				stockAdjustment: corrected.stockAdjustment ?? 0,
+				scheduleStockRebaseMilli: corrected.scheduleStockRebaseMilli ?? 0,
+				lastStockCorrectionAt: corrected.lastStockCorrectionAt?.toISOString() ?? null,
+				updatedAt: normalizeDateTime(corrected.updatedAt),
 			};
 		}
 	);
@@ -1343,20 +1353,21 @@ export async function medicationRoutes(app: FastifyInstance) {
 
 			const userId = await getUserId(req, reply);
 
-			// Delete associated image if exists (with ownership check)
-			const [existing] = await db
-				.select()
-				.from(medications)
-				.where(and(eq(medications.id, idNum), eq(medications.userId, userId)));
-			if (!existing) return reply.notFound();
-
-			if (existing.imageUrl) removeImageFiles(IMAGES_DIR, existing.imageUrl);
-
-			const deleted = await db
-				.delete(medications)
-				.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
-				.returning();
-			if (!deleted.length) return reply.notFound();
+			const deleted = await withImmediateWriteTransaction(async (transactionDb) => {
+				const [current] = await transactionDb
+					.select()
+					.from(medications)
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)));
+				if (!current) return null;
+				await deleteAsNeededAnchorsForMedication(transactionDb, userId, idNum);
+				const [removed] = await transactionDb
+					.delete(medications)
+					.where(and(eq(medications.id, idNum), eq(medications.userId, userId)))
+					.returning();
+				return removed ? current : null;
+			});
+			if (!deleted) return reply.notFound();
+			if (deleted.imageUrl) removeImageFiles(IMAGES_DIR, deleted.imageUrl);
 			return reply.status(204).send();
 		}
 	);

--- a/backend/src/routes/refills.ts
+++ b/backend/src/routes/refills.ts
@@ -1,10 +1,14 @@
 import { and, desc, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { db } from "../db/client.js";
+import { db, withImmediateWriteTransaction } from "../db/client.js";
 import { medications, refillHistory } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import {
+	getActiveAsNeededStockEffectMilli,
+	neutralizeAsNeededStockEffects,
+} from "../services/as-needed-intakes-service.js";
 import type { AuthUser } from "../types/fastify.js";
 import {
 	applyOpenApiRouteStandards,
@@ -153,16 +157,6 @@ export async function refillRoutes(app: FastifyInstance) {
 			const isPackageAmountPackage = isPackageAmountPackageType(packageType);
 			const pillsPerPack = isDiscreteCountPackage ? 0 : med.blistersPerPack * med.pillsPerBlister;
 
-			const configuredAmountPerPackage = Number(med.packageAmountValue ?? 0);
-			const fallbackAmountPerPackage = Math.max(
-				1,
-				Math.round((med.totalPills ?? med.looseTablets ?? 0) / Math.max(1, med.packCount || 1))
-			);
-			const amountPerPackage =
-				Number.isFinite(configuredAmountPerPackage) && configuredAmountPerPackage > 0
-					? configuredAmountPerPackage
-					: fallbackAmountPerPackage;
-
 			const requestedPackAdds = Math.max(0, packsAdded);
 			const requestedLooseAdds = Math.max(0, loosePillsAdded);
 			const requestedQuantityAdds = Math.max(0, quantityAdded > 0 ? quantityAdded : requestedLooseAdds);
@@ -192,33 +186,6 @@ export async function refillRoutes(app: FastifyInstance) {
 				}
 			}
 
-			const refillBaselineAt = new Date();
-			const baselineStockBeforeRefill = isAmountBased
-				? med.looseTablets + (med.stockAdjustment ?? 0)
-				: med.packCount * pillsPerPack + med.looseTablets + (med.stockAdjustment ?? 0);
-			const targetCurrentStock = baselineStockBeforeRefill + totalPillsAdded;
-
-			// Update medication stock. Refill establishes a new persisted stock baseline and resets
-			// `lastStockCorrectionAt` so pre-refill dose history is ignored for future stock math.
-			let newPackCount = med.packCount + effectivePacksAdded;
-			let newLooseTablets = med.looseTablets + effectiveLoosePillsAdded;
-			let newStockAdjustment = med.stockAdjustment ?? 0;
-			let newTotalAmount = med.totalPills ?? med.looseTablets;
-
-			if (isDiscreteCountPackage) {
-				newLooseTablets = targetCurrentStock;
-				newTotalAmount = Math.max(newTotalAmount, targetCurrentStock);
-				newStockAdjustment = 0;
-			} else if (isPackageAmountPackage) {
-				newPackCount = Math.max(1, Math.ceil(targetCurrentStock / amountPerPackage));
-				newLooseTablets = targetCurrentStock;
-				newTotalAmount = targetCurrentStock;
-				newStockAdjustment = 0;
-			} else {
-				const structuralBaseAfterRefill = newPackCount * pillsPerPack + newLooseTablets;
-				newStockAdjustment = targetCurrentStock - structuralBaseAfterRefill;
-			}
-
 			let consumedRefills = 0;
 			if (usePrescription) {
 				consumedRefills = isDiscreteCountPackage ? 1 : effectivePacksAdded;
@@ -227,45 +194,91 @@ export async function refillRoutes(app: FastifyInstance) {
 				? Math.max(0, remainingPrescriptionRefills - consumedRefills)
 				: (med.prescriptionRemainingRefills ?? null);
 
-			const updatePayload: {
-				packCount: number;
-				looseTablets: number;
-				stockAdjustment: number;
-				totalPills?: number;
-				packageAmountValue?: number;
-				prescriptionRemainingRefills: number | null;
-				lastStockCorrectionAt: Date;
-				updatedAt: Date;
-			} = {
-				packCount: newPackCount,
-				looseTablets: newLooseTablets,
-				stockAdjustment: newStockAdjustment,
-				prescriptionRemainingRefills: newRemainingRefills,
-				lastStockCorrectionAt: refillBaselineAt,
-				updatedAt: refillBaselineAt,
-			};
+			const mutation = await withImmediateWriteTransaction(async (transactionDb) => {
+				const [current] = await transactionDb
+					.select()
+					.from(medications)
+					.where(and(eq(medications.id, medId), eq(medications.userId, userId)));
+				if (!current) return null;
+				const refillInputsChanged =
+					normalizePackageType(current.packageType) !== packageType ||
+					current.blistersPerPack !== med.blistersPerPack ||
+					current.pillsPerBlister !== med.pillsPerBlister ||
+					current.prescriptionEnabled !== med.prescriptionEnabled ||
+					current.prescriptionRemainingRefills !== med.prescriptionRemainingRefills;
+				if (refillInputsChanged) return "conflict" as const;
 
-			if (isPackageAmountPackage) {
-				updatePayload.totalPills = newTotalAmount;
-				updatePayload.packageAmountValue = amountPerPackage;
+				const refillBaselineAt = new Date();
+				const activeEffectMilli = await getActiveAsNeededStockEffectMilli(transactionDb, userId, medId);
+				const structuralStock = isAmountBased
+					? current.looseTablets + (current.stockAdjustment ?? 0)
+					: current.packCount * pillsPerPack + current.looseTablets + (current.stockAdjustment ?? 0);
+				const targetCurrentStock =
+					structuralStock + (current.scheduleStockRebaseMilli ?? 0) / 1000 - activeEffectMilli / 1000 + totalPillsAdded;
+				const targetMilli = Math.round(targetCurrentStock * 1000);
+				if (!Number.isSafeInteger(targetMilli)) return "unresolvable" as const;
+				const targetWhole = Math.trunc(targetMilli / 1000);
+				const rebaseMilli = targetMilli - targetWhole * 1000;
+				const configuredAmountPerPackage = Number(current.packageAmountValue ?? 0);
+				const fallbackAmountPerPackage = Math.max(
+					1,
+					Math.round((current.totalPills ?? current.looseTablets ?? 0) / Math.max(1, current.packCount || 1))
+				);
+				const amountPerPackage =
+					Number.isFinite(configuredAmountPerPackage) && configuredAmountPerPackage > 0
+						? configuredAmountPerPackage
+						: fallbackAmountPerPackage;
+
+				let newPackCount = current.packCount + effectivePacksAdded;
+				let newLooseTablets = current.looseTablets + effectiveLoosePillsAdded;
+				let newStockAdjustment = current.stockAdjustment ?? 0;
+				let newTotalAmount = current.totalPills ?? current.looseTablets;
+				if (isDiscreteCountPackage) {
+					newLooseTablets = targetWhole;
+					newTotalAmount = Math.max(newTotalAmount, targetWhole);
+					newStockAdjustment = 0;
+				} else if (isPackageAmountPackage) {
+					newPackCount = Math.max(1, Math.ceil(targetWhole / amountPerPackage));
+					newLooseTablets = targetWhole;
+					newTotalAmount = targetWhole;
+					newStockAdjustment = 0;
+				} else {
+					newStockAdjustment = targetWhole - (newPackCount * pillsPerPack + newLooseTablets);
+				}
+
+				await transactionDb
+					.update(medications)
+					.set({
+						packCount: newPackCount,
+						looseTablets: newLooseTablets,
+						stockAdjustment: newStockAdjustment,
+						scheduleStockRebaseMilli: rebaseMilli,
+						totalPills: isPackageAmountPackage ? newTotalAmount : current.totalPills,
+						packageAmountValue: isPackageAmountPackage ? amountPerPackage : current.packageAmountValue,
+						prescriptionRemainingRefills: newRemainingRefills,
+						lastStockCorrectionAt: refillBaselineAt,
+						updatedAt: refillBaselineAt,
+					})
+					.where(and(eq(medications.id, medId), eq(medications.userId, userId)));
+				await neutralizeAsNeededStockEffects(transactionDb, userId, medId, refillBaselineAt);
+				const [refill] = await transactionDb
+					.insert(refillHistory)
+					.values({
+						medicationId: medId,
+						userId,
+						packsAdded: effectivePacksAdded,
+						loosePillsAdded: effectiveLoosePillsAdded,
+						usedPrescription: usePrescription,
+					})
+					.returning();
+				return { refill, targetCurrentStock, newPackCount, newLooseTablets };
+			});
+			if (!mutation) return reply.notFound("Medication not found");
+			if (mutation === "conflict") return reply.status(409).send({ error: "Medication changed; retry refill" });
+			if (mutation === "unresolvable") {
+				return reply.status(409).send({ error: "Current stock cannot be resolved safely" });
 			}
-
-			await db
-				.update(medications)
-				.set(updatePayload)
-				.where(and(eq(medications.id, medId), eq(medications.userId, userId)));
-
-			// Create refill history entry
-			const [refill] = await db
-				.insert(refillHistory)
-				.values({
-					medicationId: medId,
-					userId,
-					packsAdded: effectivePacksAdded,
-					loosePillsAdded: effectiveLoosePillsAdded,
-					usedPrescription: usePrescription,
-				})
-				.returning();
+			const { refill, targetCurrentStock, newPackCount, newLooseTablets } = mutation;
 
 			return {
 				success: true,

--- a/backend/src/services/as-needed-intakes-service.ts
+++ b/backend/src/services/as-needed-intakes-service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { getAsNeededQuantityProfile, normalizeAsNeededQuantityMilli } from "@medassist/shared";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, lte, sql } from "drizzle-orm";
 import { type db, withImmediateWriteTransaction } from "../db/client.js";
 import { asNeededIntakeEvents, doseTracking, medications, userSettings } from "../db/schema.js";
 import { normalizeMedicationSchedule } from "../utils/scheduler-utils.js";
@@ -116,6 +116,53 @@ export async function getActiveAsNeededStockEffectsMilli(
 		)
 		.groupBy(asNeededIntakeEvents.medicationId);
 	return new Map(rows.map((row) => [row.medicationId, Number(row.total ?? 0)]));
+}
+
+export async function neutralizeAsNeededStockEffects(
+	database: Database,
+	userId: number,
+	medicationId: number,
+	cutoff: Date
+): Promise<void> {
+	await database
+		.update(asNeededIntakeEvents)
+		.set({
+			stockEffectMilli: 0,
+			stockEffectReason: "superseded_by_correction",
+			stockCutoffAt: Math.floor(cutoff.getTime() / 1000),
+			revision: sql`${asNeededIntakeEvents.revision} + 1`,
+			updatedAt: cutoff,
+		})
+		.where(
+			and(
+				eq(asNeededIntakeEvents.userId, userId),
+				eq(asNeededIntakeEvents.medicationId, medicationId),
+				eq(asNeededIntakeEvents.status, "active"),
+				gt(asNeededIntakeEvents.stockEffectMilli, 0),
+				lte(asNeededIntakeEvents.occurredAt, cutoff)
+			)
+		);
+}
+
+export async function deleteAsNeededAnchorsForMedication(
+	database: Database,
+	userId: number,
+	medicationId: number
+): Promise<void> {
+	const anchors = await database
+		.select({ doseTrackingId: asNeededIntakeEvents.doseTrackingId })
+		.from(asNeededIntakeEvents)
+		.where(and(eq(asNeededIntakeEvents.userId, userId), eq(asNeededIntakeEvents.medicationId, medicationId)));
+	if (anchors.length === 0) return;
+	await database.delete(doseTracking).where(
+		and(
+			eq(doseTracking.userId, userId),
+			inArray(
+				doseTracking.id,
+				anchors.map((anchor) => anchor.doseTrackingId)
+			)
+		)
+	);
 }
 
 export async function createAsNeededIntake(input: {

--- a/backend/src/test/business-authz-real.test.ts
+++ b/backend/src/test/business-authz-real.test.ts
@@ -34,6 +34,8 @@ const { testClient, testDb, mockedEnv } = vi.hoisted(() => {
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>): Promise<T> =>
+		operation(testDb),
 }));
 
 vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));

--- a/backend/src/test/zero-schedule-concurrency.test.ts
+++ b/backend/src/test/zero-schedule-concurrency.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -25,7 +25,9 @@ const [
 	schema,
 	auth,
 	medicationRoutesModule,
+	refillRoutesModule,
 	stock,
+	asNeededService,
 ] = await Promise.all([
 	import("fastify"),
 	import("@fastify/sensible"),
@@ -35,14 +37,18 @@ const [
 	import("../db/schema.js"),
 	import("../plugins/auth.js"),
 	import("../routes/medications.js"),
+	import("../routes/refills.js"),
 	import("../services/current-stock.js"),
+	import("../services/as-needed-intakes-service.js"),
 ]);
 
 const { db, migrationsReady, withImmediateWriteTransaction } = dbClient;
-const { asNeededIntakeEvents, doseTracking, medications, userSettings } = schema;
+const { asNeededIntakeEvents, doseTracking, medications, userSettings, users } = schema;
 const { getAnonymousUserId } = auth;
 const { medicationRoutes } = medicationRoutesModule;
+const { refillRoutes } = refillRoutesModule;
 const { computeMedicationCurrentStockRaw } = stock;
+const { createAsNeededIntake, reverseAsNeededIntake } = asNeededService;
 
 type StockMode = "automatic" | "manual";
 
@@ -83,6 +89,13 @@ function medicationPayload(intakes: Array<{ usage: number; every: number; start:
 	};
 }
 
+let idempotencySequence = 0;
+
+function idempotencyKey(): string {
+	idempotencySequence += 1;
+	return `00000000-0000-4000-8000-${idempotencySequence.toString().padStart(12, "0")}`;
+}
+
 async function waitForChildLine(child: ReturnType<typeof spawn>, expected: string): Promise<void> {
 	let received = "";
 	await Promise.race([
@@ -115,6 +128,7 @@ describe.sequential("zero-schedule production write serialization", () => {
 		app = Fastify({ logger: false, ajv: documentationSchemaAjv });
 		await app.register(sensible);
 		await app.register(medicationRoutes);
+		await app.register(refillRoutes);
 		await app.ready();
 		userId = await getAnonymousUserId();
 	});
@@ -124,61 +138,61 @@ describe.sequential("zero-schedule production write serialization", () => {
 		rmSync(dataDir, { force: true, recursive: true });
 	});
 
-	it.each<StockMode>([
-		"automatic",
-		"manual",
-	])("serializes simultaneous schedule boundary writes and preserves raw %s stock", async (stockCalculationMode) => {
-		await db.delete(doseTracking);
-		await db.delete(medications);
-		await db.delete(userSettings);
-		await db.insert(userSettings).values({ userId, stockCalculationMode });
+	it.each<StockMode>(["automatic", "manual"])(
+		"serializes simultaneous schedule boundary writes and preserves raw %s stock",
+		async (stockCalculationMode) => {
+			await db.delete(doseTracking);
+			await db.delete(medications);
+			await db.delete(userSettings);
+			await db.insert(userSettings).values({ userId, stockCalculationMode });
 
-		const start = scheduleStart();
-		const created = await app.inject({
-			method: "POST",
-			url: "/medications",
-			payload: medicationPayload([{ usage: 1, every: 1, start }]),
-		});
-		expect(created.statusCode).toBe(200);
-		const medicationId = created.json().id as number;
-		const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
-		await db.insert(doseTracking).values({
-			userId,
-			doseId: historicalDoseId,
-			takenAt: new Date(),
-			markedBy: "history",
-			takenSource: "manual",
-		});
+			const start = scheduleStart();
+			const created = await app.inject({
+				method: "POST",
+				url: "/medications",
+				payload: medicationPayload([{ usage: 1, every: 1, start }]),
+			});
+			expect(created.statusCode).toBe(200);
+			const medicationId = created.json().id as number;
+			const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
+			await db.insert(doseTracking).values({
+				userId,
+				doseId: historicalDoseId,
+				takenAt: new Date(),
+				markedBy: "history",
+				takenSource: "manual",
+			});
 
-		const [beforeMedication] = await db.select().from(medications);
-		const beforeDoses = await db.select().from(doseTracking);
-		const expectedRawStock = computeMedicationCurrentStockRaw({
-			medication: beforeMedication,
-			doses: beforeDoses,
-			stockCalculationMode,
-		});
+			const [beforeMedication] = await db.select().from(medications);
+			const beforeDoses = await db.select().from(doseTracking);
+			const expectedRawStock = computeMedicationCurrentStockRaw({
+				medication: beforeMedication,
+				doses: beforeDoses,
+				stockCalculationMode,
+			});
 
-		const [toUnscheduled, toScheduled] = await Promise.all([
-			app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
-			app.inject({
-				method: "PUT",
-				url: `/medications/${medicationId}`,
-				payload: medicationPayload([{ usage: 2, every: 1, start }]),
-			}),
-		]);
+			const [toUnscheduled, toScheduled] = await Promise.all([
+				app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
+				app.inject({
+					method: "PUT",
+					url: `/medications/${medicationId}`,
+					payload: medicationPayload([{ usage: 2, every: 1, start }]),
+				}),
+			]);
 
-		expect(toUnscheduled.statusCode).toBe(200);
-		expect(toScheduled.statusCode).toBe(200);
-		const [persisted] = await db.select().from(medications);
-		const persistedDoses = await db.select().from(doseTracking);
-		expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
-		expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
-		expect(
-			computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
-		).toBe(expectedRawStock);
-		expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
-		expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
-	});
+			expect(toUnscheduled.statusCode).toBe(200);
+			expect(toScheduled.statusCode).toBe(200);
+			const [persisted] = await db.select().from(medications);
+			const persistedDoses = await db.select().from(doseTracking);
+			expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
+			expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
+			expect(
+				computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
+			).toBe(expectedRawStock);
+			expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
+			expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
+		}
+	);
 
 	it("returns the original bounded SQLITE_BUSY from an independent writer and releases the FIFO queue", async () => {
 		const databaseUrl = `file:${resolve(dataDir, "medassist-ng.db")}`;
@@ -256,6 +270,7 @@ process.stdin.once("data", async () => {
 			quantityUnit: "pills",
 			stockEffectMilli: 1500,
 		});
+		const [beforeEvent] = await db.select().from(asNeededIntakeEvents);
 		const before = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
 		const raw = computeMedicationCurrentStockRaw({
 			medication: before[0],
@@ -271,6 +286,7 @@ process.stdin.once("data", async () => {
 			});
 			expect(response.statusCode).toBe(200);
 			const [persisted] = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
+			const [persistedEvent] = await db.select().from(asNeededIntakeEvents);
 			expect(
 				computeMedicationCurrentStockRaw({
 					medication: persisted,
@@ -279,6 +295,228 @@ process.stdin.once("data", async () => {
 					asNeededStockEffectMilli: 1500,
 				})
 			).toBe(raw);
+			expect(persistedEvent).toMatchObject({
+				stockEffectMilli: 1500,
+				stockCutoffAt: 0,
+				revision: beforeEvent.revision,
+			});
 		}
+	});
+
+	it("neutralizes only eligible active effects when a correction races with a physical edit", async () => {
+		idempotencySequence = 0;
+		await db.delete(asNeededIntakeEvents);
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		const created = await app.inject({ method: "POST", url: "/medications", payload: medicationPayload([]) });
+		expect(created.statusCode).toBe(200);
+		const medicationId = created.json().id as number;
+		const applied = await createAsNeededIntake({
+			userId,
+			medicationId,
+			quantity: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		const reversed = await createAsNeededIntake({
+			userId,
+			medicationId,
+			quantity: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		await reverseAsNeededIntake({
+			userId,
+			eventId: reversed.eventId,
+			expectedRevision: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		const future = await createAsNeededIntake({
+			userId,
+			medicationId,
+			quantity: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		await db
+			.update(asNeededIntakeEvents)
+			.set({ occurredAt: new Date("2099-01-01T00:00:00.000Z") })
+			.where(sql`${asNeededIntakeEvents.eventId} = ${future.eventId}`);
+		const [zeroAnchor] = await db
+			.insert(doseTracking)
+			.values({ userId, doseId: "as-needed:zero-effect" })
+			.returning({ id: doseTracking.id });
+		await db.insert(asNeededIntakeEvents).values({
+			eventId: "zero-effect",
+			userId,
+			medicationId,
+			doseTrackingId: zeroAnchor.id,
+			idempotencyKeyHash: "zero-effect-key",
+			requestFingerprint: "zero-effect-fingerprint",
+			occurredAt: new Date("2020-01-01T00:00:00.000Z"),
+			recordedAt: new Date(),
+			quantityMilli: 1000,
+			quantityUnit: "pills",
+			stockEffectMilli: 0,
+			stockEffectReason: "non_measurable",
+		});
+
+		const [correction, physicalEdit] = await Promise.all([
+			app.inject({
+				method: "PATCH",
+				url: `/medications/${medicationId}/stock-adjustment`,
+				payload: { stockAdjustment: 7 },
+			}),
+			app.inject({
+				method: "PUT",
+				url: `/medications/${medicationId}`,
+				payload: { ...medicationPayload([]), looseTablets: 3 },
+			}),
+		]);
+		expect(correction.statusCode).toBe(200);
+		expect(physicalEdit.statusCode).toBe(200);
+		const events = await db.select().from(asNeededIntakeEvents);
+		const byEventId = new Map(events.map((event) => [event.eventId, event]));
+		expect(byEventId.get(applied.eventId)).toMatchObject({
+			stockEffectMilli: 0,
+			stockEffectReason: "superseded_by_correction",
+			stockCutoffAt: expect.any(Number),
+			revision: 2,
+		});
+		expect(byEventId.get(reversed.eventId)).toMatchObject({ status: "reversed", stockEffectMilli: 1000, revision: 2 });
+		expect(byEventId.get(future.eventId)).toMatchObject({ stockEffectMilli: 1000, stockCutoffAt: 0, revision: 1 });
+		expect(byEventId.get("zero-effect")).toMatchObject({
+			stockEffectMilli: 0,
+			stockEffectReason: "non_measurable",
+			revision: 1,
+		});
+	});
+
+	it.each<StockMode>(["automatic", "manual"])(
+		"rebases %s refills from transaction-visible raw stock and consumes prior event effects exactly",
+		async (stockCalculationMode) => {
+			idempotencySequence = 0;
+			await db.delete(asNeededIntakeEvents);
+			await db.delete(doseTracking);
+			await db.delete(medications);
+			await db.delete(userSettings);
+			await db.insert(userSettings).values({ userId, stockCalculationMode });
+			const created = await app.inject({ method: "POST", url: "/medications", payload: medicationPayload([]) });
+			const medicationId = created.json().id as number;
+			const event = await createAsNeededIntake({
+				userId,
+				medicationId,
+				quantity: 1.5,
+				idempotencyKey: idempotencyKey(),
+			});
+			const refills = await Promise.all([
+				app.inject({
+					method: "POST",
+					url: `/medications/${medicationId}/refill`,
+					payload: { loosePillsAdded: 2 },
+				}),
+				app.inject({
+					method: "POST",
+					url: `/medications/${medicationId}/refill`,
+					payload: { loosePillsAdded: 2 },
+				}),
+			]);
+			expect(refills.map((refill) => refill.statusCode)).toEqual([200, 200]);
+			expect(refills.map((refill) => refill.json().newStock.totalPills).sort()).toEqual([10.5, 12.5]);
+			const [persisted] = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
+			const [persistedEvent] = await db
+				.select()
+				.from(asNeededIntakeEvents)
+				.where(sql`${asNeededIntakeEvents.eventId} = ${event.eventId}`);
+			expect(persisted.scheduleStockRebaseMilli).toBe(500);
+			expect(persistedEvent).toMatchObject({
+				stockEffectMilli: 0,
+				stockEffectReason: "superseded_by_correction",
+				revision: 2,
+			});
+			expect(
+				computeMedicationCurrentStockRaw({
+					medication: persisted,
+					doses: await db.select().from(doseTracking),
+					stockCalculationMode,
+				})
+			).toBe(12.5);
+		}
+	);
+
+	it("deletes only owned event anchors after the medication delete commits", async () => {
+		idempotencySequence = 0;
+		await db.delete(asNeededIntakeEvents);
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		await db.delete(users).where(sql`${users.id} = 2`);
+		await db.insert(users).values({ id: 2, username: "other-anchor-owner" });
+		const target = await app.inject({ method: "POST", url: "/medications", payload: medicationPayload([]) });
+		const targetId = target.json().id as number;
+		const [otherMedication] = await db
+			.insert(medications)
+			.values({
+				userId,
+				name: "Other medication",
+				takenByJson: "[]",
+				intakesJson: "[]",
+				looseTablets: 10,
+			})
+			.returning({ id: medications.id });
+		const [otherOwnerMedication] = await db
+			.insert(medications)
+			.values({
+				userId: 2,
+				name: "Other owner medication",
+				takenByJson: "[]",
+				intakesJson: "[]",
+				looseTablets: 10,
+			})
+			.returning({ id: medications.id });
+		const targetEvent = await createAsNeededIntake({
+			userId,
+			medicationId: targetId,
+			quantity: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		const otherMedicationEvent = await createAsNeededIntake({
+			userId,
+			medicationId: otherMedication.id,
+			quantity: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		const otherOwnerEvent = await createAsNeededIntake({
+			userId: 2,
+			medicationId: otherOwnerMedication.id,
+			quantity: 1,
+			idempotencyKey: idempotencyKey(),
+		});
+		await db.insert(doseTracking).values({ userId, doseId: "as-needed:untrusted-prefix" });
+		const imageDir = join(dataDir, "images");
+		mkdirSync(imageDir, { recursive: true });
+		writeFileSync(join(imageDir, "target-image.webp"), "target");
+		writeFileSync(join(imageDir, "other-owner-image.webp"), "other owner");
+		await db.update(medications).set({ imageUrl: "target-image.webp" }).where(sql`${medications.id} = ${targetId}`);
+		await db
+			.update(medications)
+			.set({ imageUrl: "other-owner-image.webp" })
+			.where(sql`${medications.id} = ${otherOwnerMedication.id}`);
+
+		const deletion = await app.inject({ method: "DELETE", url: `/medications/${targetId}` });
+		expect(deletion.statusCode).toBe(204);
+		expect(existsSync(join(imageDir, "target-image.webp"))).toBe(false);
+		const failedDeletion = await app.inject({ method: "DELETE", url: `/medications/${otherOwnerMedication.id}` });
+		expect(failedDeletion.statusCode).toBe(404);
+		expect(existsSync(join(imageDir, "other-owner-image.webp"))).toBe(true);
+		const remainingEvents = await db.select().from(asNeededIntakeEvents);
+		expect(remainingEvents.map((event) => event.eventId)).toEqual(
+			expect.arrayContaining([otherMedicationEvent.eventId, otherOwnerEvent.eventId])
+		);
+		expect(remainingEvents.map((event) => event.eventId)).not.toContain(targetEvent.eventId);
+		const remainingDoses = await db.select().from(doseTracking);
+		expect(remainingDoses.map((dose) => dose.doseId)).toEqual(
+			expect.arrayContaining([
+				`as-needed:${otherMedicationEvent.eventId}`,
+				`as-needed:${otherOwnerEvent.eventId}`,
+				"as-needed:untrusted-prefix",
+			])
+		);
 	});
 });

--- a/backend/src/test/zero-schedule-concurrency.test.ts
+++ b/backend/src/test/zero-schedule-concurrency.test.ts
@@ -138,61 +138,61 @@ describe.sequential("zero-schedule production write serialization", () => {
 		rmSync(dataDir, { force: true, recursive: true });
 	});
 
-	it.each<StockMode>(["automatic", "manual"])(
-		"serializes simultaneous schedule boundary writes and preserves raw %s stock",
-		async (stockCalculationMode) => {
-			await db.delete(doseTracking);
-			await db.delete(medications);
-			await db.delete(userSettings);
-			await db.insert(userSettings).values({ userId, stockCalculationMode });
+	it.each<StockMode>([
+		"automatic",
+		"manual",
+	])("serializes simultaneous schedule boundary writes and preserves raw %s stock", async (stockCalculationMode) => {
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		await db.delete(userSettings);
+		await db.insert(userSettings).values({ userId, stockCalculationMode });
 
-			const start = scheduleStart();
-			const created = await app.inject({
-				method: "POST",
-				url: "/medications",
-				payload: medicationPayload([{ usage: 1, every: 1, start }]),
-			});
-			expect(created.statusCode).toBe(200);
-			const medicationId = created.json().id as number;
-			const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
-			await db.insert(doseTracking).values({
-				userId,
-				doseId: historicalDoseId,
-				takenAt: new Date(),
-				markedBy: "history",
-				takenSource: "manual",
-			});
+		const start = scheduleStart();
+		const created = await app.inject({
+			method: "POST",
+			url: "/medications",
+			payload: medicationPayload([{ usage: 1, every: 1, start }]),
+		});
+		expect(created.statusCode).toBe(200);
+		const medicationId = created.json().id as number;
+		const historicalDoseId = `${medicationId}-0-${new Date(2099, 0, 2).getTime()}`;
+		await db.insert(doseTracking).values({
+			userId,
+			doseId: historicalDoseId,
+			takenAt: new Date(),
+			markedBy: "history",
+			takenSource: "manual",
+		});
 
-			const [beforeMedication] = await db.select().from(medications);
-			const beforeDoses = await db.select().from(doseTracking);
-			const expectedRawStock = computeMedicationCurrentStockRaw({
-				medication: beforeMedication,
-				doses: beforeDoses,
-				stockCalculationMode,
-			});
+		const [beforeMedication] = await db.select().from(medications);
+		const beforeDoses = await db.select().from(doseTracking);
+		const expectedRawStock = computeMedicationCurrentStockRaw({
+			medication: beforeMedication,
+			doses: beforeDoses,
+			stockCalculationMode,
+		});
 
-			const [toUnscheduled, toScheduled] = await Promise.all([
-				app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
-				app.inject({
-					method: "PUT",
-					url: `/medications/${medicationId}`,
-					payload: medicationPayload([{ usage: 2, every: 1, start }]),
-				}),
-			]);
+		const [toUnscheduled, toScheduled] = await Promise.all([
+			app.inject({ method: "PUT", url: `/medications/${medicationId}`, payload: medicationPayload([]) }),
+			app.inject({
+				method: "PUT",
+				url: `/medications/${medicationId}`,
+				payload: medicationPayload([{ usage: 2, every: 1, start }]),
+			}),
+		]);
 
-			expect(toUnscheduled.statusCode).toBe(200);
-			expect(toScheduled.statusCode).toBe(200);
-			const [persisted] = await db.select().from(medications);
-			const persistedDoses = await db.select().from(doseTracking);
-			expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
-			expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
-			expect(
-				computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
-			).toBe(expectedRawStock);
-			expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
-			expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
-		}
-	);
+		expect(toUnscheduled.statusCode).toBe(200);
+		expect(toScheduled.statusCode).toBe(200);
+		const [persisted] = await db.select().from(medications);
+		const persistedDoses = await db.select().from(doseTracking);
+		expect(JSON.parse(persisted.intakesJson)).toHaveLength(1);
+		expect(persistedDoses.map((dose) => dose.doseId)).toContain(historicalDoseId);
+		expect(
+			computeMedicationCurrentStockRaw({ medication: persisted, doses: persistedDoses, stockCalculationMode })
+		).toBe(expectedRawStock);
+		expect(Number.isInteger(persisted.scheduleStockRebaseMilli)).toBe(true);
+		expect(persisted.scheduleStockRebaseMilli).not.toBe(0);
+	});
 
 	it("returns the original bounded SQLITE_BUSY from an independent writer and releases the FIFO queue", async () => {
 		const databaseUrl = `file:${resolve(dataDir, "medassist-ng.db")}`;
@@ -389,57 +389,57 @@ process.stdin.once("data", async () => {
 		});
 	});
 
-	it.each<StockMode>(["automatic", "manual"])(
-		"rebases %s refills from transaction-visible raw stock and consumes prior event effects exactly",
-		async (stockCalculationMode) => {
-			idempotencySequence = 0;
-			await db.delete(asNeededIntakeEvents);
-			await db.delete(doseTracking);
-			await db.delete(medications);
-			await db.delete(userSettings);
-			await db.insert(userSettings).values({ userId, stockCalculationMode });
-			const created = await app.inject({ method: "POST", url: "/medications", payload: medicationPayload([]) });
-			const medicationId = created.json().id as number;
-			const event = await createAsNeededIntake({
-				userId,
-				medicationId,
-				quantity: 1.5,
-				idempotencyKey: idempotencyKey(),
-			});
-			const refills = await Promise.all([
-				app.inject({
-					method: "POST",
-					url: `/medications/${medicationId}/refill`,
-					payload: { loosePillsAdded: 2 },
-				}),
-				app.inject({
-					method: "POST",
-					url: `/medications/${medicationId}/refill`,
-					payload: { loosePillsAdded: 2 },
-				}),
-			]);
-			expect(refills.map((refill) => refill.statusCode)).toEqual([200, 200]);
-			expect(refills.map((refill) => refill.json().newStock.totalPills).sort()).toEqual([10.5, 12.5]);
-			const [persisted] = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
-			const [persistedEvent] = await db
-				.select()
-				.from(asNeededIntakeEvents)
-				.where(sql`${asNeededIntakeEvents.eventId} = ${event.eventId}`);
-			expect(persisted.scheduleStockRebaseMilli).toBe(500);
-			expect(persistedEvent).toMatchObject({
-				stockEffectMilli: 0,
-				stockEffectReason: "superseded_by_correction",
-				revision: 2,
-			});
-			expect(
-				computeMedicationCurrentStockRaw({
-					medication: persisted,
-					doses: await db.select().from(doseTracking),
-					stockCalculationMode,
-				})
-			).toBe(12.5);
-		}
-	);
+	it.each<StockMode>([
+		"automatic",
+		"manual",
+	])("rebases %s refills from transaction-visible raw stock and consumes prior event effects exactly", async (stockCalculationMode) => {
+		idempotencySequence = 0;
+		await db.delete(asNeededIntakeEvents);
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		await db.delete(userSettings);
+		await db.insert(userSettings).values({ userId, stockCalculationMode });
+		const created = await app.inject({ method: "POST", url: "/medications", payload: medicationPayload([]) });
+		const medicationId = created.json().id as number;
+		const event = await createAsNeededIntake({
+			userId,
+			medicationId,
+			quantity: 1.5,
+			idempotencyKey: idempotencyKey(),
+		});
+		const refills = await Promise.all([
+			app.inject({
+				method: "POST",
+				url: `/medications/${medicationId}/refill`,
+				payload: { loosePillsAdded: 2 },
+			}),
+			app.inject({
+				method: "POST",
+				url: `/medications/${medicationId}/refill`,
+				payload: { loosePillsAdded: 2 },
+			}),
+		]);
+		expect(refills.map((refill) => refill.statusCode)).toEqual([200, 200]);
+		expect(refills.map((refill) => refill.json().newStock.totalPills).sort()).toEqual([10.5, 12.5]);
+		const [persisted] = await db.select().from(medications).where(sql`${medications.id} = ${medicationId}`);
+		const [persistedEvent] = await db
+			.select()
+			.from(asNeededIntakeEvents)
+			.where(sql`${asNeededIntakeEvents.eventId} = ${event.eventId}`);
+		expect(persisted.scheduleStockRebaseMilli).toBe(500);
+		expect(persistedEvent).toMatchObject({
+			stockEffectMilli: 0,
+			stockEffectReason: "superseded_by_correction",
+			revision: 2,
+		});
+		expect(
+			computeMedicationCurrentStockRaw({
+				medication: persisted,
+				doses: await db.select().from(doseTracking),
+				stockCalculationMode,
+			})
+		).toBe(12.5);
+	});
 
 	it("deletes only owned event anchors after the medication delete commits", async () => {
 		idempotencySequence = 0;


### PR DESCRIPTION
Closes #1022

## Summary

- serialize physical stock corrections, combined edits, and refills as immediate writes using transaction-visible stock
- atomically neutralize active positive pre-cutoff as-needed effects while preserving reversed, zero, and future events
- preserve exact schedule rebase arithmetic, including half-milli remainders, and clean trusted medication anchors after committed hard deletion

## Scope boundary

Backend-only Slice 3C. Scheduled-only behavior is unchanged. No public event routes/UI, legacy dose-surface isolation, or portability work is included. This follows #1014 and #1023 and unlocks #1026.

## Validation

- real database/concurrency focused coverage: 183 tests
- full backend suite split: 481 + 440 = 921 tests
- direct Biome on all five files
- root lint, check, build, and diff check
- direct cross-owner delete assertion preserves the other owner's image