### PR TITLE
feat: add as-needed intake portability export v1.9

### DIFF
--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -6,11 +6,20 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db } from "../db/client.js";
 import { getDataDir } from "../db/path-utils.js";
-import { doseTracking, intakeJournal, medications, refillHistory, shareTokens, userSettings } from "../db/schema.js";
+import {
+	asNeededIntakeEvents,
+	doseTracking,
+	intakeJournal,
+	medications,
+	refillHistory,
+	shareTokens,
+	userSettings,
+} from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
 import { filterScheduledDoseRows } from "../services/as-needed-intakes-service.js";
 import {
+	listAsNeededIntakeJournalExportPayloadsForUser,
 	listIntakeJournalExportPayloadsForUser,
 	restoreIntakeJournalForImportedDose,
 } from "../services/intake-journal-export.js";
@@ -36,7 +45,7 @@ const IMAGES_DIR = resolve(getDataDir(), "images");
 // =============================================================================
 // Export Format Version (bump this when format changes)
 // =============================================================================
-const EXPORT_VERSION = "1.8";
+const EXPORT_VERSION = "1.9";
 
 const currentExportVersion = parseExportVersion(EXPORT_VERSION);
 
@@ -60,8 +69,23 @@ function isValidDateLikeString(value: string): boolean {
 	return !Number.isNaN(new Date(value).getTime());
 }
 
+function toRequiredIsoString(value: Date | string | number, field: string): string {
+	const parsed = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(parsed.getTime())) {
+		throw new Error(`Cannot export invalid as-needed intake ${field}`);
+	}
+	return parsed.toISOString();
+}
+
+function stockCutoffToIsoString(value: number): string | null {
+	if (value === 0) return null;
+	return toRequiredIsoString(value * 1000, "stock cutoff timestamp");
+}
+
 const dateLikeStringSchema = z.string().refine(isValidDateLikeString, { message: "Invalid date" });
 const nullableDateLikeStringSchema = dateLikeStringSchema.nullable().optional();
+const requiredNullableDateLikeStringSchema = dateLikeStringSchema.nullable();
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 
 // =============================================================================
 // Zod Schemas for Import Validation
@@ -154,6 +178,50 @@ const shareLinkSchema = z.object({
 	regenerateToken: z.boolean().default(true),
 });
 
+const asNeededIntakeExportSchema = z
+	.object({
+		eventId: z.string().uuid(),
+		medicationRef: z.string().min(1),
+		idempotencyKeyHash: sha256Schema,
+		requestFingerprint: sha256Schema,
+		occurredAt: dateLikeStringSchema,
+		recordedAt: dateLikeStringSchema,
+		quantityMilli: z.number().int().positive(),
+		quantityUnit: z.enum(["pills", "ml", "puffs", "injections", "application"]),
+		person: z.string().max(100).nullable(),
+		source: z.literal("owner_as_needed"),
+		status: z.enum(["active", "reversed"]),
+		stockEffectMilli: z.number().int().nonnegative(),
+		stockEffectReason: z.enum(["applied", "non_measurable", "before_correction", "superseded_by_correction"]),
+		stockCutoffAt: requiredNullableDateLikeStringSchema,
+		replacementForEventId: z.string().uuid().nullable(),
+		reversedAt: requiredNullableDateLikeStringSchema,
+		reversalIdempotencyKeyHash: sha256Schema.nullable(),
+		revision: z.number().int().min(1),
+		journalNote: z.string().max(4000).nullable(),
+		journalMood: z.enum(INTAKE_MOODS).nullable(),
+		journalCreatedAt: requiredNullableDateLikeStringSchema,
+		journalUpdatedAt: requiredNullableDateLikeStringSchema,
+	})
+	.superRefine((event, context) => {
+		if (event.status === "active" && event.reversedAt !== null) {
+			context.addIssue({ code: "custom", path: ["reversedAt"], message: "Active event cannot have reversedAt" });
+		}
+		if (event.status === "reversed" && event.reversedAt === null) {
+			context.addIssue({ code: "custom", path: ["reversedAt"], message: "Reversed event requires reversedAt" });
+		}
+		if (
+			event.quantityUnit === "application" &&
+			(event.quantityMilli !== 1000 || event.stockEffectMilli !== 0 || event.stockEffectReason !== "non_measurable")
+		) {
+			context.addIssue({
+				code: "custom",
+				path: ["quantityUnit"],
+				message: "Application events require quantity 1 and zero non-measurable stock effect",
+			});
+		}
+	});
+
 const settingsSchemaBase = z.object({
 	timezone: z.string().default(""),
 	// Email notifications
@@ -197,18 +265,30 @@ const importSettingsSchema = settingsSchemaBase
 	})
 	.optional();
 
