### PR TITLE
feat: restore as-needed intake portability v1.9

### DIFF
--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -1,10 +1,15 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { extname, isAbsolute, relative, resolve } from "node:path";
-import { INTAKE_MOODS, normalizeIntakeMood } from "@medassist/shared";
-import { eq } from "drizzle-orm";
+import {
+	getAsNeededQuantityProfile,
+	INTAKE_MOODS,
+	normalizeAsNeededQuantityMilli,
+	normalizeIntakeMood,
+} from "@medassist/shared";
+import { and, eq, inArray } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { db } from "../db/client.js";
+import { db, withImmediateWriteTransaction } from "../db/client.js";
 import { getDataDir } from "../db/path-utils.js";
 import {
 	asNeededIntakeEvents,
@@ -618,32 +623,44 @@ function buildImportPreview(
 	};
 }
 
-function collectImportValidationIssues(importData: z.infer<typeof importDataSchema>): string[] {
+const MAX_IMPORT_VALIDATION_ISSUES = 10;
+type ImportData = z.infer<typeof importDataSchema>;
+type ImportedAsNeededIntake = ImportData["asNeededIntakes"][number];
+
+function formatImportSchemaIssues(error: z.ZodError): string[] {
+	return error.issues
+		.slice(0, MAX_IMPORT_VALIDATION_ISSUES)
+		.map((issue) => `${issue.path.length > 0 ? issue.path.join(".") : "root"}: ${issue.message}`);
+}
+
+function hasImportedAsNeededJournal(event: ImportedAsNeededIntake): boolean {
+	return event.journalNote !== null;
+}
+
+function collectImportValidationIssues(importData: ImportData): string[] {
 	const issues: string[] = [];
+	const addIssue = (message: string) => {
+		if (issues.length < MAX_IMPORT_VALIDATION_ISSUES) issues.push(message);
+	};
 	const medicationsByRef = new Map<string, z.infer<typeof medicationExportSchema>>();
-	const duplicateMedicationRefs = new Set<string>();
 
 	for (const med of importData.medications) {
 		if (medicationsByRef.has(med._exportId)) {
-			duplicateMedicationRefs.add(med._exportId);
+			addIssue(`Duplicate medication reference: ${med._exportId}`);
 			continue;
 		}
 		medicationsByRef.set(med._exportId, med);
-	}
-
-	for (const exportId of duplicateMedicationRefs) {
-		issues.push(`Duplicate medication reference: ${exportId}`);
 	}
 
 	const doseKeys = new Set<string>();
 	for (const dose of importData.doseHistory) {
 		const medication = medicationsByRef.get(dose.medicationRef);
 		if (!medication) {
-			issues.push(`Dose history references unknown medication: ${dose.medicationRef}`);
+			addIssue(`Dose history references unknown medication: ${dose.medicationRef}`);
 			continue;
 		}
 		if (dose.scheduleIndex >= medication.schedules.length) {
-			issues.push(`Dose history references unknown schedule index ${dose.scheduleIndex} for ${dose.medicationRef}`);
+			addIssue(`Dose history references unknown schedule index ${dose.scheduleIndex} for ${dose.medicationRef}`);
 		}
 
 		const doseKey = [
@@ -652,16 +669,176 @@ function collectImportValidationIssues(importData: z.infer<typeof importDataSche
 			new Date(dose.scheduledTime).getTime(),
 			dose.takenByPerson ?? "",
 		].join(":");
-		if (doseKeys.has(doseKey)) {
-			issues.push(`Duplicate dose history entry for ${dose.medicationRef}`);
-		}
+		if (doseKeys.has(doseKey)) addIssue(`Duplicate dose history entry for ${dose.medicationRef}`);
 		doseKeys.add(doseKey);
 	}
 
 	for (const refill of importData.refillHistory) {
 		if (!medicationsByRef.has(refill.medicationRef)) {
-			issues.push(`Refill history references unknown medication: ${refill.medicationRef}`);
+			addIssue(`Refill history references unknown medication: ${refill.medicationRef}`);
 		}
+	}
+
+	const eventsById = new Map<string, ImportedAsNeededIntake>();
+	const createKeyHashes = new Set<string>();
+	const reversalKeyHashes = new Set<string>();
+	const replacementTargets = new Set<string>();
+
+	for (const event of importData.asNeededIntakes) {
+		if (eventsById.has(event.eventId)) addIssue("Duplicate as-needed event ID");
+		else eventsById.set(event.eventId, event);
+		if (
+			event.eventId !== event.eventId.toLowerCase() ||
+			(event.replacementForEventId !== null &&
+				event.replacementForEventId !== event.replacementForEventId.toLowerCase())
+		) {
+			addIssue("As-needed event IDs must use canonical lowercase UUIDs");
+		}
+
+		if (createKeyHashes.has(event.idempotencyKeyHash)) addIssue("Duplicate as-needed idempotency key hash");
+		createKeyHashes.add(event.idempotencyKeyHash);
+		if (event.reversalIdempotencyKeyHash) {
+			if (reversalKeyHashes.has(event.reversalIdempotencyKeyHash)) {
+				addIssue("Duplicate as-needed reversal key hash");
+			}
+			reversalKeyHashes.add(event.reversalIdempotencyKeyHash);
+		}
+
+		const medication = medicationsByRef.get(event.medicationRef);
+		if (!medication) {
+			addIssue("As-needed intake references unknown medication");
+			continue;
+		}
+
+		const profile = getAsNeededQuantityProfile({
+			packageType: medication.inventory.packageType,
+			medicationForm: medication.medicationForm,
+			pillForm: medication.pillForm,
+		});
+		if (
+			event.quantityUnit !== profile.unit ||
+			normalizeAsNeededQuantityMilli(event.quantityMilli / 1000, profile) !== event.quantityMilli
+		) {
+			addIssue("As-needed intake quantity does not match the medication package profile");
+		}
+		if (event.person !== null && (event.person.length === 0 || event.person.trim() !== event.person)) {
+			addIssue("As-needed intake person must be canonical or null");
+		}
+
+		const occurredAt = new Date(event.occurredAt).getTime();
+		const recordedAt = new Date(event.recordedAt).getTime();
+		if (recordedAt < occurredAt) addIssue("As-needed intake recordedAt precedes occurredAt");
+		if (
+			[occurredAt, recordedAt, event.reversedAt ? new Date(event.reversedAt).getTime() : 0].some(
+				(timestamp) => timestamp % 1000 !== 0
+			)
+		) {
+			addIssue("As-needed intake timestamps exceed persisted whole-second precision");
+		}
+		if (event.status === "active" && event.reversalIdempotencyKeyHash !== null) {
+			addIssue("Active as-needed intake cannot have reversal metadata");
+		}
+		if (event.status === "reversed" && (event.reversalIdempotencyKeyHash === null || event.revision < 2)) {
+			addIssue("Reversed as-needed intake has incomplete reversal metadata");
+		}
+		if (event.reversedAt && new Date(event.reversedAt).getTime() < occurredAt) {
+			addIssue("As-needed intake reversedAt precedes occurredAt");
+		}
+
+		const hasJournal = hasImportedAsNeededJournal(event);
+		const hasJournalCreatedAt = event.journalCreatedAt !== null;
+		const hasJournalUpdatedAt = event.journalUpdatedAt !== null;
+		if (
+			(event.journalMood !== null && !hasJournal) ||
+			hasJournalCreatedAt !== hasJournalUpdatedAt ||
+			hasJournal !== hasJournalCreatedAt
+		) {
+			addIssue("As-needed intake journal fields are inconsistent");
+		} else if (
+			hasJournalCreatedAt &&
+			new Date(event.journalUpdatedAt as string).getTime() < new Date(event.journalCreatedAt as string).getTime()
+		) {
+			addIssue("As-needed intake journal updatedAt precedes createdAt");
+		} else if (
+			hasJournalCreatedAt &&
+			[new Date(event.journalCreatedAt as string).getTime(), new Date(event.journalUpdatedAt as string).getTime()].some(
+				(timestamp) => timestamp % 1000 !== 0
+			)
+		) {
+			addIssue("As-needed intake journal timestamps exceed persisted whole-second precision");
+		}
+
+		const cutoffAt = event.stockCutoffAt ? new Date(event.stockCutoffAt).getTime() : null;
+		if (cutoffAt !== null && cutoffAt % 1000 !== 0) {
+			addIssue("As-needed intake stock cutoff exceeds persisted whole-second precision");
+		}
+		const correctionAt = medication.lastStockCorrectionAt ? new Date(medication.lastStockCorrectionAt).getTime() : null;
+		if (!profile.measurable) {
+			if (event.stockEffectMilli !== 0 || event.stockEffectReason !== "non_measurable" || cutoffAt !== null) {
+				addIssue("Non-measurable as-needed intake has an invalid stock effect");
+			}
+		} else if (event.stockEffectReason === "applied") {
+			if (event.stockEffectMilli !== event.quantityMilli || cutoffAt !== null) {
+				addIssue("Applied as-needed intake has an invalid stock effect");
+			}
+			if (event.status === "active" && correctionAt !== null && occurredAt <= correctionAt) {
+				addIssue("Active as-needed intake predating the stock correction must have a neutralized effect");
+			}
+		} else if (
+			event.stockEffectReason === "before_correction" ||
+			event.stockEffectReason === "superseded_by_correction"
+		) {
+			if (
+				event.stockEffectMilli !== 0 ||
+				cutoffAt === null ||
+				correctionAt === null ||
+				cutoffAt < occurredAt ||
+				cutoffAt > correctionAt
+			) {
+				addIssue("Correction-neutralized as-needed intake has an invalid stock effect or cutoff");
+			}
+		} else {
+			addIssue("Measurable as-needed intake has an invalid stock effect reason");
+		}
+
+		if (event.replacementForEventId) {
+			if (replacementTargets.has(event.replacementForEventId)) {
+				addIssue("Multiple as-needed intakes replace the same event");
+			}
+			replacementTargets.add(event.replacementForEventId);
+		}
+	}
+
+	for (const event of importData.asNeededIntakes) {
+		if (!event.replacementForEventId) continue;
+		const target = eventsById.get(event.replacementForEventId);
+		if (!target) addIssue("As-needed replacement references unknown event");
+		else if (
+			target.eventId === event.eventId ||
+			target.medicationRef !== event.medicationRef ||
+			target.status !== "reversed"
+		) {
+			addIssue("As-needed replacement target must be a different reversed event for the same medication");
+		} else if (target.reversedAt && new Date(event.occurredAt).getTime() < new Date(target.reversedAt).getTime()) {
+			addIssue("As-needed replacement predates the target reversal");
+		}
+	}
+
+	const graphState = new Map<string, "visiting" | "done">();
+	for (const startId of eventsById.keys()) {
+		if (graphState.get(startId) === "done") continue;
+		const path: string[] = [];
+		let currentId: string | null = startId;
+		while (currentId && eventsById.has(currentId) && graphState.get(currentId) !== "done") {
+			if (graphState.get(currentId) === "visiting") {
+				addIssue("As-needed replacement graph contains a cycle");
+				break;
+			}
+			graphState.set(currentId, "visiting");
+			path.push(currentId);
+			currentId = eventsById.get(currentId)?.replacementForEventId ?? null;
+		}
+		for (const eventId of path) graphState.set(eventId, "done");
 	}
 
 	return issues;
@@ -1022,7 +1199,8 @@ export async function exportRoutes(app: FastifyInstance) {
 			if (!parsed.success) {
 				return reply.status(400).send({
 					error: "Invalid import data format",
-					details: parsed.error.format(),
+					code: "INVALID_IMPORT_DATA",
+					details: { _errors: formatImportSchemaIssues(parsed.error) },
 				});
 			}
 
@@ -1030,7 +1208,8 @@ export async function exportRoutes(app: FastifyInstance) {
 			if (validationIssues.length > 0) {
 				return reply.status(400).send({
 					error: "Invalid import data format",
-					details: { _errors: validationIssues.slice(0, 10) },
+					code: "INVALID_IMPORT_DATA",
+					details: { _errors: validationIssues },
 				});
 			}
 
@@ -1113,7 +1292,8 @@ export async function exportRoutes(app: FastifyInstance) {
 			if (!parsed.success) {
 				return reply.status(400).send({
 					error: "Invalid import data format",
-					details: parsed.error.format(),
+					code: "INVALID_IMPORT_DATA",
+					details: { _errors: formatImportSchemaIssues(parsed.error) },
 				});
 			}
 
@@ -1122,24 +1302,12 @@ export async function exportRoutes(app: FastifyInstance) {
 			if (validationIssues.length > 0) {
 				return reply.status(400).send({
 					error: "Invalid import data format",
-					details: { _errors: validationIssues.slice(0, 10) },
-				});
-			}
-			if (importData.asNeededIntakes.length > 0) {
-				return reply.status(400).send({
-					error: "As-needed intake restore is not available in this release",
 					code: "INVALID_IMPORT_DATA",
-					details: {
-						_errors: ["This v1.9 export contains as-needed intakes and cannot be imported without loss"],
-					},
+					details: { _errors: validationIssues },
 				});
 			}
-
-			// Existing image files are removed only after the DB import commits.
-			const existingMeds = await db.select().from(medications).where(eq(medications.userId, userId));
-			const oldImageFilenames = existingMeds
-				.map((med) => med.imageUrl)
-				.filter((filename): filename is string => typeof filename === "string" && filename.length > 0);
+			// Existing image files are captured transaction-visibly and removed only after the import commits.
+			let oldImageFilenames: string[] = [];
 			const newImageFilenames: string[] = [];
 			const imported = {
 				medications: 0,
@@ -1151,8 +1319,31 @@ export async function exportRoutes(app: FastifyInstance) {
 			};
 
 			try {
-				await db.transaction(async (tx) => {
-					// Delete in order: journal entries, refill history, doses, share tokens, medications, settings.
+				await withImmediateWriteTransaction(async (tx) => {
+					const existingMeds = await tx.select().from(medications).where(eq(medications.userId, userId));
+					oldImageFilenames = existingMeds
+						.map((med) => med.imageUrl)
+						.filter((filename): filename is string => typeof filename === "string" && filename.length > 0);
+
+					// Reserved anchors own companion events, so remove them before the remaining account graph.
+					const existingAsNeededAnchors = await tx
+						.select({ id: asNeededIntakeEvents.doseTrackingId })
+						.from(asNeededIntakeEvents)
+						.where(eq(asNeededIntakeEvents.userId, userId));
+					for (let index = 0; index < existingAsNeededAnchors.length; index += 500) {
+						await tx.delete(doseTracking).where(
+							and(
+								eq(doseTracking.userId, userId),
+								inArray(
+									doseTracking.id,
+									existingAsNeededAnchors.slice(index, index + 500).map((anchor) => anchor.id)
+								)
+							)
+						);
+					}
+					await tx.delete(asNeededIntakeEvents).where(eq(asNeededIntakeEvents.userId, userId));
+
+					// Delete in order: remaining journals, refill history, scheduled doses, shares, medications, settings.
 					await tx.delete(intakeJournal).where(eq(intakeJournal.userId, userId));
 					await tx.delete(refillHistory).where(eq(refillHistory.userId, userId));
 					await tx.delete(doseTracking).where(eq(doseTracking.userId, userId));
@@ -1276,6 +1467,118 @@ export async function exportRoutes(app: FastifyInstance) {
 							journalUpdatedAt: dose.journalUpdatedAt,
 							database: tx,
 						});
+					}
+
+					const restoredEventIds = new Map<string, number>();
+					const restoredAnchorIds = new Set<number>();
+					for (const event of importData.asNeededIntakes) {
+						const newMedId = exportIdToNewId.get(event.medicationRef);
+						if (!newMedId) throw new Error("Validated as-needed medication mapping is missing");
+
+						const occurredAt = new Date(event.occurredAt);
+						const recordedAt = new Date(event.recordedAt);
+						const reversedAt = event.reversedAt ? new Date(event.reversedAt) : null;
+						const stockCutoffAt = event.stockCutoffAt ? new Date(event.stockCutoffAt) : null;
+						const updatedAt = new Date(
+							Math.max(recordedAt.getTime(), reversedAt?.getTime() ?? 0, stockCutoffAt?.getTime() ?? 0)
+						);
+						const [anchor] = await tx
+							.insert(doseTracking)
+							.values({
+								userId,
+								doseId: `as-needed:${event.eventId}`,
+								takenAt: occurredAt,
+								markedBy: event.person,
+								takenSource: "manual",
+								dismissed: false,
+							})
+							.returning({ id: doseTracking.id });
+						const [restored] = await tx
+							.insert(asNeededIntakeEvents)
+							.values({
+								eventId: event.eventId,
+								userId,
+								medicationId: newMedId,
+								doseTrackingId: anchor.id,
+								idempotencyKeyHash: event.idempotencyKeyHash,
+								requestFingerprint: event.requestFingerprint,
+								occurredAt,
+								recordedAt,
+								quantityMilli: event.quantityMilli,
+								quantityUnit: event.quantityUnit,
+								personName: event.person ?? "",
+								source: event.source,
+								status: event.status,
+								stockEffectMilli: event.stockEffectMilli,
+								stockEffectReason: event.stockEffectReason,
+								stockCutoffAt: stockCutoffAt ? Math.floor(stockCutoffAt.getTime() / 1000) : 0,
+								reversedAt,
+								reversalIdempotencyKeyHash: event.reversalIdempotencyKeyHash,
+								revision: event.revision,
+								createdAt: recordedAt,
+								updatedAt,
+							})
+							.returning({ id: asNeededIntakeEvents.id });
+						restoredEventIds.set(event.eventId, restored.id);
+						restoredAnchorIds.add(anchor.id);
+						imported.asNeededIntakes += 1;
+
+						if (hasImportedAsNeededJournal(event)) {
+							if (!event.journalCreatedAt || !event.journalUpdatedAt) {
+								throw new Error("Validated as-needed journal timestamps are missing");
+							}
+							await tx.insert(intakeJournal).values({
+								userId,
+								doseTrackingId: anchor.id,
+								medicationId: newMedId,
+								scheduledFor: occurredAt,
+								note: event.journalNote ?? "",
+								mood: event.journalMood ?? "",
+								createdAt: new Date(event.journalCreatedAt),
+								updatedAt: new Date(event.journalUpdatedAt),
+							});
+						}
+					}
+
+					for (const event of importData.asNeededIntakes) {
+						if (!event.replacementForEventId) continue;
+						const eventId = restoredEventIds.get(event.eventId);
+						const targetId = restoredEventIds.get(event.replacementForEventId);
+						if (!eventId || !targetId) throw new Error("Validated as-needed replacement mapping is missing");
+						await tx
+							.update(asNeededIntakeEvents)
+							.set({ replacesEventId: targetId })
+							.where(and(eq(asNeededIntakeEvents.id, eventId), eq(asNeededIntakeEvents.userId, userId)));
+					}
+
+					const restoredGraph = await tx
+						.select({
+							eventId: asNeededIntakeEvents.eventId,
+							doseTrackingId: asNeededIntakeEvents.doseTrackingId,
+						})
+						.from(asNeededIntakeEvents)
+						.innerJoin(
+							doseTracking,
+							and(
+								eq(doseTracking.id, asNeededIntakeEvents.doseTrackingId),
+								eq(doseTracking.userId, asNeededIntakeEvents.userId)
+							)
+						)
+						.innerJoin(
+							medications,
+							and(
+								eq(medications.id, asNeededIntakeEvents.medicationId),
+								eq(medications.userId, asNeededIntakeEvents.userId)
+							)
+						)
+						.where(eq(asNeededIntakeEvents.userId, userId));
+					if (
+						restoredGraph.length !== importData.asNeededIntakes.length ||
+						restoredGraph.some(
+							(event) => !restoredEventIds.has(event.eventId) || !restoredAnchorIds.has(event.doseTrackingId)
+						)
+					) {
+						throw new Error("Restored as-needed intake graph contains orphan rows");
 					}
 
 					if (importData.settings) {

--- a/backend/src/services/as-needed-intakes-service.ts
+++ b/backend/src/services/as-needed-intakes-service.ts
@@ -246,7 +246,23 @@ export async function createAsNeededIntake(input: {
 			.where(and(eq(asNeededIntakeEvents.userId, input.userId), eq(asNeededIntakeEvents.idempotencyKeyHash, keyHash)));
 		if (replay) {
 			if (!fingerprint || replay.requestFingerprint !== fingerprint) {
-				throw new AsNeededIntakeError("IDEMPOTENCY_KEY_REUSED", "Idempotency key is bound to another request");
+				const [replacedEvent] = replay.replacesEventId
+					? await transactionDb
+							.select({ eventId: asNeededIntakeEvents.eventId })
+							.from(asNeededIntakeEvents)
+							.where(
+								and(eq(asNeededIntakeEvents.userId, input.userId), eq(asNeededIntakeEvents.id, replay.replacesEventId))
+							)
+					: [];
+				const matchesImportedIntent =
+					Number.isSafeInteger(rawQuantityMilli) &&
+					replay.medicationId === input.medicationId &&
+					replay.quantityMilli === rawQuantityMilli &&
+					replay.personName === personName &&
+					(replacedEvent?.eventId ?? "") === replacementId;
+				if (!matchesImportedIntent) {
+					throw new AsNeededIntakeError("IDEMPOTENCY_KEY_REUSED", "Idempotency key is bound to another request");
+				}
 			}
 			return replay;
 		}

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -265,18 +265,15 @@ describe.sequential("as-needed intake service", () => {
 		["ended", { endDate: "2000-01-01" }, undefined, "NOT_ELIGIBLE"],
 		["obsolete", { isObsolete: true }, undefined, "NOT_ELIGIBLE"],
 		["unassigned person", { people: ["Ava"] }, "Ben", "INVALID_PERSON"],
-	] as const)(
-		"rejects %s medication eligibility without an anchor or event",
-		async (_case, options, personName, code) => {
-			const medicationId = await seedMedication(options);
-			await expectCode(
-				createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
-				code
-			);
-			expect(await eventCount()).toBe(0);
-			expect((await db.select().from(doseTracking)).length).toBe(0);
-		}
-	);
+	] as const)("rejects %s medication eligibility without an anchor or event", async (_case, options, personName, code) => {
+		const medicationId = await seedMedication(options);
+		await expectCode(
+			createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
+			code
+		);
+		expect(await eventCount()).toBe(0);
+		expect((await db.select().from(doseTracking)).length).toBe(0);
+	});
 
 	it.each([
 		["insufficient stock", { stock: 1 }, 2, "INSUFFICIENT_STOCK"],

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -169,6 +170,40 @@ describe.sequential("as-needed intake service", () => {
 		expect(await eventCount()).toBe(2);
 	});
 
+	it("replays an imported semantic intent after medication IDs have been remapped", async () => {
+		const medicationId = await seedMedication({ stock: 5 });
+		const key = intentKey();
+		const [anchor] = await db
+			.insert(doseTracking)
+			.values({ userId: 1, doseId: `as-needed:${intentKey()}`, takenAt: new Date("2026-02-05T08:00:00.000Z") })
+			.returning({ id: doseTracking.id });
+		const [imported] = await db
+			.insert(asNeededIntakeEvents)
+			.values({
+				eventId: "00000000-0000-4000-8000-000000000099",
+				userId: 1,
+				medicationId,
+				doseTrackingId: anchor.id,
+				idempotencyKeyHash: createHash("sha256").update(key).digest("hex"),
+				requestFingerprint: "f".repeat(64),
+				occurredAt: new Date("2026-02-05T08:00:00.000Z"),
+				recordedAt: new Date("2026-02-05T08:01:00.000Z"),
+				quantityMilli: 1000,
+				quantityUnit: "pills",
+				stockEffectMilli: 1000,
+				stockEffectReason: "applied",
+			})
+			.returning({ id: asNeededIntakeEvents.id });
+
+		expect((await createAsNeededIntake({ userId: 1, medicationId, quantity: 1, idempotencyKey: key })).id).toBe(
+			imported.id
+		);
+		await expectCode(
+			createAsNeededIntake({ userId: 1, medicationId, quantity: 2, idempotencyKey: key }),
+			"IDEMPOTENCY_KEY_REUSED"
+		);
+	});
+
 	it("aggregates active effects per owner and medication while retaining reversed and zero-effect rows as zero", async () => {
 		const ownerMedicationId = await seedMedication({ stock: 5 });
 		const otherMedicationId = await seedMedication({ userId: 2, stock: 5 });
@@ -230,15 +265,18 @@ describe.sequential("as-needed intake service", () => {
 		["ended", { endDate: "2000-01-01" }, undefined, "NOT_ELIGIBLE"],
 		["obsolete", { isObsolete: true }, undefined, "NOT_ELIGIBLE"],
 		["unassigned person", { people: ["Ava"] }, "Ben", "INVALID_PERSON"],
-	] as const)("rejects %s medication eligibility without an anchor or event", async (_case, options, personName, code) => {
-		const medicationId = await seedMedication(options);
-		await expectCode(
-			createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
-			code
-		);
-		expect(await eventCount()).toBe(0);
-		expect((await db.select().from(doseTracking)).length).toBe(0);
-	});
+	] as const)(
+		"rejects %s medication eligibility without an anchor or event",
+		async (_case, options, personName, code) => {
+			const medicationId = await seedMedication(options);
+			await expectCode(
+				createAsNeededIntake({ userId: 1, medicationId, quantity: 1, personName, idempotencyKey: intentKey() }),
+				code
+			);
+			expect(await eventCount()).toBe(0);
+			expect((await db.select().from(doseTracking)).length).toBe(0);
+		}
+	);
 
 	it.each([
 		["insufficient stock", { stock: 1 }, 2, "INSUFFICIENT_STOCK"],

--- a/backend/src/test/intake-journal-routes.test.ts
+++ b/backend/src/test/intake-journal-routes.test.ts
@@ -40,6 +40,8 @@ const { testClient, testDb, testDbPath, mockedEnv } = vi.hoisted(() => {
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>) =>
+		testDb.transaction(operation),
 }));
 
 vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));
@@ -312,6 +314,10 @@ describe("Intake journal routes", () => {
 		const otherUserId = await createTestUser(testClient, { username: "as-needed-export-other" });
 		const sessionCookie = await buildTestSessionCookie(app, userId, "as-needed-export-owner");
 		const medicationId = await seedMedication({ userId, name: "As-needed export medication" });
+		await testClient.execute({
+			sql: "UPDATE medications SET last_stock_correction_at = ? WHERE id = ?",
+			args: [1770282300, medicationId],
+		});
 		const otherMedicationId = await seedMedication({ userId: otherUserId, name: "Other owner medication" });
 		const scheduledFor = "2026-02-05T07:00:00.000Z";
 		await seedTrackedDose({
@@ -357,8 +363,8 @@ describe("Intake journal routes", () => {
 				"Daniel",
 				"reversed",
 				1500,
-				"superseded_by_correction",
-				1770278700,
+				"applied",
+				0,
 				1770279000,
 				HASH_C,
 				2,
@@ -369,8 +375,8 @@ describe("Intake journal routes", () => {
 			sql: `INSERT INTO as_needed_intake_events (
 			  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
 			  occurred_at, recorded_at, quantity_milli, quantity_unit, person_name, stock_effect_milli,
-			  stock_effect_reason, replaces_event_id, revision
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			  stock_effect_reason, stock_cutoff_at, replaces_event_id, revision
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			args: [
 				EVENT_B,
 				userId,
@@ -385,6 +391,7 @@ describe("Intake journal routes", () => {
 				"",
 				0,
 				"before_correction",
+				1770282300,
 				firstEventId,
 				3,
 			],
@@ -444,8 +451,8 @@ describe("Intake journal routes", () => {
 				source: "owner_as_needed",
 				status: "reversed",
 				stockEffectMilli: 1500,
-				stockEffectReason: "superseded_by_correction",
-				stockCutoffAt: "2026-02-05T08:05:00.000Z",
+				stockEffectReason: "applied",
+				stockCutoffAt: null,
 				replacementForEventId: null,
 				reversedAt: "2026-02-05T08:10:00.000Z",
 				reversalIdempotencyKeyHash: HASH_C,
@@ -469,7 +476,7 @@ describe("Intake journal routes", () => {
 				status: "active",
 				stockEffectMilli: 0,
 				stockEffectReason: "before_correction",
-				stockCutoffAt: null,
+				stockCutoffAt: "2026-02-05T09:05:00.000Z",
 				replacementForEventId: EVENT_A,
 				reversedAt: null,
 				reversalIdempotencyKeyHash: null,
@@ -480,6 +487,46 @@ describe("Intake journal routes", () => {
 				journalUpdatedAt: "2026-02-05T09:03:20.000Z",
 			},
 		]);
+
+		const restored = await app.inject({
+			method: "POST",
+			url: "/import",
+			headers: { cookie: sessionCookie },
+			payload: body,
+		});
+		expect(restored.statusCode).toBe(200);
+		expect(restored.json().imported).toEqual(
+			expect.objectContaining({ medications: 1, doseHistory: 1, asNeededIntakes: 2 })
+		);
+
+		const reExport = await app.inject({ method: "GET", url: "/export", headers: { cookie: sessionCookie } });
+		expect(reExport.statusCode).toBe(200);
+		expect(reExport.json().doseHistory).toEqual(body.doseHistory);
+		expect(reExport.json().asNeededIntakes).toEqual(body.asNeededIntakes);
+
+		const repeatedRestore = await app.inject({
+			method: "POST",
+			url: "/import",
+			headers: { cookie: sessionCookie },
+			payload: body,
+		});
+		expect(repeatedRestore.statusCode).toBe(200);
+		const [events, anchors, stockEffect] = await Promise.all([
+			testClient.execute("SELECT event_id FROM as_needed_intake_events WHERE user_id = ? ORDER BY event_id", [userId]),
+			testClient.execute("SELECT dose_id FROM dose_tracking WHERE user_id = ? AND dose_id LIKE 'as-needed:%'", [
+				userId,
+			]),
+			testClient.execute(
+				"SELECT coalesce(sum(stock_effect_milli), 0) AS total FROM as_needed_intake_events WHERE user_id = ?",
+				[userId]
+			),
+		]);
+		expect(events.rows).toEqual([
+			expect.objectContaining({ event_id: EVENT_A }),
+			expect.objectContaining({ event_id: EVENT_B }),
+		]);
+		expect(anchors.rows).toHaveLength(2);
+		expect(stockEffect.rows[0].total).toBe(1500);
 	});
 
 	it("requires asNeededIntakes for v1.9 while keeping empty v1.9 and older imports compatible", async () => {
@@ -514,7 +561,7 @@ describe("Intake journal routes", () => {
 		expect(olderImport.json().imported).toEqual(expect.objectContaining({ asNeededIntakes: 0 }));
 	});
 
-	it("previews v1.9 intake counts and rejects nonempty restores before changing data", async () => {
+	it("rejects invalid nonempty v1.9 restores before changing data", async () => {
 		const userId = await createTestUser(testClient, { username: "as-needed-import-rejection" });
 		const sessionCookie = await buildTestSessionCookie(app, userId, "as-needed-import-rejection");
 		const medicationId = await seedMedication({ userId, name: "Existing import medication" });
@@ -544,14 +591,8 @@ describe("Intake journal routes", () => {
 			headers: { cookie: sessionCookie },
 			payload,
 		});
-		expect(preview.statusCode).toBe(200);
-		expect(preview.json().preview).toEqual(
-			expect.objectContaining({
-				incoming: expect.objectContaining({ asNeededIntakes: 1, journalEntries: 1 }),
-				current: expect.objectContaining({ medications: 1, doseHistory: 0, asNeededIntakes: 1 }),
-				warnings: expect.objectContaining({ replacesExistingData: true }),
-			})
-		);
+		expect(preview.statusCode).toBe(400);
+		expect(preview.json()).toEqual(expect.objectContaining({ code: "INVALID_IMPORT_DATA" }));
 
 		const rejectedImport = await app.inject({
 			method: "POST",
@@ -560,12 +601,7 @@ describe("Intake journal routes", () => {
 			payload,
 		});
 		expect(rejectedImport.statusCode).toBe(400);
-		expect(rejectedImport.json()).toEqual(
-			expect.objectContaining({
-				code: "INVALID_IMPORT_DATA",
-				details: { _errors: ["This v1.9 export contains as-needed intakes and cannot be imported without loss"] },
-			})
-		);
+		expect(rejectedImport.json()).toEqual(expect.objectContaining({ code: "INVALID_IMPORT_DATA" }));
 
 		const [medicationRows, eventRows, doseRows] = await Promise.all([
 			testClient.execute("SELECT name FROM medications WHERE user_id = ?", [userId]),
@@ -575,6 +611,88 @@ describe("Intake journal routes", () => {
 		expect(medicationRows.rows).toEqual([expect.objectContaining({ name: "Existing import medication" })]);
 		expect(eventRows.rows).toEqual([expect.objectContaining({ event_id: EVENT_A })]);
 		expect(doseRows.rows).toEqual([expect.objectContaining({ dose_id: `as-needed:${EVENT_A}` })]);
+	});
+
+	it("bounds invalid as-needed import graphs and leaves existing rows untouched", async () => {
+		const userId = await createTestUser(testClient, { username: "as-needed-import-matrix" });
+		const sessionCookie = await buildTestSessionCookie(app, userId, "as-needed-import-matrix");
+		const medicationId = await seedMedication({ userId, name: "Unchanged import medication" });
+		const baseMedication = {
+			_exportId: "med-1",
+			name: "Imported tablet",
+			medicationForm: "tablet",
+			inventory: { packCount: 0, blistersPerPack: 1, pillsPerBlister: 1, looseTablets: 5, packageType: "blister" },
+			schedules: [],
+		};
+		const payloadFor = (asNeededIntakes: Record<string, unknown>[], medication = baseMedication) => ({
+			version: "1.9",
+			exportedAt: "2026-02-05T08:00:00.000Z",
+			medications: [medication],
+			doseHistory: [],
+			asNeededIntakes,
+		});
+		const reversedEvent = asNeededImportEvent({
+			status: "reversed",
+			reversedAt: "2026-02-05T08:02:00.000Z",
+			reversalIdempotencyKeyHash: HASH_C,
+			revision: 2,
+		});
+		const matrix = [
+			payloadFor([asNeededImportEvent(), asNeededImportEvent()]),
+			payloadFor([asNeededImportEvent(), asNeededImportEvent({ eventId: EVENT_B, requestFingerprint: HASH_A })]),
+			payloadFor([asNeededImportEvent({ replacementForEventId: EVENT_B })]),
+			payloadFor([asNeededImportEvent({ replacementForEventId: EVENT_A })]),
+			payloadFor([asNeededImportEvent({ reversalIdempotencyKeyHash: HASH_C })]),
+			payloadFor([asNeededImportEvent({ person: " Daniel " })]),
+			payloadFor([asNeededImportEvent({ stockEffectMilli: 0 })]),
+			payloadFor([asNeededImportEvent({ journalMood: "good" })]),
+			payloadFor([asNeededImportEvent({ idempotencyKeyHash: "not-a-hash" })]),
+			payloadFor([asNeededImportEvent({ occurredAt: "2026-02-05T08:00:00.500Z" })]),
+			payloadFor([asNeededImportEvent({ stockEffectReason: "before_correction", stockEffectMilli: 0 })]),
+			payloadFor([asNeededImportEvent()], {
+				...baseMedication,
+				medicationForm: "liquid",
+				inventory: { ...baseMedication.inventory, packageType: "liquid_container" },
+			}),
+			{
+				version: "1.9",
+				exportedAt: "2026-02-05T08:00:00.000Z",
+				medications: [baseMedication, { ...baseMedication, _exportId: "med-2", name: "Imported tablet two" }],
+				doseHistory: [],
+				asNeededIntakes: [
+					reversedEvent,
+					asNeededImportEvent({
+						eventId: EVENT_B,
+						medicationRef: "med-2",
+						idempotencyKeyHash: HASH_B,
+						requestFingerprint: HASH_C,
+						occurredAt: "2026-02-05T08:03:00.000Z",
+						recordedAt: "2026-02-05T08:04:00.000Z",
+						replacementForEventId: EVENT_A,
+					}),
+				],
+			},
+		];
+
+		for (const payload of matrix) {
+			const response = await app.inject({
+				method: "POST",
+				url: "/import",
+				headers: { cookie: sessionCookie },
+				payload,
+			});
+			expect(response.statusCode).toBe(400);
+			expect(response.json()).toEqual(
+				expect.objectContaining({
+					code: "INVALID_IMPORT_DATA",
+					details: expect.objectContaining({ _errors: expect.any(Array) }),
+				})
+			);
+			expect(response.json().details._errors.length).toBeLessThanOrEqual(10);
+		}
+
+		const rows = await testClient.execute("SELECT id, name FROM medications WHERE user_id = ?", [userId]);
+		expect(rows.rows).toEqual([expect.objectContaining({ id: medicationId, name: "Unchanged import medication" })]);
 	});
 
 	it("preserves journal metadata through authenticated export and import", async () => {


### PR DESCRIPTION
Closes #1029

## Summary

- validate the complete bounded v1.9 as-needed intake graph before any restore mutation
- restore remapped medications, schedules, anchors, events, replacements, and journals in FK-safe transactional order
- preserve stable IDs, hashes, fingerprints, timestamps, revisions, effects, replay semantics, and repeated idempotence without stock duplication

## Scope boundary

Backend-only Slice 4B. No schema, API, or UI work. It removes the temporary 4A restore guard and unlocks Core API #1016.

## Validation

- focused exact round-trip, replay, invalid-data, and zero-mutation coverage: 20/20
- full backend suite: 47 files, 929 tests
- CI-identical Biome
- root lint, check, build, and diff check