### PR TITLE
feat: expose as-needed owner API

### DIFF
--- a/backend/src/app/createApp.ts
+++ b/backend/src/app/createApp.ts
@@ -12,6 +12,7 @@ import { getDataDir } from "../db/db-utils.js";
 import { registerApiDocs } from "../plugins/api-docs.js";
 import { jwtPlugin } from "../plugins/jwt.js";
 import { apiKeyRoutes } from "../routes/api-keys.js";
+import { asNeededIntakeRoutes } from "../routes/as-needed-intakes.js";
 import { authRoutes } from "../routes/auth.js";
 import { doseRoutes } from "../routes/doses.js";
 import { exportRoutes } from "../routes/export.js";
@@ -108,6 +109,7 @@ async function registerAppRoutes(app: FastifyInstance, imagesDir: string): Promi
 	await app.register(healthRoutes);
 	await app.register(authRoutes);
 	await app.register(apiKeyRoutes);
+	await app.register(asNeededIntakeRoutes);
 	await app.register(oidcRoutes);
 	await app.register(medicationRoutes);
 	await app.register(medicationEnrichmentRoutes);

--- a/backend/src/routes/as-needed-intakes.ts
+++ b/backend/src/routes/as-needed-intakes.ts
@@ -1,0 +1,447 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { getAnonymousUserId, isReadOnlyApiKeyRequest, requireAuth } from "../plugins/auth.js";
+import { env } from "../plugins/env.js";
+import {
+	AsNeededIntakeError,
+	createAsNeededIntake,
+	getAsNeededMutationResponse,
+	listAsNeededIntakes,
+	reverseAsNeededIntake,
+} from "../services/as-needed-intakes-service.js";
+import type { AuthUser } from "../types/fastify.js";
+import { applyOpenApiRouteStandards, genericErrorSchema } from "../utils/openapi-route-standards.js";
+
+const medicationParamsSchema = z.object({ medicationId: z.coerce.number().int().positive() }).strict();
+const eventParamsSchema = z.object({ eventId: z.string().trim().uuid() }).strict();
+const idempotencyHeadersSchema = z.object({ "idempotency-key": z.string().trim().uuid() }).strict();
+const includeReversedSchema = z.preprocess((value) => {
+	if (value === "true") return true;
+	if (value === "false") return false;
+	return value;
+}, z.boolean().default(true));
+const listQuerySchema = z
+	.object({
+		includeReversed: includeReversedSchema,
+		from: z.string().datetime({ offset: true }).optional(),
+		to: z.string().datetime({ offset: true }).optional(),
+		limit: z.coerce.number().int().min(1).max(200).default(100),
+		cursor: z.string().min(1).max(512).optional(),
+	})
+	.strict();
+const createBodySchema = z
+	.object({
+		quantity: z.number().positive().multipleOf(0.001),
+		person: z.string().trim().min(1).max(100).nullable().optional(),
+		replacementForEventId: z.string().trim().uuid().nullable().optional(),
+	})
+	.strict();
+const reversalBodySchema = z.object({ expectedRevision: z.number().int().positive() }).strict();
+
+const medicationParamsOpenApiSchema = {
+	type: "object",
+	required: ["medicationId"],
+	properties: { medicationId: { type: "integer", minimum: 1 } },
+	additionalProperties: false,
+} as const;
+const eventParamsOpenApiSchema = {
+	type: "object",
+	required: ["eventId"],
+	properties: { eventId: { type: "string", format: "uuid" } },
+	additionalProperties: false,
+} as const;
+const idempotencyHeadersOpenApiSchema = {
+	type: "object",
+	required: ["idempotency-key"],
+	properties: { "idempotency-key": { type: "string", format: "uuid" } },
+} as const;
+const listQueryOpenApiSchema = {
+	type: "object",
+	properties: {
+		includeReversed: { type: "boolean", default: true },
+		from: { type: "string", format: "date-time" },
+		to: { type: "string", format: "date-time" },
+		limit: { type: "integer", minimum: 1, maximum: 200, default: 100 },
+		cursor: { type: "string", minLength: 1, maxLength: 512 },
+	},
+	additionalProperties: false,
+} as const;
+const createBodyOpenApiSchema = {
+	type: "object",
+	required: ["quantity"],
+	properties: {
+		quantity: { type: "number", exclusiveMinimum: 0, multipleOf: 0.001 },
+		person: { type: ["string", "null"], minLength: 1, maxLength: 100 },
+		replacementForEventId: { type: ["string", "null"], format: "uuid" },
+	},
+	additionalProperties: false,
+} as const;
+const reversalBodyOpenApiSchema = {
+	type: "object",
+	required: ["expectedRevision"],
+	properties: { expectedRevision: { type: "integer", minimum: 1 } },
+	additionalProperties: false,
+} as const;
+
+const errorResponseSchema = {
+	type: "object",
+	required: ["error", "code"],
+	properties: { error: { type: "string" }, code: { type: "string" } },
+	additionalProperties: false,
+} as const;
+const conflictResponseSchema = {
+	type: "object",
+	required: ["error", "code"],
+	properties: {
+		error: { type: "string" },
+		code: { type: "string" },
+		currentRevision: { type: "integer", minimum: 1 },
+		currentStock: { type: "number", minimum: 0 },
+	},
+	additionalProperties: false,
+} as const;
+const medicationContextSchema = {
+	type: "object",
+	required: [
+		"name",
+		"genericName",
+		"medicationForm",
+		"packageType",
+		"isObsolete",
+		"hasRegularSchedule",
+		"lifecycle",
+		"recordEligibility",
+	],
+	properties: {
+		name: { type: "string" },
+		genericName: { type: ["string", "null"] },
+		medicationForm: { type: "string" },
+		packageType: { type: "string" },
+		isObsolete: { type: "boolean" },
+		hasRegularSchedule: { type: "boolean" },
+		lifecycle: { type: "string", enum: ["active_no_schedule", "active_scheduled", "ended", "obsolete"] },
+		recordEligibility: {
+			type: "object",
+			required: ["eligible", "reason"],
+			properties: {
+				eligible: { type: "boolean" },
+				reason: { type: "string", enum: ["eligible", "has_regular_schedule", "ended", "obsolete"] },
+			},
+			additionalProperties: false,
+		},
+	},
+	additionalProperties: false,
+} as const;
+const journalSchema = {
+	type: ["object", "null"],
+	required: ["doseId", "mood", "note", "createdAt", "updatedAt"],
+	properties: {
+		doseId: { type: "string" },
+		mood: { type: ["string", "null"] },
+		note: { type: ["string", "null"] },
+		createdAt: { type: ["string", "null"], format: "date-time" },
+		updatedAt: { type: ["string", "null"], format: "date-time" },
+	},
+	additionalProperties: false,
+} as const;
+const eventResponseSchema = {
+	type: "object",
+	required: [
+		"eventType",
+		"eventId",
+		"medicationId",
+		"medication",
+		"occurredAt",
+		"recordedAt",
+		"quantity",
+		"quantityUnit",
+		"person",
+		"source",
+		"status",
+		"revision",
+		"stockEffect",
+		"stockEffectReason",
+		"stockCutoffAt",
+		"replacementForEventId",
+		"reversedAt",
+		"journal",
+	],
+	properties: {
+		eventType: { type: "string", const: "as_needed" },
+		eventId: { type: "string", format: "uuid" },
+		medicationId: { type: "integer" },
+		medication: medicationContextSchema,
+		occurredAt: { type: "string", format: "date-time" },
+		recordedAt: { type: "string", format: "date-time" },
+		quantity: { type: "number", exclusiveMinimum: 0 },
+		quantityUnit: { type: "string", enum: ["pills", "ml", "puffs", "injections", "application"] },
+		person: { type: ["string", "null"] },
+		source: { type: "string", const: "owner_as_needed" },
+		status: { type: "string", enum: ["active", "reversed"] },
+		revision: { type: "integer", minimum: 1 },
+		stockEffect: { type: "number", minimum: 0 },
+		stockEffectReason: {
+			type: "string",
+			enum: ["applied", "non_measurable", "before_correction", "superseded_by_correction"],
+		},
+		stockCutoffAt: { type: ["string", "null"], format: "date-time" },
+		replacementForEventId: { type: ["string", "null"], format: "uuid" },
+		reversedAt: { type: ["string", "null"], format: "date-time" },
+		journal: journalSchema,
+	},
+	additionalProperties: false,
+} as const;
+const inventoryResponseSchema = {
+	type: "object",
+	required: ["currentStock", "unit", "capacity", "reconciliationRequired"],
+	properties: {
+		currentStock: { type: "number", minimum: 0 },
+		unit: { type: "string", enum: ["pills", "ml", "puffs", "injections", "application"] },
+		capacity: { type: ["number", "null"], minimum: 0 },
+		reconciliationRequired: { type: "boolean" },
+	},
+	additionalProperties: false,
+} as const;
+const mutationResponseSchema = {
+	type: "object",
+	required: ["event", "inventory"],
+	properties: { event: eventResponseSchema, inventory: inventoryResponseSchema },
+	additionalProperties: false,
+} as const;
+const listResponseSchema = {
+	type: "object",
+	required: ["events", "nextCursor"],
+	properties: {
+		events: { type: "array", items: eventResponseSchema },
+		nextCursor: { type: ["string", "null"] },
+	},
+	additionalProperties: false,
+} as const;
+
+async function getUserId(request: FastifyRequest, reply: FastifyReply): Promise<number | null> {
+	if (!env.AUTH_ENABLED) return getAnonymousUserId();
+	const user = request.user as AuthUser | null;
+	if (user) return user.id;
+	reply.status(401).send({ error: "Authentication required", code: "AUTH_REQUIRED" });
+	return null;
+}
+
+function validationError(reply: FastifyReply, code: string, message: string): FastifyReply {
+	return reply.status(400).send({ error: message, code });
+}
+
+function sendServiceError(
+	request: FastifyRequest,
+	reply: FastifyReply,
+	operation: "list" | "create" | "reverse",
+	userId: number,
+	error: unknown
+): FastifyReply {
+	if (!(error instanceof AsNeededIntakeError)) {
+		request.log.error({ err: error, operation, userId }, "[AsNeededIntake] Owner operation failed");
+		return reply.status(500).send({ error: "Internal server error", code: "INTERNAL_ERROR" });
+	}
+
+	if (error.code === "TOO_MANY_NEW_INTAKES") {
+		const retryAfterSeconds = error.details?.retryAfterSeconds ?? 1;
+		reply.header("Retry-After", retryAfterSeconds);
+		return reply.status(429).send({ error: error.message, code: error.code });
+	}
+	if (error.code === "MEDICATION_NOT_FOUND") {
+		return reply.status(404).send({ error: "Medication not found", code: error.code });
+	}
+	if (error.code === "EVENT_NOT_FOUND" || error.code === "REPLACEMENT_NOT_FOUND") {
+		return reply.status(404).send({ error: "Event not found", code: "EVENT_NOT_FOUND" });
+	}
+	if (
+		error.code === "INVALID_IDEMPOTENCY_KEY" ||
+		error.code === "INVALID_QUANTITY" ||
+		error.code === "INVALID_PERSON" ||
+		error.code === "INVALID_DATE_RANGE" ||
+		error.code === "INVALID_CURSOR"
+	) {
+		return reply.status(400).send({ error: error.message, code: error.code });
+	}
+
+	const codeByConflict = {
+		NOT_ELIGIBLE: "MEDICATION_NOT_ELIGIBLE",
+		STOCK_UNRESOLVABLE: "STOCK_UNRESOLVABLE",
+		INSUFFICIENT_STOCK: "INSUFFICIENT_STOCK",
+		IDEMPOTENCY_KEY_REUSED: "IDEMPOTENCY_KEY_REUSED",
+		REVERSAL_KEY_REUSED: "IDEMPOTENCY_KEY_REUSED",
+		REVISION_CONFLICT: "EVENT_VERSION_CONFLICT",
+		REPLACEMENT_INVALID: "REPLACEMENT_NOT_ALLOWED",
+	} as const;
+	const code = codeByConflict[error.code];
+	return reply.status(409).send({
+		error: error.message,
+		code,
+		...(error.details?.currentRevision === undefined ? {} : { currentRevision: error.details.currentRevision }),
+		...(error.details?.currentStock === undefined ? {} : { currentStock: error.details.currentStock }),
+	});
+}
+
+export async function asNeededIntakeRoutes(app: FastifyInstance) {
+	app.addHook("preHandler", requireAuth);
+	applyOpenApiRouteStandards(app, { tag: "as-needed-intakes", protectedByDefault: true });
+	// The app-wide limiter remains first. The service's owner limiter runs only after same-key replay resolution.
+
+	app.get<{ Params: Record<string, unknown>; Querystring: Record<string, unknown> }>(
+		"/medications/:medicationId/as-needed-intakes",
+		{
+			attachValidation: true,
+			schema: {
+				params: medicationParamsOpenApiSchema,
+				querystring: listQueryOpenApiSchema,
+				response: {
+					200: listResponseSchema,
+					400: errorResponseSchema,
+					404: errorResponseSchema,
+					500: genericErrorSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const params = medicationParamsSchema.safeParse(request.params);
+			if (!params.success) return validationError(reply, "INVALID_REQUEST", "Invalid medication id");
+			const query = listQuerySchema.safeParse(request.query);
+			if (!query.success || request.validationError) {
+				const field = query.success ? null : query.error.issues[0]?.path[0];
+				if (field === "cursor") return validationError(reply, "INVALID_CURSOR", "Invalid cursor");
+				if (field === "from" || field === "to") {
+					return validationError(reply, "INVALID_DATE_RANGE", "Invalid date-time range");
+				}
+				return validationError(reply, "INVALID_REQUEST", "Invalid list request");
+			}
+			const userId = await getUserId(request, reply);
+			if (userId === null) return;
+			try {
+				return await listAsNeededIntakes({
+					userId,
+					medicationId: params.data.medicationId,
+					includeReversed: query.data.includeReversed,
+					from: query.data.from ? new Date(query.data.from) : undefined,
+					to: query.data.to ? new Date(query.data.to) : undefined,
+					limit: query.data.limit,
+					cursor: query.data.cursor,
+				});
+			} catch (error) {
+				return sendServiceError(request, reply, "list", userId, error);
+			}
+		}
+	);
+
+	app.post<{ Params: Record<string, unknown>; Body: Record<string, unknown> }>(
+		"/medications/:medicationId/as-needed-intakes",
+		{
+			attachValidation: true,
+			schema: {
+				params: medicationParamsOpenApiSchema,
+				headers: idempotencyHeadersOpenApiSchema,
+				body: createBodyOpenApiSchema,
+				response: {
+					200: mutationResponseSchema,
+					201: mutationResponseSchema,
+					400: errorResponseSchema,
+					403: errorResponseSchema,
+					404: errorResponseSchema,
+					409: conflictResponseSchema,
+					429: genericErrorSchema,
+					500: genericErrorSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const params = medicationParamsSchema.safeParse(request.params);
+			if (!params.success) return validationError(reply, "INVALID_REQUEST", "Invalid medication id");
+			const headers = idempotencyHeadersSchema.safeParse({
+				"idempotency-key": request.headers["idempotency-key"],
+			});
+			if (!headers.success) {
+				return validationError(reply, "INVALID_IDEMPOTENCY_KEY", "Idempotency-Key must be a UUID");
+			}
+			const body = createBodySchema.safeParse(request.body);
+			if (!body.success || request.validationError) {
+				const field = body.success ? null : body.error.issues[0]?.path[0];
+				if (field === "quantity") return validationError(reply, "INVALID_QUANTITY", "Invalid quantity");
+				if (field === "person") return validationError(reply, "INVALID_PERSON", "Invalid person");
+				return validationError(reply, "INVALID_REQUEST", "Invalid create request");
+			}
+			const userId = await getUserId(request, reply);
+			if (userId === null) return;
+			if (isReadOnlyApiKeyRequest(request)) {
+				return reply.status(403).send({ error: "API key is read-only", code: "READ_ONLY" });
+			}
+			try {
+				const event = await createAsNeededIntake({
+					userId,
+					medicationId: params.data.medicationId,
+					quantity: body.data.quantity,
+					personName: body.data.person,
+					idempotencyKey: headers.data["idempotency-key"],
+					replacesEventId: body.data.replacementForEventId,
+					enforceOwnerRateLimit: true,
+				});
+				const response = await getAsNeededMutationResponse(userId, event.eventId);
+				if (event.isReplay) {
+					reply.header("Idempotent-Replay", "true");
+					return reply.status(200).send(response);
+				}
+				return reply.status(201).send(response);
+			} catch (error) {
+				return sendServiceError(request, reply, "create", userId, error);
+			}
+		}
+	);
+
+	app.post<{ Params: Record<string, unknown>; Body: Record<string, unknown> }>(
+		"/as-needed-intakes/:eventId/reversal",
+		{
+			attachValidation: true,
+			schema: {
+				params: eventParamsOpenApiSchema,
+				headers: idempotencyHeadersOpenApiSchema,
+				body: reversalBodyOpenApiSchema,
+				response: {
+					200: mutationResponseSchema,
+					400: errorResponseSchema,
+					403: errorResponseSchema,
+					404: errorResponseSchema,
+					409: conflictResponseSchema,
+					429: genericErrorSchema,
+					500: genericErrorSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const params = eventParamsSchema.safeParse(request.params);
+			if (!params.success) return validationError(reply, "INVALID_REQUEST", "Invalid event id");
+			const headers = idempotencyHeadersSchema.safeParse({
+				"idempotency-key": request.headers["idempotency-key"],
+			});
+			if (!headers.success) {
+				return validationError(reply, "INVALID_IDEMPOTENCY_KEY", "Idempotency-Key must be a UUID");
+			}
+			const body = reversalBodySchema.safeParse(request.body);
+			if (!body.success || request.validationError) {
+				return validationError(reply, "INVALID_REVISION", "Invalid expected revision");
+			}
+			const userId = await getUserId(request, reply);
+			if (userId === null) return;
+			if (isReadOnlyApiKeyRequest(request)) {
+				return reply.status(403).send({ error: "API key is read-only", code: "READ_ONLY" });
+			}
+			try {
+				const event = await reverseAsNeededIntake({
+					userId,
+					eventId: params.data.eventId,
+					expectedRevision: body.data.expectedRevision,
+					idempotencyKey: headers.data["idempotency-key"],
+				});
+				return reply.status(200).send(await getAsNeededMutationResponse(userId, event.eventId));
+			} catch (error) {
+				return sendServiceError(request, reply, "reverse", userId, error);
+			}
+		}
+	);
+}

--- a/backend/src/test/as-needed-intakes-routes.test.ts
+++ b/backend/src/test/as-needed-intakes-routes.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Fastify from "fastify";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authState = vi.hoisted(() => ({ readOnly: false, userId: 1 }));
+const dataDir = mkdtempSync(join(tmpdir(), "medassist-as-needed-routes-"));
+process.env.DATA_DIR = dataDir;
+process.env.DOTENV_PATH = join(dataDir, "missing.env");
+process.env.NODE_ENV = "test";
+process.env.AUTH_ENABLED = "false";
+process.env.OIDC_ENABLED = "false";
+process.env.LOG_LEVEL = "silent";
+
+vi.mock("../plugins/auth.js", () => ({
+	requireAuth: async () => {},
+	getAnonymousUserId: async () => authState.userId,
+	isReadOnlyApiKeyRequest: () => authState.readOnly,
+}));
+
+const [{ db, migrationsReady }, schema, { asNeededIntakeRoutes }] = await Promise.all([
+	import("../db/client.js"),
+	import("../db/schema.js"),
+	import("../routes/as-needed-intakes.js"),
+]);
+const { asNeededIntakeEvents, doseTracking, intakeJournal, medications, userSettings, users } = schema;
+let sequence = 0;
+
+function key(): string {
+	sequence += 1;
+	return `00000000-0000-4000-8000-${sequence.toString().padStart(12, "0")}`;
+}
+
+async function buildRouteApp() {
+	const app = Fastify({ logger: false });
+	await app.register(asNeededIntakeRoutes);
+	return app;
+}
+
+async function seedMedication(userId = 1, stock = 50, options: { people?: string[]; intakes?: unknown[] } = {}) {
+	const [medication] = await db
+		.insert(medications)
+		.values({
+			userId,
+			name: `As-needed route medication ${userId}`,
+			takenByJson: JSON.stringify(options.people ?? []),
+			medicationForm: "tablet",
+			packageType: "blister",
+			packCount: 0,
+			blistersPerPack: 1,
+			pillsPerBlister: 1,
+			looseTablets: stock,
+			intakesJson: JSON.stringify(options.intakes ?? []),
+		})
+		.returning({ id: medications.id });
+	return medication.id;
+}
+
+async function create(
+	app: Awaited<ReturnType<typeof buildRouteApp>>,
+	medicationId: number,
+	body: object,
+	idempotencyKey = key()
+) {
+	return app.inject({
+		method: "POST",
+		url: `/medications/${medicationId}/as-needed-intakes`,
+		headers: { "idempotency-key": idempotencyKey },
+		payload: body,
+	});
+}
+
+describe.sequential("as-needed owner routes", () => {
+	beforeAll(() => migrationsReady);
+
+	beforeEach(async () => {
+		sequence = 0;
+		authState.readOnly = false;
+		authState.userId = 1;
+		await db.delete(intakeJournal);
+		await db.delete(asNeededIntakeEvents);
+		await db.delete(doseTracking);
+		await db.delete(medications);
+		await db.delete(userSettings);
+		await db.delete(users);
+		await db.insert(users).values([
+			{ id: 1, username: "owner" },
+			{ id: 2, username: "other" },
+			{ id: 3, username: "limited" },
+		]);
+		await db.insert(userSettings).values([{ userId: 1, stockCalculationMode: "manual" }, { userId: 2 }, { userId: 3 }]);
+	});
+
+	afterAll(() => rmSync(dataDir, { force: true, recursive: true }));
+
+	it("registers exactly the three owner /api-convention paths with documented strict schemas", async () => {
+		const app = await buildRouteApp();
+		const routes = app.printRoutes();
+		expect(routes).toContain(":medicationId");
+		expect(routes).toContain("/as-needed-intakes (GET, HEAD, POST)");
+		expect(routes).toContain(":eventId");
+		expect(routes).toContain("/reversal (POST)");
+		expect(routes).not.toContain("DELETE");
+		expect(routes).not.toContain("share");
+		expect((await app.inject({ method: "DELETE", url: "/medications/1/as-needed-intakes" })).statusCode).toBe(404);
+		expect((await app.inject({ method: "GET", url: "/api/medications/1/as-needed-intakes" })).statusCode).toBe(404);
+		await app.close();
+	});
+
+	it("creates, lists with deterministic cursor pagination, and exposes nullable journal DTOs to read scope", async () => {
+		const app = await buildRouteApp();
+		const medicationId = await seedMedication();
+		const one = await create(app, medicationId, { quantity: 1 });
+		const two = await create(app, medicationId, { quantity: 1 });
+		expect(one.statusCode).toBe(201);
+		expect(two.statusCode).toBe(201);
+		expect(one.json()).toMatchObject({
+			event: { eventType: "as_needed", journal: null },
+			inventory: { currentStock: 49 },
+		});
+		authState.readOnly = true;
+		const page = await app.inject({ method: "GET", url: `/medications/${medicationId}/as-needed-intakes?limit=1` });
+		expect(page.statusCode).toBe(200);
+		expect(page.json()).toMatchObject({ events: [expect.objectContaining({ eventType: "as_needed", journal: null })] });
+		expect(page.json().nextCursor).toEqual(expect.any(String));
+		const next = await app.inject({
+			method: "GET",
+			url: `/medications/${medicationId}/as-needed-intakes?limit=1&cursor=${encodeURIComponent(page.json().nextCursor)}`,
+		});
+		expect(next.statusCode).toBe(200);
+		expect(next.json().events[0].eventId).not.toBe(page.json().events[0].eventId);
+		for (const url of [
+			`/medications/${medicationId}/as-needed-intakes?limit=0`,
+			`/medications/${medicationId}/as-needed-intakes?cursor=not-a-cursor`,
+		]) {
+			expect((await app.inject({ method: "GET", url })).statusCode).toBe(400);
+		}
+		await app.close();
+	});
+
+	it("enforces strict idempotency and known mutation request shapes while preserving read-only key access", async () => {
+		const app = await buildRouteApp();
+		const medicationId = await seedMedication();
+		expect(
+			(
+				await app.inject({
+					method: "POST",
+					url: `/medications/${medicationId}/as-needed-intakes`,
+					payload: { quantity: 1 },
+				})
+			).statusCode
+		).toBe(400);
+		expect((await create(app, medicationId, { quantity: 1, replacementForEventId: "not-a-uuid" })).statusCode).toBe(
+			400
+		);
+		authState.readOnly = true;
+		expect((await create(app, medicationId, { quantity: 1 })).json()).toMatchObject({ code: "READ_ONLY" });
+		expect(
+			(await app.inject({ method: "GET", url: `/medications/${medicationId}/as-needed-intakes` })).statusCode
+		).toBe(200);
+		await app.close();
+	});
+
+	it("maps owner eligibility, quantity, person, stock, key, revision, replacement and owner boundaries without disclosure", async () => {
+		const app = await buildRouteApp();
+		const medicationId = await seedMedication(1, 1, { people: ["Ava"] });
+		const otherMedicationId = await seedMedication(2, 5);
+		const validKey = key();
+		const valid = await create(app, medicationId, { quantity: 1, person: "Ava" }, validKey);
+		const eventId = valid.json().event.eventId as string;
+		expect((await create(app, medicationId, { quantity: 0.5, person: "Ava" }, validKey)).json()).toMatchObject({
+			code: "IDEMPOTENCY_KEY_REUSED",
+		});
+		for (const [body, status, code] of [
+			[{ quantity: 0 }, 400, "INVALID_QUANTITY"],
+			[{ quantity: 1, person: "Ben" }, 400, "INVALID_PERSON"],
+			[{ quantity: 2 }, 409, "INSUFFICIENT_STOCK"],
+			[{ quantity: 1 }, 409, "INSUFFICIENT_STOCK"],
+		] as const) {
+			const result = await create(app, medicationId, body);
+			expect(result.statusCode).toBe(status);
+			expect(result.json()).toMatchObject({ code });
+		}
+		authState.userId = 2;
+		expect(
+			(await app.inject({ method: "GET", url: `/medications/${medicationId}/as-needed-intakes` })).statusCode
+		).toBe(404);
+		expect(
+			(
+				await app.inject({
+					method: "POST",
+					url: `/as-needed-intakes/${eventId}/reversal`,
+					headers: { "idempotency-key": key() },
+					payload: { expectedRevision: 1 },
+				})
+			).statusCode
+		).toBe(404);
+		authState.userId = 1;
+		authState.readOnly = true;
+		expect(
+			(
+				await app.inject({
+					method: "POST",
+					url: `/as-needed-intakes/${eventId}/reversal`,
+					headers: { "idempotency-key": key() },
+					payload: { expectedRevision: 1 },
+				})
+			).json()
+		).toMatchObject({ code: "READ_ONLY" });
+		authState.readOnly = false;
+		const reversed = await app.inject({
+			method: "POST",
+			url: `/as-needed-intakes/${eventId}/reversal`,
+			headers: { "idempotency-key": key() },
+			payload: { expectedRevision: 1 },
+		});
+		expect(reversed.statusCode).toBe(200);
+		expect(
+			(
+				await app.inject({
+					method: "POST",
+					url: `/as-needed-intakes/${eventId}/reversal`,
+					headers: { "idempotency-key": key() },
+					payload: { expectedRevision: 0 },
+				})
+			).json()
+		).toMatchObject({ code: "INVALID_REVISION" });
+		const replacement = await create(app, medicationId, { quantity: 1, replacementForEventId: eventId });
+		expect(replacement.statusCode).toBe(201);
+		expect(replacement.json().event.replacementForEventId).toBe(eventId);
+		expect((await create(app, medicationId, { quantity: 1, replacementForEventId: eventId })).json()).toMatchObject({
+			code: "REPLACEMENT_NOT_ALLOWED",
+		});
+		expect(otherMedicationId).toBeGreaterThan(0);
+		await app.close();
+	});
+
+	it("replays a lost create response before the 20-intent guard and supplies Retry-After for the next new intent", async () => {
+		const app = await buildRouteApp();
+		authState.userId = 3;
+		const medicationId = await seedMedication(3, 30);
+		const firstKey = key();
+		const first = await create(app, medicationId, { quantity: 1 }, firstKey);
+		expect(first.statusCode).toBe(201);
+		for (let index = 1; index < 20; index += 1) {
+			expect((await create(app, medicationId, { quantity: 1 })).statusCode).toBe(201);
+		}
+		const replay = await create(app, medicationId, { quantity: 1 }, firstKey);
+		expect(replay.statusCode).toBe(200);
+		expect(replay.headers["idempotent-replay"]).toBe("true");
+		const limited = await create(app, medicationId, { quantity: 1 });
+		expect(limited.statusCode).toBe(429);
+		expect(limited.headers["retry-after"]).toMatch(/^[1-9][0-9]*$/);
+		expect(limited.json()).toMatchObject({ code: "TOO_MANY_NEW_INTAKES" });
+		await app.close();
+	});
+});


### PR DESCRIPTION
Closes #1032

## Summary

- expose authenticated owner list, create/replacement, and reversal endpoints for as-needed intake events
- validate request boundaries with strict Zod and stable OpenAPI contracts, safe error mapping, deterministic cursors, and replay-first rate-limit semantics
- enforce read-only API-key mutation denial before the service while retaining read access and owner-non-disclosure

## Scope boundary

No DELETE, share/public route, frontend, or Slice 6 work is included. This unlocks #1017.

## Validation

- focused route coverage: 5 tests
- full backend suite: 48 files, 938 tests
- root lint, check, build, and diff check

Security review found no critical, major, or minor findings.