### PR TITLE
feat: isolate as-needed anchors from legacy doses

### DIFF
--- a/backend/src/routes/doses.ts
+++ b/backend/src/routes/doses.ts
@@ -6,7 +6,12 @@ import { db } from "../db/client.js";
 import { doseTracking, intakeJournal, medications, type shareTokens, userSettings } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
-import { getActiveAsNeededStockEffectMilli } from "../services/as-needed-intakes-service.js";
+import {
+	filterScheduledDoseRows,
+	getActiveAsNeededStockEffectMilli,
+	getAsNeededAnchorDoseIds,
+	isAsNeededAnchorDoseId,
+} from "../services/as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "../services/current-stock.js";
 import { markDoseTakenForUser } from "../services/dose-tracking-service.js";
 import {
@@ -231,6 +236,7 @@ function validateShareDoseIdWithMedicationMap(
 }
 
 async function validateShareDoseId(share: typeof shareTokens.$inferSelect, doseId: string): Promise<boolean> {
+	if (await isAsNeededAnchorDoseId(db, share.userId, doseId)) return false;
 	const medicationById = await loadShareVisibleMedicationMap(share);
 	return validateShareDoseIdWithMedicationMap(share, doseId, medicationById);
 }
@@ -327,7 +333,8 @@ async function isDoseOutOfStock(options: {
 			})()
 		: parsedDose.timestampMs;
 
-	const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, options.userId));
+	const allDoses = await db.select().from(doseTracking).where(eq(doseTracking.userId, options.userId));
+	const doses = await filterScheduledDoseRows(db, options.userId, allDoses);
 	const asNeededStockEffectMilli = await getActiveAsNeededStockEffectMilli(db, options.userId, medication.id);
 	const stockBeforeDoseMs = Math.max(0, scheduledOccurrenceMs - 1);
 	return (
@@ -344,7 +351,8 @@ async function isDoseOutOfStock(options: {
 async function markDoseSkippedForUser(input: {
 	userId: number;
 	doseId: string;
-}): Promise<"created" | "updated" | "already_skipped"> {
+}): Promise<"created" | "updated" | "already_skipped" | "invalid"> {
+	if (await isAsNeededAnchorDoseId(db, input.userId, input.doseId)) return "invalid";
 	const [existing] = await db
 		.select()
 		.from(doseTracking)
@@ -373,7 +381,8 @@ async function markDoseSkippedForUser(input: {
 	return "created";
 }
 
-async function undoDoseSkippedForUser(input: { userId: number; doseId: string }): Promise<boolean> {
+async function undoDoseSkippedForUser(input: { userId: number; doseId: string }): Promise<boolean | "invalid"> {
+	if (await isAsNeededAnchorDoseId(db, input.userId, input.doseId)) return "invalid";
 	const [existing] = await db
 		.select()
 		.from(doseTracking)
@@ -455,7 +464,8 @@ export async function doseRoutes(app: FastifyInstance) {
 			const userId = await getUserId(request, reply);
 
 			// Get all taken doses for this user (no time limit)
-			const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, userId));
+			const allDoses = await db.select().from(doseTracking).where(eq(doseTracking.userId, userId));
+			const doses = await filterScheduledDoseRows(db, userId, allDoses);
 
 			return {
 				doses: doses.map((d) => ({
@@ -553,6 +563,7 @@ export async function doseRoutes(app: FastifyInstance) {
 				},
 				response: {
 					200: { type: "object", properties: { success: { type: "boolean" } } },
+					400: genericErrorSchema,
 					401: genericErrorSchema,
 				},
 			},
@@ -561,6 +572,9 @@ export async function doseRoutes(app: FastifyInstance) {
 			const userId = await getUserId(request, reply);
 
 			const { doseId } = request.params;
+			if (await isAsNeededAnchorDoseId(db, userId, doseId)) {
+				return reply.status(400).send({ error: "Invalid dose ID", code: "INVALID_DOSE" });
+			}
 
 			// Check if this dose was dismissed
 			const [existing] = await db
@@ -628,6 +642,9 @@ export async function doseRoutes(app: FastifyInstance) {
 			}
 
 			const status = await markDoseSkippedForUser({ userId, doseId });
+			if (status === "invalid") {
+				return reply.status(400).send({ error: "Invalid dose ID", code: "INVALID_DOSE" });
+			}
 			if (status === "already_skipped") {
 				return { success: true, message: "Already skipped" };
 			}
@@ -655,13 +672,17 @@ export async function doseRoutes(app: FastifyInstance) {
 				},
 				response: {
 					200: { type: "object", properties: { success: { type: "boolean" } } },
+					400: genericErrorSchema,
 					401: genericErrorSchema,
 				},
 			},
 		},
 		async (request, reply) => {
 			const userId = await getUserId(request, reply);
-			await undoDoseSkippedForUser({ userId, doseId: request.params.doseId });
+			const result = await undoDoseSkippedForUser({ userId, doseId: request.params.doseId });
+			if (result === "invalid") {
+				return reply.status(400).send({ error: "Invalid dose ID", code: "INVALID_DOSE" });
+			}
 
 			return { success: true };
 		}
@@ -711,6 +732,9 @@ export async function doseRoutes(app: FastifyInstance) {
 			}
 
 			const { doseIds } = parsed.data;
+			if ((await getAsNeededAnchorDoseIds(db, userId, doseIds)).size > 0) {
+				return reply.status(400).send({ error: "Invalid dose ID", code: "INVALID_DOSE" });
+			}
 			const hasFutureDose = doseIds.some((doseId) => {
 				const parsedDose = parseDoseId(doseId);
 				return parsedDose ? isFutureDoseDay(parsedDose) : false;
@@ -727,6 +751,9 @@ export async function doseRoutes(app: FastifyInstance) {
 			let dismissedCount = 0;
 			for (const doseId of doseIds) {
 				const status = await markDoseSkippedForUser({ userId, doseId });
+				if (status === "invalid") {
+					return reply.status(400).send({ error: "Invalid dose ID", code: "INVALID_DOSE" });
+				}
 				if (status !== "already_skipped") {
 					dismissedCount++;
 				}
@@ -763,10 +790,11 @@ export async function doseRoutes(app: FastifyInstance) {
 
 			// Delete all dismissed-only records (not taken ones)
 			// For taken+dismissed, just remove the dismissed flag
-			const dismissed = await db
+			const allDismissed = await db
 				.select()
 				.from(doseTracking)
 				.where(and(eq(doseTracking.userId, userId), eq(doseTracking.dismissed, true)));
+			const dismissed = await filterScheduledDoseRows(db, userId, allDismissed);
 
 			for (const d of dismissed) {
 				const hasRealTakenTimestamp = d.takenAt instanceof Date ? d.takenAt.getTime() > 0 : Boolean(d.takenAt);
@@ -827,7 +855,8 @@ export async function doseRoutes(app: FastifyInstance) {
 					.from(doseTracking)
 					.where(and(eq(doseTracking.userId, share.userId), medicationDoseFilter));
 			}
-			const visibleDoses = doses.filter((dose) =>
+			const scheduledDoses = await filterScheduledDoseRows(db, share.userId, doses);
+			const visibleDoses = scheduledDoses.filter((dose) =>
 				validateShareDoseIdWithMedicationMap(share, dose.doseId, medicationById)
 			);
 
@@ -1146,6 +1175,9 @@ export async function doseRoutes(app: FastifyInstance) {
 			}
 
 			const status = await markDoseSkippedForUser({ userId: share.userId, doseId });
+			if (status === "invalid") {
+				return reply.status(400).send({ error: "Invalid or unauthorized doseId", code: "INVALID_DOSE" });
+			}
 			if (status === "already_skipped") {
 				return { success: true, message: "Already skipped" };
 			}
@@ -1231,7 +1263,10 @@ export async function doseRoutes(app: FastifyInstance) {
 				return reply.status(400).send({ error: "Invalid or unauthorized doseId" });
 			}
 
-			await undoDoseSkippedForUser({ userId: share.userId, doseId });
+			const result = await undoDoseSkippedForUser({ userId: share.userId, doseId });
+			if (result === "invalid") {
+				return reply.status(400).send({ error: "Invalid or unauthorized doseId", code: "INVALID_DOSE" });
+			}
 			return { success: true };
 		}
 	);

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -9,6 +9,7 @@ import { getDataDir } from "../db/path-utils.js";
 import { doseTracking, intakeJournal, medications, refillHistory, shareTokens, userSettings } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import { filterScheduledDoseRows } from "../services/as-needed-intakes-service.js";
 import {
 	listIntakeJournalExportPayloadsForUser,
 	restoreIntakeJournalForImportedDose,
@@ -666,7 +667,8 @@ export async function exportRoutes(app: FastifyInstance) {
 			});
 
 			// 2. Load all dose tracking entries
-			const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, userId));
+			const doseRows = await db.select().from(doseTracking).where(eq(doseTracking.userId, userId));
+			const doses = await filterScheduledDoseRows(db, userId, doseRows);
 			const journalPayloadsByDoseTrackingId = await listIntakeJournalExportPayloadsForUser(userId);
 
 			const exportDoseHistory = doses
@@ -899,12 +901,13 @@ export async function exportRoutes(app: FastifyInstance) {
 					db.select({ id: shareTokens.id }).from(shareTokens).where(eq(shareTokens.userId, userId)),
 					db.select({ id: userSettings.id }).from(userSettings).where(eq(userSettings.userId, userId)),
 				]);
+			const scheduledDoseHistory = await filterScheduledDoseRows(db, userId, existingDoseHistory);
 
 			return {
 				success: true,
 				preview: buildImportPreview(parsed.data, {
 					medications: existingMeds.length,
-					doseHistory: existingDoseHistory.length,
+					doseHistory: scheduledDoseHistory.length,
 					refillHistory: existingRefillHistory.length,
 					shareLinks: existingShareLinks.length,
 					hasSettings: existingSettings.length > 0,

--- a/backend/src/routes/medications.ts
+++ b/backend/src/routes/medications.ts
@@ -9,6 +9,7 @@ import { getAnonymousUserId, isReadOnlyApiKeyRequest, requireAuth } from "../plu
 import { env } from "../plugins/env.js";
 import {
 	deleteAsNeededAnchorsForMedication,
+	filterScheduledDoseRows,
 	getActiveAsNeededStockEffectMilli,
 	getActiveAsNeededStockEffectsMilli,
 	neutralizeAsNeededStockEffects,
@@ -872,6 +873,7 @@ export async function medicationRoutes(app: FastifyInstance) {
 						.select()
 						.from(doseTracking)
 						.where(and(eq(doseTracking.userId, userId), like(doseTracking.doseId, `${idNum}-%`)));
+					dosesForProjection = await filterScheduledDoseRows(transactionDb, userId, dosesForProjection);
 					const [settings] = await transactionDb
 						.select({ stockCalculationMode: userSettings.stockCalculationMode })
 						.from(userSettings)
@@ -964,12 +966,13 @@ export async function medicationRoutes(app: FastifyInstance) {
 			const oldIntakes = transition.oldIntakes;
 
 			// Get all dose tracking entries for this medication
-			const allDoses = transition.hasScheduleOnBothSides
+			const doseRows = transition.hasScheduleOnBothSides
 				? await db
 						.select()
 						.from(doseTracking)
 						.where(and(eq(doseTracking.userId, userId), like(doseTracking.doseId, `${idNum}-%`)))
 				: [];
+			const allDoses = await filterScheduledDoseRows(db, userId, doseRows);
 
 			// A zero schedule is a snapshot boundary: keep historical dose IDs untouched instead of
 			// reinterpreting or deleting them against a schedule that did not exist when they were recorded.
@@ -1056,10 +1059,11 @@ export async function medicationRoutes(app: FastifyInstance) {
 				}, Infinity);
 				if (!Number.isNaN(earliestStartDate)) {
 					// Re-fetch after possible migrations
-					const updatedDoses = await db
+					const updatedDoseRows = await db
 						.select()
 						.from(doseTracking)
 						.where(and(eq(doseTracking.userId, userId), like(doseTracking.doseId, `${idNum}-%`)));
+					const updatedDoses = await filterScheduledDoseRows(db, userId, updatedDoseRows);
 
 					const dosesToDelete = updatedDoses.filter((dose) => {
 						const parts = dose.doseId.split("-");

--- a/backend/src/routes/notification-actions.ts
+++ b/backend/src/routes/notification-actions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { db } from "../db/client.js";
 import { notificationActionGroups, notificationActionTokens, userSettings } from "../db/schema.js";
 import { getTranslations, type Language } from "../i18n/translations.js";
+import { getAsNeededAnchorDoseIds } from "../services/as-needed-intakes-service.js";
 import { markDoseTakenForUser, skipDosesForUser } from "../services/dose-tracking-service.js";
 import {
 	getNotificationActionTokenRecord,
@@ -543,6 +544,14 @@ export async function notificationActionRoutes(app: FastifyInstance) {
 				});
 			}
 
+			if ((await getAsNeededAnchorDoseIds(db, record.group.userId, record.doseIds)).size > 0) {
+				request.log.warn(
+					buildNotificationActionLogContext(record, { requestedAction: action, code: "INVALID_DOSE" }),
+					"[NotificationActions] Rejected invalid scheduled dose action"
+				);
+				return reply.status(400).send({ error: "Invalid dose ID", code: "INVALID_DOSE" });
+			}
+
 			if (action === "taken") {
 				for (const [doseIndex, doseId] of record.doseIds.entries()) {
 					const result = await markDoseTakenForUser({
@@ -566,7 +575,10 @@ export async function notificationActionRoutes(app: FastifyInstance) {
 					}
 				}
 			} else {
-				await skipDosesForUser({ userId: record.group.userId, doseIds: record.doseIds });
+				const result = await skipDosesForUser({ userId: record.group.userId, doseIds: record.doseIds });
+				if (!result.success) {
+					return reply.status(400).send({ error: result.message, code: result.code });
+				}
 			}
 
 			await db

--- a/backend/src/routes/report.ts
+++ b/backend/src/routes/report.ts
@@ -6,6 +6,7 @@ import { db } from "../db/client.js";
 import { doseTracking, intakeJournal, medications, refillHistory } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
+import { filterScheduledDoseRows } from "../services/as-needed-intakes-service.js";
 import type { AuthUser } from "../types/fastify.js";
 import {
 	applyOpenApiRouteStandards,
@@ -239,7 +240,7 @@ export async function reportRoutes(app: FastifyInstance) {
 
 			// Fetch dose tracking for all requested medications
 			// doseId format: "{medicationId}-{blisterIndex}-{dateMs}" or "{medicationId}-{blisterIndex}-{dateMs}-{takenBy}"
-			const allDoses = await db
+			const doseRows = await db
 				.select({
 					id: doseTracking.id,
 					doseId: doseTracking.doseId,
@@ -249,6 +250,7 @@ export async function reportRoutes(app: FastifyInstance) {
 				})
 				.from(doseTracking)
 				.where(eq(doseTracking.userId, userId));
+			const allDoses = await filterScheduledDoseRows(db, userId, doseRows);
 
 			// Group doses by medication ID
 			const dosesByMed = new Map<

--- a/backend/src/routes/share.ts
+++ b/backend/src/routes/share.ts
@@ -5,7 +5,7 @@ import { db } from "../db/client.js";
 import { doseTracking, medications, shareTokens, userSettings, users } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
-import { getActiveAsNeededStockEffectsMilli } from "../services/as-needed-intakes-service.js";
+import { filterScheduledDoseRows, getActiveAsNeededStockEffectsMilli } from "../services/as-needed-intakes-service.js";
 import { buildSharedMedicationOverview } from "../services/coverage.js";
 import {
 	getPublicShareContext,
@@ -362,10 +362,14 @@ export async function shareRoutes(app: FastifyInstance) {
 						meds.map((medication) => medication.id)
 					)
 				: new Map<number, number>();
+			const doseRows = shareMedicationOverview
+				? await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId))
+				: [];
+			const scheduledDoses = await filterScheduledDoseRows(db, share.userId, doseRows);
 			const medicationOverview = shareMedicationOverview
 				? buildSharedMedicationOverview({
 						medications: meds,
-						doses: await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId)),
+						doses: scheduledDoses,
 						thresholdDays: settings?.lowStockDays ?? 30,
 						shareTakenBy: share.takenBy,
 						asNeededStockEffectsMilli,
@@ -459,7 +463,8 @@ export async function shareRoutes(app: FastifyInstance) {
 				meds.map((medication) => medication.id)
 			);
 
-			const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId));
+			const doseRows = await db.select().from(doseTracking).where(eq(doseTracking.userId, share.userId));
+			const doses = await filterScheduledDoseRows(db, share.userId, doseRows);
 
 			const overview = buildSharedMedicationOverview({
 				medications: meds,

--- a/backend/src/services/as-needed-intakes-service.ts
+++ b/backend/src/services/as-needed-intakes-service.ts
@@ -118,6 +118,65 @@ export async function getActiveAsNeededStockEffectsMilli(
 	return new Map(rows.map((row) => [row.medicationId, Number(row.total ?? 0)]));
 }
 
+export async function getAsNeededAnchorIds(
+	database: Database,
+	userId: number,
+	doseTrackingIds: number[]
+): Promise<Set<number>> {
+	if (doseTrackingIds.length === 0) return new Set();
+	const requestedIds = new Set(doseTrackingIds);
+	const rows = await database
+		.select({ id: doseTracking.id })
+		.from(asNeededIntakeEvents)
+		.innerJoin(
+			doseTracking,
+			and(
+				eq(doseTracking.id, asNeededIntakeEvents.doseTrackingId),
+				eq(doseTracking.userId, asNeededIntakeEvents.userId)
+			)
+		)
+		.where(and(eq(asNeededIntakeEvents.userId, userId), eq(doseTracking.userId, userId)));
+	return new Set(rows.map((row) => row.id).filter((id) => requestedIds.has(id)));
+}
+
+export async function filterScheduledDoseRows<T extends { id: number }>(
+	database: Database,
+	userId: number,
+	rows: T[]
+): Promise<T[]> {
+	const anchorIds = await getAsNeededAnchorIds(
+		database,
+		userId,
+		rows.map((row) => row.id)
+	);
+	return rows.filter((row) => !anchorIds.has(row.id));
+}
+
+export async function getAsNeededAnchorDoseIds(
+	database: Database,
+	userId: number,
+	doseIds?: string[]
+): Promise<Set<string>> {
+	if (doseIds?.length === 0) return new Set();
+	const requestedDoseIds = doseIds ? new Set(doseIds) : null;
+	const rows = await database
+		.select({ doseId: doseTracking.doseId })
+		.from(asNeededIntakeEvents)
+		.innerJoin(
+			doseTracking,
+			and(
+				eq(doseTracking.id, asNeededIntakeEvents.doseTrackingId),
+				eq(doseTracking.userId, asNeededIntakeEvents.userId)
+			)
+		)
+		.where(and(eq(asNeededIntakeEvents.userId, userId), eq(doseTracking.userId, userId)));
+	return new Set(rows.map((row) => row.doseId).filter((doseId) => !requestedDoseIds || requestedDoseIds.has(doseId)));
+}
+
+export async function isAsNeededAnchorDoseId(database: Database, userId: number, doseId: string): Promise<boolean> {
+	return (await getAsNeededAnchorDoseIds(database, userId, [doseId])).has(doseId);
+}
+
 export async function neutralizeAsNeededStockEffects(
 	database: Database,
 	userId: number,
@@ -225,7 +284,8 @@ export async function createAsNeededIntake(input: {
 			.select({ stockCalculationMode: userSettings.stockCalculationMode })
 			.from(userSettings)
 			.where(eq(userSettings.userId, input.userId));
-		const doses = await transactionDb.select().from(doseTracking).where(eq(doseTracking.userId, input.userId));
+		const doseRows = await transactionDb.select().from(doseTracking).where(eq(doseTracking.userId, input.userId));
+		const doses = await filterScheduledDoseRows(transactionDb, input.userId, doseRows);
 		const activeEffectMilli = await getActiveAsNeededStockEffectMilli(transactionDb, input.userId, input.medicationId);
 		const currentStockMilli = Math.round(
 			computeMedicationCurrentStockRaw({

--- a/backend/src/services/dose-tracking-service.ts
+++ b/backend/src/services/dose-tracking-service.ts
@@ -3,7 +3,12 @@ import { db } from "../db/client.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { parseDoseId } from "../utils/dose-id.js";
 import { normalizeMedicationIntakes, parseLocalDateTime } from "../utils/scheduler-utils.js";
-import { getActiveAsNeededStockEffectMilli } from "./as-needed-intakes-service.js";
+import {
+	filterScheduledDoseRows,
+	getActiveAsNeededStockEffectMilli,
+	getAsNeededAnchorDoseIds,
+	isAsNeededAnchorDoseId,
+} from "./as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 
 export type DoseTrackingSource = "manual" | "automatic" | "notification";
@@ -19,18 +24,13 @@ export type MarkDoseTakenResult =
 			message: string;
 	  };
 
-export type DismissDosesResult = {
-	success: true;
-	dismissedCount: number;
-	alreadyTakenCount: number;
-};
+export type DismissDosesResult =
+	| { success: true; dismissedCount: number; alreadyTakenCount: number }
+	| { success: false; code: "INVALID_DOSE"; message: string };
 
-export type SkipDosesResult = {
-	success: true;
-	skippedCount: number;
-	alreadySkippedCount: number;
-	switchedFromTakenCount: number;
-};
+export type SkipDosesResult =
+	| { success: true; skippedCount: number; alreadySkippedCount: number; switchedFromTakenCount: number }
+	| { success: false; code: "INVALID_DOSE"; message: string };
 
 function hasRealTakenTimestamp(takenAt: Date | null): boolean {
 	return takenAt instanceof Date && takenAt.getTime() > 0;
@@ -105,7 +105,8 @@ async function isDoseOutOfStock(options: { userId: number; doseId: string }): Pr
 			})()
 		: parsedDose.timestampMs;
 
-	const doses = await db.select().from(doseTracking).where(eq(doseTracking.userId, options.userId));
+	const allDoses = await db.select().from(doseTracking).where(eq(doseTracking.userId, options.userId));
+	const doses = await filterScheduledDoseRows(db, options.userId, allDoses);
 	const asNeededStockEffectMilli = await getActiveAsNeededStockEffectMilli(db, options.userId, medication.id);
 	const stockBeforeDoseMs = Math.max(0, scheduledOccurrenceMs - 1);
 
@@ -126,6 +127,9 @@ export async function markDoseTakenForUser(input: {
 	source: DoseTrackingSource;
 	markedBy?: string | null;
 }): Promise<MarkDoseTakenResult> {
+	if (await isAsNeededAnchorDoseId(db, input.userId, input.doseId)) {
+		return { success: false, code: "INVALID_DOSE", message: "Invalid dose ID" };
+	}
 	const parsedDose = parseDoseId(input.doseId);
 	if (!parsedDose) {
 		return {
@@ -202,6 +206,9 @@ export async function markDoseTakenForUser(input: {
 }
 
 export async function skipDosesForUser(input: { userId: number; doseIds: string[] }): Promise<SkipDosesResult> {
+	if ((await getAsNeededAnchorDoseIds(db, input.userId, input.doseIds)).size > 0) {
+		return { success: false, code: "INVALID_DOSE", message: "Invalid dose ID" };
+	}
 	let skippedCount = 0;
 	let alreadySkippedCount = 0;
 	let switchedFromTakenCount = 0;
@@ -261,6 +268,9 @@ export async function skipDosesForUser(input: { userId: number; doseIds: string[
 }
 
 export async function dismissDosesForUser(input: { userId: number; doseIds: string[] }): Promise<DismissDosesResult> {
+	if ((await getAsNeededAnchorDoseIds(db, input.userId, input.doseIds)).size > 0) {
+		return { success: false, code: "INVALID_DOSE", message: "Invalid dose ID" };
+	}
 	let dismissedCount = 0;
 	let alreadyTakenCount = 0;
 

--- a/backend/src/services/intake-journal-export.ts
+++ b/backend/src/services/intake-journal-export.ts
@@ -1,7 +1,7 @@
 import { type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { intakeJournal } from "../db/schema.js";
+import { asNeededIntakeEvents, doseTracking, intakeJournal } from "../db/schema.js";
 
 type IntakeJournalWriteDatabase = Pick<typeof db, "insert">;
 
@@ -45,16 +45,24 @@ function toDateOrFallback(value: string | null | undefined, fallback: Date): Dat
 export async function listIntakeJournalExportPayloadsForUser(
 	userId: number
 ): Promise<Map<number, IntakeJournalExportPayload>> {
-	const rows = await db.select().from(intakeJournal).where(eq(intakeJournal.userId, userId));
+	const rows = await db
+		.select({ journal: intakeJournal })
+		.from(intakeJournal)
+		.innerJoin(doseTracking, eq(doseTracking.id, intakeJournal.doseTrackingId))
+		.leftJoin(
+			asNeededIntakeEvents,
+			and(eq(asNeededIntakeEvents.doseTrackingId, doseTracking.id), eq(asNeededIntakeEvents.userId, userId))
+		)
+		.where(and(eq(intakeJournal.userId, userId), eq(doseTracking.userId, userId), isNull(asNeededIntakeEvents.id)));
 
 	return new Map(
-		rows.map((row) => [
-			row.doseTrackingId,
+		rows.map(({ journal }) => [
+			journal.doseTrackingId,
 			{
-				journalNote: row.note,
-				journalMood: normalizeIntakeMood(row.mood),
-				journalCreatedAt: toIsoStringOrNull(row.createdAt),
-				journalUpdatedAt: toIsoStringOrNull(row.updatedAt),
+				journalNote: journal.note,
+				journalMood: normalizeIntakeMood(journal.mood),
+				journalCreatedAt: toIsoStringOrNull(journal.createdAt),
+				journalUpdatedAt: toIsoStringOrNull(journal.updatedAt),
 			},
 		])
 	);

--- a/backend/src/services/intake-journal-service.ts
+++ b/backend/src/services/intake-journal-service.ts
@@ -1,7 +1,7 @@
 import { type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
-import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { and, desc, eq, gte, isNull, lte } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { doseTracking, intakeJournal, medications } from "../db/schema.js";
+import { asNeededIntakeEvents, doseTracking, intakeJournal, medications } from "../db/schema.js";
 import { type ParsedDoseId, parseDoseId } from "../utils/dose-id.js";
 import { normalizeMedicationIntakes, parseLocalDateTime } from "../utils/scheduler-utils.js";
 import type { DoseTrackingSource } from "./dose-tracking-service.js";
@@ -117,8 +117,14 @@ export async function resolveTrackedDoseEventForUser(input: {
 			intakeRemindersEnabled: medications.intakeRemindersEnabled,
 		})
 		.from(doseTracking)
+		.leftJoin(
+			asNeededIntakeEvents,
+			and(eq(asNeededIntakeEvents.doseTrackingId, doseTracking.id), eq(asNeededIntakeEvents.userId, input.userId))
+		)
 		.innerJoin(medications, and(eq(medications.id, parsedDose.medicationId), eq(medications.userId, input.userId)))
-		.where(and(eq(doseTracking.userId, input.userId), eq(doseTracking.doseId, input.doseId)))
+		.where(
+			and(eq(doseTracking.userId, input.userId), eq(doseTracking.doseId, input.doseId), isNull(asNeededIntakeEvents.id))
+		)
 		.limit(1);
 
 	if (!event) {
@@ -273,8 +279,19 @@ export async function listIntakeJournalEntriesForUser(input: {
 		})
 		.from(intakeJournal)
 		.innerJoin(doseTracking, eq(doseTracking.id, intakeJournal.doseTrackingId))
+		.leftJoin(
+			asNeededIntakeEvents,
+			and(eq(asNeededIntakeEvents.doseTrackingId, doseTracking.id), eq(asNeededIntakeEvents.userId, input.userId))
+		)
 		.innerJoin(medications, eq(medications.id, intakeJournal.medicationId))
-		.where(and(...filters))
+		.where(
+			and(
+				...filters,
+				eq(doseTracking.userId, input.userId),
+				eq(medications.userId, input.userId),
+				isNull(asNeededIntakeEvents.id)
+			)
+		)
 		.orderBy(desc(intakeJournal.scheduledFor), desc(intakeJournal.updatedAt))
 		.limit(input.limit ?? 100);
 

--- a/backend/src/services/intake-reminder-scheduler.ts
+++ b/backend/src/services/intake-reminder-scheduler.ts
@@ -31,7 +31,11 @@ import {
 	parseIntakeReminderState,
 	type UpcomingIntake,
 } from "../utils/scheduler-utils.js";
-import { getActiveAsNeededStockEffectsMilli } from "./as-needed-intakes-service.js";
+import {
+	filterScheduledDoseRows,
+	getActiveAsNeededStockEffectsMilli,
+	getAsNeededAnchorDoseIds,
+} from "./as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 import {
 	createNotificationActionContext,
@@ -149,7 +153,7 @@ async function autoMarkDueIntakesAsTaken(
 	todayEnd.setHours(23, 59, 59, 999);
 
 	const existingToday = await db
-		.select({ doseId: doseTracking.doseId })
+		.select({ id: doseTracking.id, doseId: doseTracking.doseId })
 		.from(doseTracking)
 		.where(
 			and(
@@ -158,11 +162,14 @@ async function autoMarkDueIntakesAsTaken(
 				lte(doseTracking.takenAt, todayEnd)
 			)
 		);
-	const existingDoseIds = new Set(existingToday.map((d) => d.doseId));
-	const trackedDoses = await db
+	const scheduledToday = await filterScheduledDoseRows(db, settings.userId, existingToday);
+	const existingDoseIds = new Set(scheduledToday.map((d) => d.doseId));
+	const reservedAnchorDoseIds = await getAsNeededAnchorDoseIds(db, settings.userId);
+	const trackedDoseRows = await db
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, settings.userId), eq(doseTracking.dismissed, false)));
+	const trackedDoses = await filterScheduledDoseRows(db, settings.userId, trackedDoseRows);
 	const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
 		db,
 		settings.userId,
@@ -221,6 +228,12 @@ async function autoMarkDueIntakesAsTaken(
 			});
 
 			if (existingDoseIds.has(doseId)) {
+				continue;
+			}
+			if (reservedAnchorDoseIds.has(doseId)) {
+				logger.warn(
+					`[IntakeReminder] Skipped auto-mark because a reserved anchor occupies the scheduled identity: userId=${settings.userId}, medicationId=${intake.medicationId}, intakeIndex=${intake.blisterIndex}`
+				);
 				continue;
 			}
 
@@ -519,10 +532,11 @@ export async function checkAndSendIntakeRemindersForUser(
 
 	const now = new Date();
 	const state = loadIntakeReminderState(logger);
-	const trackedDoses = await db
+	const trackedDoseRows = await db
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, settings.userId), eq(doseTracking.dismissed, false)));
+	const trackedDoses = await filterScheduledDoseRows(db, settings.userId, trackedDoseRows);
 	const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
 		db,
 		settings.userId,
@@ -726,7 +740,7 @@ export async function checkAndSendIntakeRemindersForUser(
 	if (settings.skipRemindersForTakenDoses) {
 		const beforeFilterCount = remindersToSend.length;
 		// Query doses marked as taken today (takenAt is timestamp, stored as seconds since epoch)
-		const takenToday = await db
+		const takenTodayRows = await db
 			.select()
 			.from(doseTracking)
 			.where(
@@ -736,6 +750,7 @@ export async function checkAndSendIntakeRemindersForUser(
 					lte(doseTracking.takenAt, todayEnd)
 				)
 			);
+		const takenToday = await filterScheduledDoseRows(db, settings.userId, takenTodayRows);
 
 		const takenDoseIds = new Set(takenToday.map((d) => d.doseId));
 

--- a/backend/src/services/planner-demand.ts
+++ b/backend/src/services/planner-demand.ts
@@ -3,7 +3,7 @@ import { db } from "../db/client.js";
 import { doseTracking, medications, userSettings } from "../db/schema.js";
 import { isAmountBasedPackageType, isTubePackageType, normalizePackageType } from "../utils/package-profiles.js";
 import { normalizeIntakeUsageForStock, normalizeMedicationSchedule } from "../utils/scheduler-utils.js";
-import { getActiveAsNeededStockEffectsMilli } from "./as-needed-intakes-service.js";
+import { filterScheduledDoseRows, getActiveAsNeededStockEffectsMilli } from "./as-needed-intakes-service.js";
 import { computeMedicationCurrentStock } from "./current-stock.js";
 import { calculateUsageInRange, parseIntakesWithUnits } from "./medications-service.js";
 
@@ -60,10 +60,11 @@ export async function calculatePlannerDemandRows(options: PlannerDemandOptions):
 		.where(eq(userSettings.userId, userId));
 	const stockCalculationMode = settingsRow?.stockCalculationMode === "manual" ? "manual" : "automatic";
 
-	const takenDoses = await db
+	const takenDoseRows = await db
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, userId), eq(doseTracking.dismissed, false)));
+	const takenDoses = await filterScheduledDoseRows(db, userId, takenDoseRows);
 	const asNeededEffects = await getActiveAsNeededStockEffectsMilli(
 		db,
 		userId,

--- a/backend/src/services/reminder-scheduler.ts
+++ b/backend/src/services/reminder-scheduler.ts
@@ -33,6 +33,7 @@ import {
 	normalizeMedicationSchedule,
 	parseLocalDateTime,
 } from "../utils/scheduler-utils.js";
+import { filterScheduledDoseRows } from "./as-needed-intakes-service.js";
 import {
 	buildPrescriptionReminderPushNotification,
 	buildStockReminderPushNotification,
@@ -141,10 +142,11 @@ async function getMedicationsNeedingReminder(
 		.where(and(eq(medications.userId, userId), eq(medications.isObsolete, false)))
 		.orderBy(medications.id);
 
-	const takenDoseRows = await db
+	const allTakenDoseRows = await db
 		.select()
 		.from(doseTracking)
 		.where(and(eq(doseTracking.userId, userId), eq(doseTracking.dismissed, false)));
+	const takenDoseRows = await filterScheduledDoseRows(db, userId, allTakenDoseRows);
 
 	const takenDoseIdsByMed = new Map<number, Set<string>>();
 	const takenDoseTimestamps = new Map<string, number>();

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -230,18 +230,15 @@ describe.sequential("as-needed intake service", () => {
 		["ended", { endDate: "2000-01-01" }, undefined, "NOT_ELIGIBLE"],
 		["obsolete", { isObsolete: true }, undefined, "NOT_ELIGIBLE"],
 		["unassigned person", { people: ["Ava"] }, "Ben", "INVALID_PERSON"],
-	] as const)(
-		"rejects %s medication eligibility without an anchor or event",
-		async (_case, options, personName, code) => {
-			const medicationId = await seedMedication(options);
-			await expectCode(
-				createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
-				code
-			);
-			expect(await eventCount()).toBe(0);
-			expect((await db.select().from(doseTracking)).length).toBe(0);
-		}
-	);
+	] as const)("rejects %s medication eligibility without an anchor or event", async (_case, options, personName, code) => {
+		const medicationId = await seedMedication(options);
+		await expectCode(
+			createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
+			code
+		);
+		expect(await eventCount()).toBe(0);
+		expect((await db.select().from(doseTracking)).length).toBe(0);
+	});
 
 	it.each([
 		["insufficient stock", { stock: 1 }, 2, "INSUFFICIENT_STOCK"],

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createClient } from "@libsql/client";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate } from "drizzle-orm/libsql/migrator";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -26,7 +27,9 @@ const [{ db, migrationsReady }, schema, service] = await Promise.all([
 const { asNeededIntakeEvents, doseTracking, medications, userSettings, users } = schema;
 const {
 	createAsNeededIntake,
+	filterScheduledDoseRows,
 	getActiveAsNeededStockEffectMilli,
+	getAsNeededAnchorDoseIds,
 	getActiveAsNeededStockEffectsMilli,
 	reverseAsNeededIntake,
 } = service;
@@ -202,20 +205,43 @@ describe.sequential("as-needed intake service", () => {
 		expect(await getActiveAsNeededStockEffectMilli(db, 1, topicalId)).toBe(0);
 	});
 
+	it("identifies anchors only through the companion relation and owner boundary", async () => {
+		const medicationId = await seedMedication();
+		const event = await createAsNeededIntake({ userId: 1, medicationId, quantity: 1, idempotencyKey: intentKey() });
+		const scheduledLookingAnchor = `1-0-1735344000000`;
+		const [ordinary] = await db.insert(doseTracking).values({ userId: 1, doseId: scheduledLookingAnchor }).returning();
+		const [fakePrefix] = await db
+			.insert(doseTracking)
+			.values({ userId: 1, doseId: "as-needed:untrusted-prefix" })
+			.returning();
+		const rows = await db.select().from(doseTracking).where(eq(doseTracking.userId, 1));
+		expect((await getAsNeededAnchorDoseIds(db, 1)).has(`as-needed:${event.eventId}`)).toBe(true);
+		expect(await filterScheduledDoseRows(db, 1, rows)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: ordinary.id }),
+				expect.objectContaining({ id: fakePrefix.id }),
+			])
+		);
+		expect(await getAsNeededAnchorDoseIds(db, 2, [`as-needed:${event.eventId}`])).toEqual(new Set());
+	});
+
 	it.each([
 		["scheduled", { intakes: [{ usage: 1, every: 1, start: "2099-01-01T08:00:00" }] }, undefined, "NOT_ELIGIBLE"],
 		["ended", { endDate: "2000-01-01" }, undefined, "NOT_ELIGIBLE"],
 		["obsolete", { isObsolete: true }, undefined, "NOT_ELIGIBLE"],
 		["unassigned person", { people: ["Ava"] }, "Ben", "INVALID_PERSON"],
-	] as const)("rejects %s medication eligibility without an anchor or event", async (_case, options, personName, code) => {
-		const medicationId = await seedMedication(options);
-		await expectCode(
-			createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
-			code
-		);
-		expect(await eventCount()).toBe(0);
-		expect((await db.select().from(doseTracking)).length).toBe(0);
-	});
+	] as const)(
+		"rejects %s medication eligibility without an anchor or event",
+		async (_case, options, personName, code) => {
+			const medicationId = await seedMedication(options);
+			await expectCode(
+				createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
+				code
+			);
+			expect(await eventCount()).toBe(0);
+			expect((await db.select().from(doseTracking)).length).toBe(0);
+		}
+	);
 
 	it.each([
 		["insufficient stock", { stock: 1 }, 2, "INSUFFICIENT_STOCK"],

--- a/backend/src/test/doses.test.ts
+++ b/backend/src/test/doses.test.ts
@@ -51,10 +51,15 @@ async function clearTables() {
 	await testClient.execute("DELETE FROM users");
 }
 
-async function insertActiveAsNeededEffect(userId: number, medicationId: number, effectMilli: number) {
+async function insertActiveAsNeededEffect(
+	userId: number,
+	medicationId: number,
+	effectMilli: number,
+	doseId = `as-needed:dose-guard-${medicationId}`
+) {
 	const anchor = await testClient.execute({
 		sql: "INSERT INTO dose_tracking (user_id, dose_id) VALUES (?, ?) RETURNING id",
-		args: [userId, `as-needed:dose-guard-${medicationId}`],
+		args: [userId, doseId],
 	});
 	await testClient.execute({
 		sql: "INSERT INTO as_needed_intake_events (event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint, occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli) VALUES (?, ?, ?, ?, 'key', 'fingerprint', 1, 1, ?, 'pills', ?)",
@@ -425,6 +430,23 @@ describe("Dose Tracking API", () => {
 				])
 			);
 		});
+
+		it("filters a companion anchor even when its ID looks scheduled, while preserving ordinary rows", async () => {
+			const scheduledLookingAnchor = "1-0-1735344000000";
+			const ordinaryScheduledDose = "1-0-1735430400000";
+			await insertMedication({ id: 1, userId });
+			await insertActiveAsNeededEffect(userId, 1, 1000, scheduledLookingAnchor);
+			await insertDose({ userId, doseId: ordinaryScheduledDose });
+
+			const response = await app.inject({
+				method: "GET",
+				url: "/doses/taken",
+				headers: { cookie: cookieHeader },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json()).toEqual({ doses: [expect.objectContaining({ doseId: ordinaryScheduledDose })] });
+		});
 	});
 
 	describe("DELETE /doses/taken/:doseId", () => {
@@ -476,6 +498,30 @@ describe("Dose Tracking API", () => {
 
 			expect(response.statusCode).toBe(200);
 			expect(response.json()).toEqual({ success: true });
+		});
+
+		it("rejects a companion anchor without mutating its journal row", async () => {
+			const anchorDoseId = "1-0-1735344000000";
+			await insertMedication({ id: 1, userId });
+			await insertActiveAsNeededEffect(userId, 1, 1000, anchorDoseId);
+
+			for (const request of [
+				{ method: "POST", url: "/doses/taken", payload: { doseId: anchorDoseId } },
+				{ method: "POST", url: "/doses/skip", payload: { doseId: anchorDoseId } },
+				{ method: "POST", url: "/doses/dismiss", payload: { doseIds: [anchorDoseId] } },
+				{ method: "DELETE", url: `/doses/taken/${encodeURIComponent(anchorDoseId)}` },
+				{ method: "DELETE", url: `/doses/skip/${encodeURIComponent(anchorDoseId)}` },
+			] as const) {
+				const response = await app.inject({ ...request, headers: { cookie: cookieHeader } });
+				expect(response.statusCode).toBe(400);
+				expect(response.json()).toMatchObject({ code: "INVALID_DOSE" });
+			}
+
+			const rows = await testClient.execute({
+				sql: "SELECT dismissed FROM dose_tracking WHERE user_id = ? AND dose_id = ?",
+				args: [userId, anchorDoseId],
+			});
+			expect(rows.rows).toEqual([expect.objectContaining({ dismissed: 0 })]);
 		});
 	});
 

--- a/backend/src/test/intake-reminder-scheduler-actions.test.ts
+++ b/backend/src/test/intake-reminder-scheduler-actions.test.ts
@@ -49,7 +49,9 @@ vi.mock("../services/notification-actions-service.js", () => ({
 }));
 
 vi.mock("../services/as-needed-intakes-service.js", () => ({
+	filterScheduledDoseRows: async <T>(_: unknown, __: number, rows: T[]) => rows,
 	getActiveAsNeededStockEffectsMilli: getActiveAsNeededStockEffectsMilliMock,
+	getAsNeededAnchorDoseIds: async () => new Set<string>(),
 }));
 
 vi.mock("../services/notifications/delivery.js", () => ({

--- a/backend/src/test/intake-reminder-scheduler.test.ts
+++ b/backend/src/test/intake-reminder-scheduler.test.ts
@@ -14,7 +14,9 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("../services/as-needed-intakes-service.js", () => ({
+	filterScheduledDoseRows: async <T>(_: unknown, __: number, rows: T[]) => rows,
 	getActiveAsNeededStockEffectsMilli: getActiveAsNeededStockEffectsMilliMock,
+	getAsNeededAnchorDoseIds: async () => new Set<string>(),
 }));
 
 function createLogger() {

--- a/backend/src/utils/dose-id.ts
+++ b/backend/src/utils/dose-id.ts
@@ -7,6 +7,8 @@ export type ParsedDoseId = {
 	personSuffix: string | null;
 };
 
+// This parser validates scheduled-dose syntax only. Persisted anchor classification must use the
+// as_needed_intake_events companion relation because an anchor may intentionally match this syntax.
 export function parseDoseId(doseId: string): ParsedDoseId | null {
 	const match = doseIdPattern.exec(doseId);
 	if (!match) {


### PR DESCRIPTION
Closes #1026

## Summary

- use companion-table ownership as the sole authority for reserved as-needed anchor detection
- filter or deny reserved anchors across legacy dose CRUD, skip/dismiss/bulk, notifications, reminders, sharing, planning, stock, journal/history, reports, and legacy export paths
- retain generic non-disclosing cross-owner behavior; planned-looking identifiers without a companion remain ordinary legacy doses

## Scope boundary

Backend-only Slice 3D. No schema change, public event route, frontend work, or v1.9 portability work. This follows #1022 and unlocks Slice 4 / #1015.

## Validation

- focused coverage: 13 files, 163 tests
- full backend suite split: 484 + 440 = 924 tests
- direct Biome on every changed file
- root lint, check, build, and diff check