-const importDataSchema = z.object({
-	version: z.string().refine(isSupportedExportVersion, {
-		message: `Unsupported export format version. Supported up to ${EXPORT_VERSION}.`,
-	}),
-	exportedAt: dateLikeStringSchema,
-	includeSensitiveData: z.boolean().default(false),
-	medications: z.array(medicationExportSchema).default([]),
-	doseHistory: z.array(doseHistorySchema).default([]),
-	refillHistory: z.array(refillHistoryExportSchema).default([]),
-	settings: importSettingsSchema,
-	shareLinks: z.array(shareLinkSchema).default([]),
-});
+const importDataSchema = z
+	.object({
+		version: z.string().refine(isSupportedExportVersion, {
+			message: `Unsupported export format version. Supported up to ${EXPORT_VERSION}.`,
+		}),
+		exportedAt: dateLikeStringSchema,
+		includeSensitiveData: z.boolean().default(false),
+		medications: z.array(medicationExportSchema).default([]),
+		doseHistory: z.array(doseHistorySchema).default([]),
+		asNeededIntakes: z.array(asNeededIntakeExportSchema).optional(),
+		refillHistory: z.array(refillHistoryExportSchema).default([]),
+		settings: importSettingsSchema,
+		shareLinks: z.array(shareLinkSchema).default([]),
+	})
+	.superRefine((data, context) => {
+		if (parseExportVersion(data.version)?.minor === 9 && data.asNeededIntakes === undefined) {
+			context.addIssue({
+				code: "custom",
+				path: ["asNeededIntakes"],
+				message: "Export format 1.9 requires asNeededIntakes",
+			});
+		}
+	})
+	.transform((data) => ({ ...data, asNeededIntakes: data.asNeededIntakes ?? [] }));
 
 const exportQuerystringSchema = {
 	type: "object",
@@ -226,6 +306,7 @@ const exportResponseSchema = {
 		includeSensitiveData: { type: "boolean" },
 		medications: { type: "array", items: { type: "object", additionalProperties: true } },
 		doseHistory: { type: "array", items: { type: "object", additionalProperties: true } },
+		asNeededIntakes: { type: "array", items: { type: "object", additionalProperties: true } },
 		refillHistory: { type: "array", items: { type: "object", additionalProperties: true } },
 		settings: { type: "object", additionalProperties: true },
 		shareLinks: { type: "array", items: { type: "object", additionalProperties: true } },
@@ -241,12 +322,13 @@ const importBodyOpenApiSchema = {
 		includeSensitiveData: { type: "boolean" },
 		medications: { type: "array", items: { type: "object", additionalProperties: true } },
 		doseHistory: { type: "array", items: { type: "object", additionalProperties: true } },
+		asNeededIntakes: { type: "array", items: { type: "object", additionalProperties: true } },
 		refillHistory: { type: "array", items: { type: "object", additionalProperties: true } },
 		settings: { type: "object", additionalProperties: true },
 		shareLinks: { type: "array", items: { type: "object", additionalProperties: true } },
 	},
 	example: {
-		version: "1.7",
+		version: "1.9",
 		exportedAt: "2026-03-11T10:15:00.000Z",
 		includeSensitiveData: true,
 		medications: [
@@ -281,6 +363,7 @@ const importBodyOpenApiSchema = {
 				journalUpdatedAt: "2026-03-11T08:05:00.000Z",
 			},
 		],
+		asNeededIntakes: [],
 		refillHistory: [{ packsAdded: 1, loosePillsAdded: 4, quantityAdded: 34, refillDate: "2026-03-10T12:00:00.000Z" }],
 		settings: { language: "en", stockCalculationMode: "automatic" },
 		shareLinks: [{ takenBy: "Daniel", scheduleDays: 14 }],
@@ -302,6 +385,7 @@ const importPreviewResponseSchema = {
 					properties: {
 						medications: { type: "integer" },
 						doseHistory: { type: "integer" },
+						asNeededIntakes: { type: "integer" },
 						refillHistory: { type: "integer" },
 						shareLinks: { type: "integer" },
 						journalEntries: { type: "integer" },
@@ -314,6 +398,7 @@ const importPreviewResponseSchema = {
 					properties: {
 						medications: { type: "integer" },
 						doseHistory: { type: "integer" },
+						asNeededIntakes: { type: "integer" },
 						refillHistory: { type: "integer" },
 						shareLinks: { type: "integer" },
 						hasSettings: { type: "boolean" },
@@ -481,15 +566,23 @@ function buildImportPreview(
 	currentData: {
 		medications: number;
 		doseHistory: number;
+		asNeededIntakes: number;
 		refillHistory: number;
 		shareLinks: number;
 		hasSettings: boolean;
 	}
 ) {
-	const journalEntries = importData.doseHistory.filter(
+	const scheduledJournalEntries = importData.doseHistory.filter(
 		(dose) =>
 			(typeof dose.journalNote === "string" && dose.journalNote.trim()) ||
 			normalizeIntakeMood(dose.journalMood) !== null
+	).length;
+	const asNeededJournalEntries = importData.asNeededIntakes.filter(
+		(event) =>
+			event.journalNote !== null ||
+			event.journalMood !== null ||
+			event.journalCreatedAt !== null ||
+			event.journalUpdatedAt !== null
 	).length;
 	const imageCount = importData.medications.filter(
 		(med) => typeof med.image === "string" && med.image.startsWith("data:")
@@ -502,9 +595,10 @@ function buildImportPreview(
 		incoming: {
 			medications: importData.medications.length,
 			doseHistory: importData.doseHistory.length,
+			asNeededIntakes: importData.asNeededIntakes.length,
 			refillHistory: importData.refillHistory.length,
 			shareLinks: importData.shareLinks.length,
-			journalEntries,
+			journalEntries: scheduledJournalEntries + asNeededJournalEntries,
 			imageCount,
 			hasSettings: Boolean(importData.settings),
 		},
@@ -513,6 +607,7 @@ function buildImportPreview(
 			replacesExistingData:
 				currentData.medications > 0 ||
 				currentData.doseHistory > 0 ||
+				currentData.asNeededIntakes > 0 ||
 				currentData.refillHistory > 0 ||
 				currentData.shareLinks > 0 ||
 				currentData.hasSettings,
@@ -718,6 +813,51 @@ export async function exportRoutes(app: FastifyInstance) {
 				})
 				.filter((d): d is NonNullable<typeof d> => d !== null);
 
+			const asNeededEvents = await db
+				.select()
+				.from(asNeededIntakeEvents)
+				.where(eq(asNeededIntakeEvents.userId, userId))
+				.orderBy(asNeededIntakeEvents.id);
+			const eventIdByInternalId = new Map(asNeededEvents.map((event) => [event.id, event.eventId]));
+			const asNeededJournalPayloads = await listAsNeededIntakeJournalExportPayloadsForUser(userId);
+			const exportAsNeededIntakes = asNeededEvents.map((event) => {
+				const medicationRef = medIdToExportId.get(event.medicationId);
+				if (!medicationRef) {
+					throw new Error("Cannot export as-needed intake with missing medication");
+				}
+
+				const replacementForEventId = event.replacesEventId ? eventIdByInternalId.get(event.replacesEventId) : null;
+				if (event.replacesEventId && !replacementForEventId) {
+					throw new Error("Cannot export as-needed intake with missing replacement target");
+				}
+
+				const journal = asNeededJournalPayloads.get(event.doseTrackingId);
+				return asNeededIntakeExportSchema.parse({
+					eventId: event.eventId,
+					medicationRef,
+					idempotencyKeyHash: event.idempotencyKeyHash,
+					requestFingerprint: event.requestFingerprint,
+					occurredAt: toRequiredIsoString(event.occurredAt, "occurred timestamp"),
+					recordedAt: toRequiredIsoString(event.recordedAt, "recorded timestamp"),
+					quantityMilli: event.quantityMilli,
+					quantityUnit: event.quantityUnit,
+					person: event.personName || null,
+					source: event.source,
+					status: event.status,
+					stockEffectMilli: event.stockEffectMilli,
+					stockEffectReason: event.stockEffectReason,
+					stockCutoffAt: stockCutoffToIsoString(event.stockCutoffAt),
+					replacementForEventId,
+					reversedAt: event.reversedAt ? toRequiredIsoString(event.reversedAt, "reversed timestamp") : null,
+					reversalIdempotencyKeyHash: event.reversalIdempotencyKeyHash,
+					revision: event.revision,
+					journalNote: journal?.journalNote ?? null,
+					journalMood: journal?.journalMood ?? null,
+					journalCreatedAt: journal?.journalCreatedAt ?? null,
+					journalUpdatedAt: journal?.journalUpdatedAt ?? null,
+				});
+			});
+
 			// 3. Load user settings
 			const [settings] = await db.select().from(userSettings).where(eq(userSettings.userId, userId));
 
@@ -837,6 +977,7 @@ export async function exportRoutes(app: FastifyInstance) {
 				includeSensitiveData: includeSensitive,
 				medications: exportMedications,
 				doseHistory: exportDoseHistory,
+				asNeededIntakes: exportAsNeededIntakes,
 				refillHistory: exportRefillHistory,
 				settings: exportSettings,
 				shareLinks: exportShareLinks,
@@ -893,14 +1034,24 @@ export async function exportRoutes(app: FastifyInstance) {
 				});
 			}
 
-			const [existingMeds, existingDoseHistory, existingRefillHistory, existingShareLinks, existingSettings] =
-				await Promise.all([
-					db.select({ id: medications.id }).from(medications).where(eq(medications.userId, userId)),
-					db.select({ id: doseTracking.id }).from(doseTracking).where(eq(doseTracking.userId, userId)),
-					db.select({ id: refillHistory.id }).from(refillHistory).where(eq(refillHistory.userId, userId)),
-					db.select({ id: shareTokens.id }).from(shareTokens).where(eq(shareTokens.userId, userId)),
-					db.select({ id: userSettings.id }).from(userSettings).where(eq(userSettings.userId, userId)),
-				]);
+			const [
+				existingMeds,
+				existingDoseHistory,
+				existingAsNeededIntakes,
+				existingRefillHistory,
+				existingShareLinks,
+				existingSettings,
+			] = await Promise.all([
+				db.select({ id: medications.id }).from(medications).where(eq(medications.userId, userId)),
+				db.select({ id: doseTracking.id }).from(doseTracking).where(eq(doseTracking.userId, userId)),
+				db
+					.select({ id: asNeededIntakeEvents.id })
+					.from(asNeededIntakeEvents)
+					.where(eq(asNeededIntakeEvents.userId, userId)),
+				db.select({ id: refillHistory.id }).from(refillHistory).where(eq(refillHistory.userId, userId)),
+				db.select({ id: shareTokens.id }).from(shareTokens).where(eq(shareTokens.userId, userId)),
+				db.select({ id: userSettings.id }).from(userSettings).where(eq(userSettings.userId, userId)),
+			]);
 			const scheduledDoseHistory = await filterScheduledDoseRows(db, userId, existingDoseHistory);
 
 			return {
@@ -908,6 +1059,7 @@ export async function exportRoutes(app: FastifyInstance) {
 				preview: buildImportPreview(parsed.data, {
 					medications: existingMeds.length,
 					doseHistory: scheduledDoseHistory.length,
+					asNeededIntakes: existingAsNeededIntakes.length,
 					refillHistory: existingRefillHistory.length,
 					shareLinks: existingShareLinks.length,
 					hasSettings: existingSettings.length > 0,
@@ -939,6 +1091,7 @@ export async function exportRoutes(app: FastifyInstance) {
 								properties: {
 									medications: { type: "integer" },
 									doseHistory: { type: "integer" },
+									asNeededIntakes: { type: "integer" },
 									refillHistory: { type: "integer" },
 									settings: { type: "integer" },
 									shareLinks: { type: "integer" },
@@ -972,6 +1125,15 @@ export async function exportRoutes(app: FastifyInstance) {
 					details: { _errors: validationIssues.slice(0, 10) },
 				});
 			}
+			if (importData.asNeededIntakes.length > 0) {
+				return reply.status(400).send({
+					error: "As-needed intake restore is not available in this release",
+					code: "INVALID_IMPORT_DATA",
+					details: {
+						_errors: ["This v1.9 export contains as-needed intakes and cannot be imported without loss"],
+					},
+				});
+			}
 
 			// Existing image files are removed only after the DB import commits.
 			const existingMeds = await db.select().from(medications).where(eq(medications.userId, userId));
@@ -982,6 +1144,7 @@ export async function exportRoutes(app: FastifyInstance) {
 			const imported = {
 				medications: 0,
 				doseHistory: 0,
+				asNeededIntakes: 0,
 				refillHistory: 0,
 				settings: 0,
 				shareLinks: 0,

--- a/backend/src/services/intake-journal-export.ts
+++ b/backend/src/services/intake-journal-export.ts
@@ -12,6 +12,15 @@ export type IntakeJournalExportPayload = {
 	journalUpdatedAt?: string | null;
 };
 
+function toExportPayload(journal: typeof intakeJournal.$inferSelect): IntakeJournalExportPayload {
+	return {
+		journalNote: journal.note,
+		journalMood: normalizeIntakeMood(journal.mood),
+		journalCreatedAt: toIsoStringOrNull(journal.createdAt),
+		journalUpdatedAt: toIsoStringOrNull(journal.updatedAt),
+	};
+}
+
 function toIsoStringOrNull(value: Date | string | number | null | undefined): string | null {
 	if (!value) {
 		return null;
@@ -55,17 +64,23 @@ export async function listIntakeJournalExportPayloadsForUser(
 		)
 		.where(and(eq(intakeJournal.userId, userId), eq(doseTracking.userId, userId), isNull(asNeededIntakeEvents.id)));
 
-	return new Map(
-		rows.map(({ journal }) => [
-			journal.doseTrackingId,
-			{
-				journalNote: journal.note,
-				journalMood: normalizeIntakeMood(journal.mood),
-				journalCreatedAt: toIsoStringOrNull(journal.createdAt),
-				journalUpdatedAt: toIsoStringOrNull(journal.updatedAt),
-			},
-		])
-	);
+	return new Map(rows.map(({ journal }) => [journal.doseTrackingId, toExportPayload(journal)]));
+}
+
+export async function listAsNeededIntakeJournalExportPayloadsForUser(
+	userId: number
+): Promise<Map<number, IntakeJournalExportPayload>> {
+	const rows = await db
+		.select({ journal: intakeJournal })
+		.from(intakeJournal)
+		.innerJoin(doseTracking, eq(doseTracking.id, intakeJournal.doseTrackingId))
+		.innerJoin(
+			asNeededIntakeEvents,
+			and(eq(asNeededIntakeEvents.doseTrackingId, doseTracking.id), eq(asNeededIntakeEvents.userId, userId))
+		)
+		.where(and(eq(intakeJournal.userId, userId), eq(doseTracking.userId, userId)));
+
+	return new Map(rows.map(({ journal }) => [journal.doseTrackingId, toExportPayload(journal)]));
 }
 
 export async function restoreIntakeJournalForImportedDose(input: {

--- a/backend/src/test/intake-journal-routes.test.ts
+++ b/backend/src/test/intake-journal-routes.test.ts
@@ -49,6 +49,7 @@ const { intakeJournalRoutes } = await import("../routes/intake-journal.js");
 
 async function clearTables() {
 	await testClient.execute("DELETE FROM intake_journal");
+	await testClient.execute("DELETE FROM as_needed_intake_events");
 	await testClient.execute("DELETE FROM refill_history");
 	await testClient.execute("DELETE FROM dose_tracking");
 	await testClient.execute("DELETE FROM share_tokens");
@@ -121,6 +122,41 @@ async function seedTrackedDose(options: {
 	});
 
 	return Number(result.rows[0].id);
+}
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+const HASH_C = "c".repeat(64);
+const EVENT_A = "00000000-0000-4000-8000-000000000001";
+const EVENT_B = "00000000-0000-4000-8000-000000000002";
+const EVENT_C = "00000000-0000-4000-8000-000000000003";
+
+function asNeededImportEvent(overrides: Record<string, unknown> = {}) {
+	return {
+		eventId: EVENT_A,
+		medicationRef: "med-1",
+		idempotencyKeyHash: HASH_A,
+		requestFingerprint: HASH_B,
+		occurredAt: "2026-02-05T08:00:00.000Z",
+		recordedAt: "2026-02-05T08:01:00.000Z",
+		quantityMilli: 1000,
+		quantityUnit: "pills",
+		person: null,
+		source: "owner_as_needed",
+		status: "active",
+		stockEffectMilli: 1000,
+		stockEffectReason: "applied",
+		stockCutoffAt: null,
+		replacementForEventId: null,
+		reversedAt: null,
+		reversalIdempotencyKeyHash: null,
+		revision: 1,
+		journalNote: null,
+		journalMood: null,
+		journalCreatedAt: null,
+		journalUpdatedAt: null,
+		...overrides,
+	};
 }
 
 describe("Intake journal routes", () => {
@@ -269,6 +305,276 @@ describe("Intake journal routes", () => {
 
 		expect(emptyHistoryResponse.statusCode).toBe(200);
 		expect(emptyHistoryResponse.json().entries).toEqual([]);
+	});
+
+	it("exports owner as-needed events in v1.9 without leaking anchors into scheduled history", async () => {
+		const userId = await createTestUser(testClient, { username: "as-needed-export-owner" });
+		const otherUserId = await createTestUser(testClient, { username: "as-needed-export-other" });
+		const sessionCookie = await buildTestSessionCookie(app, userId, "as-needed-export-owner");
+		const medicationId = await seedMedication({ userId, name: "As-needed export medication" });
+		const otherMedicationId = await seedMedication({ userId: otherUserId, name: "Other owner medication" });
+		const scheduledFor = "2026-02-05T07:00:00.000Z";
+		await seedTrackedDose({
+			userId,
+			doseId: `${medicationId}-0-${new Date(scheduledFor).getTime()}-Daniel`,
+			takenAt: new Date("2026-02-05T07:02:00.000Z"),
+			markedBy: "Daniel",
+		});
+		const firstAnchorId = await seedTrackedDose({
+			userId,
+			doseId: `as-needed:${EVENT_A}`,
+			takenAt: new Date("2026-02-05T08:01:00.000Z"),
+			markedBy: "Daniel",
+		});
+		const replacementAnchorId = await seedTrackedDose({
+			userId,
+			doseId: `as-needed:${EVENT_B}`,
+			takenAt: new Date("2026-02-05T09:01:00.000Z"),
+		});
+		const otherAnchorId = await seedTrackedDose({
+			userId: otherUserId,
+			doseId: `as-needed:${EVENT_C}`,
+			takenAt: new Date("2026-02-05T10:01:00.000Z"),
+		});
+
+		const firstEvent = await testClient.execute({
+			sql: `INSERT INTO as_needed_intake_events (
+			  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
+			  occurred_at, recorded_at, quantity_milli, quantity_unit, person_name, status, stock_effect_milli,
+			  stock_effect_reason, stock_cutoff_at, reversed_at, reversal_idempotency_key_hash, revision
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+			args: [
+				EVENT_A,
+				userId,
+				medicationId,
+				firstAnchorId,
+				HASH_A,
+				HASH_B,
+				1770278400,
+				1770278460,
+				1500,
+				"pills",
+				"Daniel",
+				"reversed",
+				1500,
+				"superseded_by_correction",
+				1770278700,
+				1770279000,
+				HASH_C,
+				2,
+			],
+		});
+		const firstEventId = Number(firstEvent.rows[0].id);
+		await testClient.execute({
+			sql: `INSERT INTO as_needed_intake_events (
+			  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
+			  occurred_at, recorded_at, quantity_milli, quantity_unit, person_name, stock_effect_milli,
+			  stock_effect_reason, replaces_event_id, revision
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				EVENT_B,
+				userId,
+				medicationId,
+				replacementAnchorId,
+				HASH_B,
+				HASH_C,
+				1770282000,
+				1770282060,
+				1000,
+				"pills",
+				"",
+				0,
+				"before_correction",
+				firstEventId,
+				3,
+			],
+		});
+		await testClient.execute({
+			sql: `INSERT INTO as_needed_intake_events (
+			  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
+			  occurred_at, recorded_at, quantity_milli, quantity_unit
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				EVENT_C,
+				otherUserId,
+				otherMedicationId,
+				otherAnchorId,
+				HASH_C,
+				HASH_A,
+				1770285600,
+				1770285660,
+				1000,
+				"pills",
+			],
+		});
+		await testClient.execute({
+			sql: `INSERT INTO intake_journal (
+			  user_id, dose_tracking_id, medication_id, scheduled_for, mood, note, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				userId,
+				replacementAnchorId,
+				medicationId,
+				1770282000,
+				"neutral",
+				"Replacement note",
+				1770282100,
+				1770282200,
+			],
+		});
+
+		const response = await app.inject({ method: "GET", url: "/export", headers: { cookie: sessionCookie } });
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.version).toBe("1.9");
+		expect(body.doseHistory).toHaveLength(1);
+		expect(body.doseHistory[0]).toEqual(expect.objectContaining({ medicationRef: "med-1", takenByPerson: "Daniel" }));
+		expect(body.asNeededIntakes).toEqual([
+			{
+				eventId: EVENT_A,
+				medicationRef: "med-1",
+				idempotencyKeyHash: HASH_A,
+				requestFingerprint: HASH_B,
+				occurredAt: "2026-02-05T08:00:00.000Z",
+				recordedAt: "2026-02-05T08:01:00.000Z",
+				quantityMilli: 1500,
+				quantityUnit: "pills",
+				person: "Daniel",
+				source: "owner_as_needed",
+				status: "reversed",
+				stockEffectMilli: 1500,
+				stockEffectReason: "superseded_by_correction",
+				stockCutoffAt: "2026-02-05T08:05:00.000Z",
+				replacementForEventId: null,
+				reversedAt: "2026-02-05T08:10:00.000Z",
+				reversalIdempotencyKeyHash: HASH_C,
+				revision: 2,
+				journalNote: null,
+				journalMood: null,
+				journalCreatedAt: null,
+				journalUpdatedAt: null,
+			},
+			{
+				eventId: EVENT_B,
+				medicationRef: "med-1",
+				idempotencyKeyHash: HASH_B,
+				requestFingerprint: HASH_C,
+				occurredAt: "2026-02-05T09:00:00.000Z",
+				recordedAt: "2026-02-05T09:01:00.000Z",
+				quantityMilli: 1000,
+				quantityUnit: "pills",
+				person: null,
+				source: "owner_as_needed",
+				status: "active",
+				stockEffectMilli: 0,
+				stockEffectReason: "before_correction",
+				stockCutoffAt: null,
+				replacementForEventId: EVENT_A,
+				reversedAt: null,
+				reversalIdempotencyKeyHash: null,
+				revision: 3,
+				journalNote: "Replacement note",
+				journalMood: "neutral",
+				journalCreatedAt: "2026-02-05T09:01:40.000Z",
+				journalUpdatedAt: "2026-02-05T09:03:20.000Z",
+			},
+		]);
+	});
+
+	it("requires asNeededIntakes for v1.9 while keeping empty v1.9 and older imports compatible", async () => {
+		const userId = await createTestUser(testClient, { username: "as-needed-import-compatibility" });
+		const sessionCookie = await buildTestSessionCookie(app, userId, "as-needed-import-compatibility");
+		const basePayload = { exportedAt: "2026-02-05T08:00:00.000Z", medications: [], doseHistory: [] };
+
+		const missingV19 = await app.inject({
+			method: "POST",
+			url: "/import",
+			headers: { cookie: sessionCookie },
+			payload: { ...basePayload, version: "1.9" },
+		});
+		expect(missingV19.statusCode).toBe(400);
+
+		const emptyV19 = await app.inject({
+			method: "POST",
+			url: "/import",
+			headers: { cookie: sessionCookie },
+			payload: { ...basePayload, version: "1.9", asNeededIntakes: [] },
+		});
+		expect(emptyV19.statusCode).toBe(200);
+		expect(emptyV19.json().imported).toEqual(expect.objectContaining({ asNeededIntakes: 0 }));
+
+		const olderImport = await app.inject({
+			method: "POST",
+			url: "/import",
+			headers: { cookie: sessionCookie },
+			payload: { ...basePayload, version: "1.8" },
+		});
+		expect(olderImport.statusCode).toBe(200);
+		expect(olderImport.json().imported).toEqual(expect.objectContaining({ asNeededIntakes: 0 }));
+	});
+
+	it("previews v1.9 intake counts and rejects nonempty restores before changing data", async () => {
+		const userId = await createTestUser(testClient, { username: "as-needed-import-rejection" });
+		const sessionCookie = await buildTestSessionCookie(app, userId, "as-needed-import-rejection");
+		const medicationId = await seedMedication({ userId, name: "Existing import medication" });
+		const anchorId = await seedTrackedDose({
+			userId,
+			doseId: `as-needed:${EVENT_A}`,
+			takenAt: new Date("2026-02-05T08:01:00.000Z"),
+		});
+		await testClient.execute({
+			sql: `INSERT INTO as_needed_intake_events (
+			  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
+			  occurred_at, recorded_at, quantity_milli, quantity_unit
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [EVENT_A, userId, medicationId, anchorId, HASH_A, HASH_B, 1770278400, 1770278460, 1000, "pills"],
+		});
+
+		const payload = {
+			version: "1.9",
+			exportedAt: "2026-02-05T08:00:00.000Z",
+			medications: [],
+			doseHistory: [],
+			asNeededIntakes: [asNeededImportEvent({ journalNote: "Imported journal", journalMood: "good" })],
+		};
+		const preview = await app.inject({
+			method: "POST",
+			url: "/import/preview",
+			headers: { cookie: sessionCookie },
+			payload,
+		});
+		expect(preview.statusCode).toBe(200);
+		expect(preview.json().preview).toEqual(
+			expect.objectContaining({
+				incoming: expect.objectContaining({ asNeededIntakes: 1, journalEntries: 1 }),
+				current: expect.objectContaining({ medications: 1, doseHistory: 0, asNeededIntakes: 1 }),
+				warnings: expect.objectContaining({ replacesExistingData: true }),
+			})
+		);
+
+		const rejectedImport = await app.inject({
+			method: "POST",
+			url: "/import",
+			headers: { cookie: sessionCookie },
+			payload,
+		});
+		expect(rejectedImport.statusCode).toBe(400);
+		expect(rejectedImport.json()).toEqual(
+			expect.objectContaining({
+				code: "INVALID_IMPORT_DATA",
+				details: { _errors: ["This v1.9 export contains as-needed intakes and cannot be imported without loss"] },
+			})
+		);
+
+		const [medicationRows, eventRows, doseRows] = await Promise.all([
+			testClient.execute("SELECT name FROM medications WHERE user_id = ?", [userId]),
+			testClient.execute("SELECT event_id FROM as_needed_intake_events WHERE user_id = ?", [userId]),
+			testClient.execute("SELECT dose_id FROM dose_tracking WHERE user_id = ?", [userId]),
+		]);
+		expect(medicationRows.rows).toEqual([expect.objectContaining({ name: "Existing import medication" })]);
+		expect(eventRows.rows).toEqual([expect.objectContaining({ event_id: EVENT_A })]);
+		expect(doseRows.rows).toEqual([expect.objectContaining({ dose_id: `as-needed:${EVENT_A}` })]);
 	});
 
 	it("preserves journal metadata through authenticated export and import", async () => {

--- a/frontend/e2e/export-import.spec.ts
+++ b/frontend/e2e/export-import.spec.ts
@@ -124,7 +124,7 @@ test.describe("Export/import E2E", () => {
 		});
 
 		const nonSensitive = await downloadExportFromSettings(page, { includeSensitive: false });
-		expect(nonSensitive.version).toBe("1.8");
+		expect(nonSensitive.version).toBe("1.9");
 		expect(nonSensitive.includeSensitiveData).toBe(false);
 		expect(nonSensitive.settings?.timezone).toBe("Europe/Berlin");
 		expect(nonSensitive.settings?.upcomingTodayOnly).toBe(true);


### PR DESCRIPTION
Closes #1015

## Summary

- export exact active, reversed, and replacement as-needed intake records with hashes, trusted timing, quantities, effects, cutoffs, revisions, people, and journal context
- exclude reserved anchors from legacy dose history and retain v1.0–v1.8 empty-default compatibility
- add v1.9 preview counts and warnings while rejecting non-empty v1.9 restore before any mutation until #1029 ships

## Scope boundary

Backend-only Slice 4A. No public mutation route or UI; complete validation and all-or-nothing v1.9 restore remain gated on #1029.

## Validation

- focused export/route coverage: 7/7
- full backend suite: 47 files, 927 tests
- CI-identical Biome
- root lint, check, build, and diff check
- owner-scoped export/import behavior reviewed