### PR TITLE
feat: add as-needed journal CRUD

### DIFF
--- a/backend/src/routes/doses.ts
+++ b/backend/src/routes/doses.ts
@@ -408,13 +408,17 @@ function buildSharedJournalEntryDto(input: {
 	journalEntry: Awaited<ReturnType<typeof getIntakeJournalForDoseEvent>>;
 }) {
 	const { event, journalEntry } = input;
+	const scheduledFor = journalEntry?.scheduledFor ?? event.scheduledFor;
+	if (event.eventType !== "scheduled" || !scheduledFor) {
+		throw new Error("Shared journal resolver returned a non-scheduled event");
+	}
 
 	return {
 		doseTrackingId: event.doseTrackingId,
 		doseId: event.doseId,
 		medicationId: event.medicationId,
 		medicationName: event.medicationName,
-		scheduledFor: toLocalDateTimeOffsetString(journalEntry?.scheduledFor ?? event.scheduledFor),
+		scheduledFor: toLocalDateTimeOffsetString(scheduledFor),
 		takenAt: serializeJournalTakenAt(event.takenAt, event.dismissed),
 		dismissed: event.dismissed,
 		takenSource: event.takenSource,

--- a/backend/src/routes/intake-journal.ts
+++ b/backend/src/routes/intake-journal.ts
@@ -6,6 +6,7 @@ import { env } from "../plugins/env.js";
 import {
 	deleteIntakeJournalForDoseEvent,
 	getIntakeJournalForDoseEvent,
+	IntakeJournalMutationError,
 	isTrackedDoseIdFormat,
 	listIntakeJournalEntriesForUser,
 	resolveTrackedDoseEventForUser,
@@ -35,26 +36,37 @@ const doseIdParamsSchema = {
 const intakeJournalEntrySchema = {
 	type: "object",
 	required: [
+		"eventType",
+		"eventId",
 		"doseTrackingId",
 		"doseId",
 		"medicationId",
 		"medicationName",
 		"scheduledFor",
+		"occurredAt",
+		"status",
+		"takenAt",
 		"dismissed",
 		"takenSource",
+		"markedBy",
 		"mood",
 		"note",
+		"createdAt",
 		"updatedAt",
 	],
 	properties: {
+		eventType: { type: "string", enum: ["scheduled", "as_needed"] },
+		eventId: { type: ["string", "null"], format: "uuid" },
 		doseTrackingId: { type: "integer" },
 		doseId: { type: "string" },
 		medicationId: { type: "integer" },
 		medicationName: { type: "string" },
-		scheduledFor: { type: "string", format: "date-time" },
+		scheduledFor: { type: ["string", "null"], format: "date-time" },
+		occurredAt: { type: ["string", "null"], format: "date-time" },
+		status: { type: "string", enum: ["taken", "skipped", "active", "reversed"] },
 		takenAt: { type: ["string", "null"], format: "date-time" },
 		dismissed: { type: "boolean" },
-		takenSource: { type: "string", enum: ["manual", "automatic", "notification"] },
+		takenSource: { type: "string", enum: ["manual", "automatic", "notification", "owner_as_needed"] },
 		markedBy: { type: ["string", "null"] },
 		mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
 		note: { type: ["string", "null"] },
@@ -136,13 +148,21 @@ function buildJournalEntryDto(input: {
 	journalEntry: Awaited<ReturnType<typeof getIntakeJournalForDoseEvent>>;
 }) {
 	const { event, journalEntry } = input;
+	const scheduledFor =
+		event.eventType === "scheduled" && event.scheduledFor
+			? toLocalDateTimeOffsetString(journalEntry?.scheduledFor ?? event.scheduledFor)
+			: null;
 
 	return {
+		eventType: event.eventType,
+		eventId: event.eventId,
 		doseTrackingId: event.doseTrackingId,
 		doseId: event.doseId,
 		medicationId: event.medicationId,
 		medicationName: event.medicationName,
-		scheduledFor: toLocalDateTimeOffsetString(journalEntry?.scheduledFor ?? event.scheduledFor),
+		scheduledFor,
+		occurredAt: event.occurredAt?.toISOString() ?? null,
+		status: event.status,
 		takenAt: serializeTakenAt(event.takenAt, event.dismissed),
 		dismissed: event.dismissed,
 		takenSource: event.takenSource,
@@ -152,6 +172,19 @@ function buildJournalEntryDto(input: {
 		updatedAt: journalEntry?.updatedAt?.toISOString() ?? null,
 		createdAt: journalEntry?.createdAt?.toISOString() ?? null,
 	};
+}
+
+function sendJournalMutationError(
+	request: FastifyRequest,
+	reply: FastifyReply,
+	operation: "upsert" | "delete",
+	error: unknown
+): FastifyReply {
+	if (error instanceof IntakeJournalMutationError) {
+		return reply.status(409).send({ error: error.message, code: error.code });
+	}
+	request.log.error({ err: error, operation }, "[IntakeJournal] Owner mutation failed");
+	return reply.status(500).send({ error: "Internal server error", code: "INTERNAL_ERROR" });
 }
 
 async function getUserId(request: FastifyRequest, reply: FastifyReply): Promise<number> {
@@ -227,11 +260,18 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 
 			return {
 				entries: entries.map((entry) => ({
+					eventType: entry.eventType,
+					eventId: entry.eventId,
 					doseTrackingId: entry.doseTrackingId,
 					doseId: entry.doseId,
 					medicationId: entry.medicationId,
 					medicationName: entry.medicationName,
-					scheduledFor: toLocalDateTimeOffsetString(entry.scheduledFor),
+					scheduledFor:
+						entry.eventType === "scheduled" && entry.scheduledFor
+							? toLocalDateTimeOffsetString(entry.scheduledFor)
+							: null,
+					occurredAt: entry.occurredAt?.toISOString() ?? null,
+					status: entry.status,
 					takenAt: serializeTakenAt(entry.takenAt, entry.dismissed),
 					dismissed: entry.dismissed,
 					takenSource: entry.takenSource,
@@ -303,6 +343,8 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 					400: { anyOf: [genericErrorSchema, validationErrorSchema] },
 					401: genericErrorSchema,
 					404: genericErrorSchema,
+					409: genericErrorSchema,
+					500: genericErrorSchema,
 				},
 			},
 		},
@@ -326,12 +368,17 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 					.send({ error: "Tracked dose event not found for the current owner", code: "DOSE_NOT_FOUND" });
 			}
 
-			const journalEntry = await upsertIntakeJournalForDoseEvent({
-				userId,
-				doseId,
-				note: parsed.data.note,
-				mood: parsed.data.mood ?? null,
-			});
+			let journalEntry: Awaited<ReturnType<typeof upsertIntakeJournalForDoseEvent>>;
+			try {
+				journalEntry = await upsertIntakeJournalForDoseEvent({
+					userId,
+					doseId,
+					note: parsed.data.note,
+					mood: parsed.data.mood ?? null,
+				});
+			} catch (error) {
+				return sendJournalMutationError(request, reply, "upsert", error);
+			}
 
 			return { entry: buildJournalEntryDto({ event, journalEntry }) };
 		}
@@ -357,6 +404,8 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 					400: { anyOf: [genericErrorSchema, validationErrorSchema] },
 					401: genericErrorSchema,
 					404: genericErrorSchema,
+					409: genericErrorSchema,
+					500: genericErrorSchema,
 				},
 			},
 		},
@@ -368,7 +417,12 @@ export async function intakeJournalRoutes(app: FastifyInstance) {
 				return reply.status(400).send({ error: "Invalid doseId format", code: "INVALID_DOSE" });
 			}
 
-			const deleted = await deleteIntakeJournalForDoseEvent({ userId, doseId });
+			let deleted: boolean;
+			try {
+				deleted = await deleteIntakeJournalForDoseEvent({ userId, doseId });
+			} catch (error) {
+				return sendJournalMutationError(request, reply, "delete", error);
+			}
 			if (!deleted) {
 				return reply
 					.status(404)

--- a/backend/src/services/intake-journal-service.ts
+++ b/backend/src/services/intake-journal-service.ts
@@ -1,6 +1,6 @@
 import { type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
-import { and, desc, eq, gte, isNull, lte } from "drizzle-orm";
-import { db } from "../db/client.js";
+import { and, desc, eq, gte, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
+import { db, withImmediateWriteTransaction } from "../db/client.js";
 import { asNeededIntakeEvents, doseTracking, intakeJournal, medications } from "../db/schema.js";
 import { type ParsedDoseId, parseDoseId } from "../utils/dose-id.js";
 import { normalizeMedicationIntakes, parseLocalDateTime } from "../utils/scheduler-utils.js";
@@ -23,13 +23,26 @@ export type ResolvedTrackedDoseEvent = {
 	doseId: string;
 	medicationId: number;
 	medicationName: string;
-	scheduledFor: Date;
+	eventType: "scheduled" | "as_needed";
+	eventId: string | null;
+	scheduledFor: Date | null;
+	occurredAt: Date | null;
+	status: "taken" | "skipped" | "active" | "reversed";
 	takenAt: Date;
 	markedBy: string | null;
-	takenSource: DoseTrackingSource;
+	takenSource: DoseTrackingSource | "owner_as_needed";
 	dismissed: boolean;
 	personSuffix: string | null;
 };
+
+export class IntakeJournalMutationError extends Error {
+	readonly code = "EVENT_REVERSED";
+
+	constructor() {
+		super("Reversed as-needed intake journals are read-only");
+		this.name = "IntakeJournalMutationError";
+	}
+}
 
 export type IntakeJournalEntry = typeof intakeJournal.$inferSelect;
 
@@ -39,10 +52,14 @@ export type IntakeJournalHistoryEntry = {
 	doseId: string;
 	medicationId: number;
 	medicationName: string;
-	scheduledFor: Date;
+	eventType: "scheduled" | "as_needed";
+	eventId: string | null;
+	scheduledFor: Date | null;
+	occurredAt: Date | null;
+	status: "taken" | "skipped" | "active" | "reversed";
 	takenAt: Date;
 	markedBy: string | null;
-	takenSource: DoseTrackingSource;
+	takenSource: DoseTrackingSource | "owner_as_needed";
 	dismissed: boolean;
 	mood: IntakeMood | null;
 	note: string;
@@ -51,7 +68,10 @@ export type IntakeJournalHistoryEntry = {
 };
 
 export function isTrackedDoseIdFormat(doseId: string): boolean {
-	return parseDoseId(doseId) !== null;
+	return (
+		parseDoseId(doseId) !== null ||
+		/^as-needed:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(doseId)
+	);
 }
 
 function getMedicationDisplayName(medication: Pick<MedicationTimingRow, "id" | "name" | "genericName">): string {
@@ -89,16 +109,76 @@ function resolveScheduledFor(parsedDose: ParsedDoseId, medication: MedicationTim
 	);
 }
 
-export async function resolveTrackedDoseEventForUser(input: {
-	userId: number;
-	doseId: string;
-}): Promise<ResolvedTrackedDoseEvent | null> {
+export async function resolveTrackedDoseEventForUser(
+	input: {
+		userId: number;
+		doseId: string;
+	},
+	database = db
+): Promise<ResolvedTrackedDoseEvent | null> {
+	const [asNeededEvent] = await database
+		.select({
+			doseTrackingId: doseTracking.id,
+			userId: doseTracking.userId,
+			doseId: doseTracking.doseId,
+			eventId: asNeededIntakeEvents.eventId,
+			occurredAt: asNeededIntakeEvents.occurredAt,
+			status: asNeededIntakeEvents.status,
+			medicationId: medications.id,
+			medicationName: medications.name,
+			medicationGenericName: medications.genericName,
+		})
+		.from(asNeededIntakeEvents)
+		.innerJoin(
+			doseTracking,
+			and(
+				eq(doseTracking.id, asNeededIntakeEvents.doseTrackingId),
+				eq(doseTracking.userId, asNeededIntakeEvents.userId)
+			)
+		)
+		.innerJoin(
+			medications,
+			and(eq(medications.id, asNeededIntakeEvents.medicationId), eq(medications.userId, asNeededIntakeEvents.userId))
+		)
+		.where(
+			and(
+				eq(asNeededIntakeEvents.userId, input.userId),
+				eq(doseTracking.userId, input.userId),
+				eq(doseTracking.doseId, input.doseId)
+			)
+		)
+		.limit(1);
+
+	if (asNeededEvent) {
+		return {
+			doseTrackingId: asNeededEvent.doseTrackingId,
+			userId: asNeededEvent.userId,
+			doseId: asNeededEvent.doseId,
+			medicationId: asNeededEvent.medicationId,
+			medicationName: getMedicationDisplayName({
+				id: asNeededEvent.medicationId,
+				name: asNeededEvent.medicationName,
+				genericName: asNeededEvent.medicationGenericName,
+			}),
+			eventType: "as_needed",
+			eventId: asNeededEvent.eventId,
+			scheduledFor: null,
+			occurredAt: asNeededEvent.occurredAt,
+			status: asNeededEvent.status === "reversed" ? "reversed" : "active",
+			takenAt: asNeededEvent.occurredAt,
+			markedBy: null,
+			takenSource: "owner_as_needed",
+			dismissed: false,
+			personSuffix: null,
+		};
+	}
+
 	const parsedDose = parseDoseId(input.doseId);
 	if (!parsedDose) {
 		return null;
 	}
 
-	const [event] = await db
+	const [event] = await database
 		.select({
 			doseTrackingId: doseTracking.id,
 			userId: doseTracking.userId,
@@ -152,7 +232,11 @@ export async function resolveTrackedDoseEventForUser(input: {
 			name: event.medicationName,
 			genericName: event.medicationGenericName,
 		}),
+		eventType: "scheduled",
+		eventId: null,
 		scheduledFor,
+		occurredAt: null,
+		status: event.dismissed ? "skipped" : "taken",
 		takenAt: event.takenAt,
 		markedBy: event.markedBy,
 		takenSource: event.takenSource as DoseTrackingSource,
@@ -187,55 +271,68 @@ export async function upsertIntakeJournalForDoseEvent(input: {
 }): Promise<IntakeJournalEntry | null> {
 	const normalizedNote = input.note.trim();
 	const normalizedMood = input.mood ?? null;
-	if (normalizedNote.length === 0 && normalizedMood === null) {
-		await deleteIntakeJournalForDoseEvent({ userId: input.userId, doseId: input.doseId });
-		return null;
-	}
+	return withImmediateWriteTransaction(async (transactionDb) => {
+		const event = await resolveTrackedDoseEventForUser({ userId: input.userId, doseId: input.doseId }, transactionDb);
+		if (!event) return null;
+		if (event.eventType === "as_needed" && event.status === "reversed") {
+			throw new IntakeJournalMutationError();
+		}
 
-	const event = await resolveTrackedDoseEventForUser({ userId: input.userId, doseId: input.doseId });
-	if (!event) {
-		return null;
-	}
+		if (normalizedNote.length === 0 && normalizedMood === null) {
+			await transactionDb
+				.delete(intakeJournal)
+				.where(and(eq(intakeJournal.userId, input.userId), eq(intakeJournal.doseTrackingId, event.doseTrackingId)));
+			return null;
+		}
 
-	const now = new Date();
-
-	await db
-		.insert(intakeJournal)
-		.values({
-			userId: input.userId,
-			doseTrackingId: event.doseTrackingId,
-			medicationId: event.medicationId,
-			scheduledFor: event.scheduledFor,
-			mood: normalizedMood ?? "",
-			note: normalizedNote,
-			createdAt: now,
-			updatedAt: now,
-		})
-		.onConflictDoUpdate({
-			target: intakeJournal.doseTrackingId,
-			set: {
+		const journalTimestamp = event.occurredAt ?? event.scheduledFor;
+		if (!journalTimestamp) throw new Error("Resolved journal event has no authoritative timestamp");
+		const now = new Date();
+		await transactionDb
+			.insert(intakeJournal)
+			.values({
 				userId: input.userId,
+				doseTrackingId: event.doseTrackingId,
 				medicationId: event.medicationId,
+				scheduledFor: journalTimestamp,
 				mood: normalizedMood ?? "",
 				note: normalizedNote,
+				createdAt: now,
 				updatedAt: now,
-			},
-		});
+			})
+			.onConflictDoUpdate({
+				target: intakeJournal.doseTrackingId,
+				set: {
+					userId: input.userId,
+					medicationId: event.medicationId,
+					mood: normalizedMood ?? "",
+					note: normalizedNote,
+					updatedAt: now,
+				},
+			});
 
-	return getIntakeJournalForDoseEvent({ userId: input.userId, doseId: input.doseId });
+		const [journalEntry] = await transactionDb
+			.select()
+			.from(intakeJournal)
+			.where(and(eq(intakeJournal.userId, input.userId), eq(intakeJournal.doseTrackingId, event.doseTrackingId)))
+			.limit(1);
+		return journalEntry ?? null;
+	});
 }
 
 export async function deleteIntakeJournalForDoseEvent(input: { userId: number; doseId: string }): Promise<boolean> {
-	const event = await resolveTrackedDoseEventForUser(input);
-	if (!event) {
-		return false;
-	}
+	return withImmediateWriteTransaction(async (transactionDb) => {
+		const event = await resolveTrackedDoseEventForUser(input, transactionDb);
+		if (!event) return false;
+		if (event.eventType === "as_needed" && event.status === "reversed") {
+			throw new IntakeJournalMutationError();
+		}
 
-	await db
-		.delete(intakeJournal)
-		.where(and(eq(intakeJournal.userId, input.userId), eq(intakeJournal.doseTrackingId, event.doseTrackingId)));
-
-	return true;
+		await transactionDb
+			.delete(intakeJournal)
+			.where(and(eq(intakeJournal.userId, input.userId), eq(intakeJournal.doseTrackingId, event.doseTrackingId)));
+		return true;
+	});
 }
 
 export async function listIntakeJournalEntriesForUser(input: {
@@ -252,11 +349,21 @@ export async function listIntakeJournalEntriesForUser(input: {
 	}
 
 	if (input.from) {
-		filters.push(gte(intakeJournal.scheduledFor, input.from));
+		filters.push(
+			or(
+				and(isNotNull(asNeededIntakeEvents.id), gte(asNeededIntakeEvents.occurredAt, input.from)),
+				and(isNull(asNeededIntakeEvents.id), gte(intakeJournal.scheduledFor, input.from))
+			)!
+		);
 	}
 
 	if (input.to) {
-		filters.push(lte(intakeJournal.scheduledFor, input.to));
+		filters.push(
+			or(
+				and(isNotNull(asNeededIntakeEvents.id), lte(asNeededIntakeEvents.occurredAt, input.to)),
+				and(isNull(asNeededIntakeEvents.id), lte(intakeJournal.scheduledFor, input.to))
+			)!
+		);
 	}
 
 	const rows = await db
@@ -276,43 +383,65 @@ export async function listIntakeJournalEntriesForUser(input: {
 			note: intakeJournal.note,
 			createdAt: intakeJournal.createdAt,
 			updatedAt: intakeJournal.updatedAt,
+			eventId: asNeededIntakeEvents.eventId,
+			eventOccurredAt: asNeededIntakeEvents.occurredAt,
+			eventStatus: asNeededIntakeEvents.status,
 		})
 		.from(intakeJournal)
 		.innerJoin(doseTracking, eq(doseTracking.id, intakeJournal.doseTrackingId))
 		.leftJoin(
 			asNeededIntakeEvents,
-			and(eq(asNeededIntakeEvents.doseTrackingId, doseTracking.id), eq(asNeededIntakeEvents.userId, input.userId))
-		)
-		.innerJoin(medications, eq(medications.id, intakeJournal.medicationId))
-		.where(
 			and(
-				...filters,
-				eq(doseTracking.userId, input.userId),
-				eq(medications.userId, input.userId),
-				isNull(asNeededIntakeEvents.id)
+				eq(asNeededIntakeEvents.doseTrackingId, doseTracking.id),
+				eq(asNeededIntakeEvents.userId, input.userId),
+				eq(asNeededIntakeEvents.medicationId, intakeJournal.medicationId)
 			)
 		)
-		.orderBy(desc(intakeJournal.scheduledFor), desc(intakeJournal.updatedAt))
+		.innerJoin(medications, eq(medications.id, intakeJournal.medicationId))
+		.where(and(...filters, eq(doseTracking.userId, input.userId), eq(medications.userId, input.userId)))
+		.orderBy(
+			desc(sql`coalesce(${asNeededIntakeEvents.occurredAt}, ${intakeJournal.scheduledFor})`),
+			desc(intakeJournal.updatedAt)
+		)
 		.limit(input.limit ?? 100);
 
-	return rows.map((row) => ({
-		id: row.id,
-		doseTrackingId: row.doseTrackingId,
-		doseId: row.doseId,
-		medicationId: row.medicationId,
-		medicationName: getMedicationDisplayName({
-			id: row.medicationId,
-			name: row.medicationName,
-			genericName: row.medicationGenericName,
-		}),
-		scheduledFor: row.scheduledFor,
-		takenAt: row.takenAt,
-		markedBy: row.markedBy,
-		takenSource: row.takenSource as DoseTrackingSource,
-		dismissed: row.dismissed ?? false,
-		mood: normalizeIntakeMood(row.mood),
-		note: row.note,
-		createdAt: row.createdAt,
-		updatedAt: row.updatedAt,
-	}));
+	return rows.map((row) => {
+		const isAsNeeded = row.eventId !== null && row.eventOccurredAt !== null;
+		let status: IntakeJournalHistoryEntry["status"];
+		let takenAt: Date;
+		let takenSource: IntakeJournalHistoryEntry["takenSource"];
+		if (isAsNeeded) {
+			status = row.eventStatus === "reversed" ? "reversed" : "active";
+			takenAt = row.eventOccurredAt ?? row.takenAt;
+			takenSource = "owner_as_needed";
+		} else {
+			status = row.dismissed ? "skipped" : "taken";
+			takenAt = row.takenAt;
+			takenSource = row.takenSource as DoseTrackingSource;
+		}
+		return {
+			id: row.id,
+			doseTrackingId: row.doseTrackingId,
+			doseId: row.doseId,
+			medicationId: row.medicationId,
+			medicationName: getMedicationDisplayName({
+				id: row.medicationId,
+				name: row.medicationName,
+				genericName: row.medicationGenericName,
+			}),
+			eventType: isAsNeeded ? "as_needed" : "scheduled",
+			eventId: isAsNeeded ? row.eventId : null,
+			scheduledFor: isAsNeeded ? null : row.scheduledFor,
+			occurredAt: isAsNeeded ? row.eventOccurredAt : null,
+			status,
+			takenAt,
+			markedBy: isAsNeeded ? null : row.markedBy,
+			takenSource,
+			dismissed: isAsNeeded ? false : (row.dismissed ?? false),
+			mood: normalizeIntakeMood(row.mood),
+			note: row.note,
+			createdAt: row.createdAt,
+			updatedAt: row.updatedAt,
+		};
+	});
 }

--- a/backend/src/test/doses.test.ts
+++ b/backend/src/test/doses.test.ts
@@ -33,6 +33,8 @@ const { testClient, testDb, mockedEnv } = vi.hoisted(() => {
 vi.mock("../db/client.js", () => ({
 	db: testDb,
 	migrationsReady: Promise.resolve(),
+	withImmediateWriteTransaction: async <T>(operation: (transactionDb: typeof testDb) => Promise<T>): Promise<T> =>
+		operation(testDb),
 }));
 
 vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));

--- a/backend/src/test/intake-journal-routes.test.ts
+++ b/backend/src/test/intake-journal-routes.test.ts
@@ -47,7 +47,9 @@ vi.mock("../db/client.js", () => ({
 vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));
 
 const { exportRoutes } = await import("../routes/export.js");
+const { asNeededIntakeRoutes } = await import("../routes/as-needed-intakes.js");
 const { intakeJournalRoutes } = await import("../routes/intake-journal.js");
+const { hashApiKeyToken } = await import("../plugins/auth.js");
 
 async function clearTables() {
 	await testClient.execute("DELETE FROM intake_journal");
@@ -126,6 +128,66 @@ async function seedTrackedDose(options: {
 	return Number(result.rows[0].id);
 }
 
+async function seedAsNeededEvent(options: {
+	userId: number;
+	medicationId: number;
+	eventId: string;
+	occurredAt: string;
+	journalScheduledFor?: string;
+}) {
+	const doseId = `as-needed:${options.eventId}`;
+	const occurredAt = new Date(options.occurredAt);
+	const idempotencyKeyHash = options.eventId.replaceAll("-", "").padEnd(64, "0");
+	const anchorId = await seedTrackedDose({ userId: options.userId, doseId, takenAt: occurredAt });
+	await testClient.execute({
+		sql: `INSERT INTO as_needed_intake_events (
+		  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
+		  occurred_at, recorded_at, quantity_milli, quantity_unit, stock_effect_milli
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		args: [
+			options.eventId,
+			options.userId,
+			options.medicationId,
+			anchorId,
+			idempotencyKeyHash,
+			HASH_B,
+			Math.floor(occurredAt.getTime() / 1000),
+			Math.floor(occurredAt.getTime() / 1000),
+			1000,
+			"pills",
+			1000,
+		],
+	});
+
+	if (options.journalScheduledFor) {
+		await testClient.execute({
+			sql: `INSERT INTO intake_journal (
+			  user_id, dose_tracking_id, medication_id, scheduled_for, mood, note, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				options.userId,
+				anchorId,
+				options.medicationId,
+				Math.floor(new Date(options.journalScheduledFor).getTime() / 1000),
+				"neutral",
+				"Seeded note",
+				Math.floor(occurredAt.getTime() / 1000),
+				Math.floor(occurredAt.getTime() / 1000),
+			],
+		});
+	}
+
+	return { anchorId, doseId };
+}
+
+async function insertReadOnlyApiKey(userId: number, token: string) {
+	await testClient.execute({
+		sql: `INSERT INTO api_keys (user_id, name, key_hash, token_prefix, scope, is_active)
+		      VALUES (?, 'Read journal', ?, ?, 'read', 1)`,
+		args: [userId, hashApiKeyToken(token), `${token.slice(0, 12)}...`],
+	});
+}
+
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
 const HASH_C = "c".repeat(64);
@@ -167,6 +229,7 @@ describe("Intake journal routes", () => {
 	beforeAll(async () => {
 		const context = await buildTestApp({ client: testClient });
 		app = context.app;
+		await app.register(asNeededIntakeRoutes);
 		await app.register(intakeJournalRoutes);
 		await app.register(exportRoutes);
 		await app.ready();
@@ -307,6 +370,219 @@ describe("Intake journal routes", () => {
 
 		expect(emptyHistoryResponse.statusCode).toBe(200);
 		expect(emptyHistoryResponse.json().entries).toEqual([]);
+	});
+
+	it("keeps scheduled DTOs stable while exposing owner-scoped as-needed journal events", async () => {
+		const ownerId = await createTestUser(testClient, { username: "journal-as-needed-owner" });
+		const otherId = await createTestUser(testClient, { username: "journal-as-needed-other" });
+		const ownerCookie = await buildTestSessionCookie(app, ownerId, "journal-as-needed-owner");
+		const medicationId = await seedMedication({ userId: ownerId, name: "As-needed journal medication" });
+		const otherMedicationId = await seedMedication({ userId: otherId, name: "Other as-needed medication" });
+		const scheduledDoseId = `${medicationId}-0-${new Date("2026-02-02T08:00:00.000Z").getTime()}-Daniel`;
+		await seedTrackedDose({
+			userId: ownerId,
+			doseId: scheduledDoseId,
+			takenAt: new Date("2026-02-02T08:05:00.000Z"),
+			markedBy: "Daniel",
+		});
+		const { doseId } = await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_A,
+			occurredAt: "2026-02-03T09:15:00.000Z",
+		});
+		const { doseId: otherDoseId } = await seedAsNeededEvent({
+			userId: otherId,
+			medicationId: otherMedicationId,
+			eventId: EVENT_B,
+			occurredAt: "2026-02-03T10:15:00.000Z",
+		});
+
+		const scheduled = await app.inject({
+			method: "GET",
+			url: `/intake-journal/event/${encodeURIComponent(scheduledDoseId)}`,
+			headers: { cookie: ownerCookie },
+		});
+		expect(scheduled.statusCode).toBe(200);
+		expect(scheduled.json().entry).toMatchObject({
+			eventType: "scheduled",
+			eventId: null,
+			scheduledFor: expect.stringContaining("T08:00:00"),
+			occurredAt: null,
+			status: "taken",
+			takenSource: "manual",
+		});
+
+		const initial = await app.inject({
+			method: "GET",
+			url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+			headers: { cookie: ownerCookie },
+		});
+		expect(initial.statusCode).toBe(200);
+		expect(initial.json().entry).toMatchObject({
+			eventType: "as_needed",
+			eventId: EVENT_A,
+			scheduledFor: null,
+			occurredAt: "2026-02-03T09:15:00.000Z",
+			status: "active",
+			takenSource: "owner_as_needed",
+			markedBy: null,
+			note: null,
+			mood: null,
+		});
+
+		const saved = await app.inject({
+			method: "PUT",
+			url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+			headers: { cookie: ownerCookie },
+			payload: { note: "Used when needed.", mood: "good" },
+		});
+		expect(saved.statusCode).toBe(200);
+		expect(saved.json().entry).toMatchObject({ eventType: "as_needed", scheduledFor: null, note: "Used when needed." });
+
+		for (const inaccessibleDoseId of [otherDoseId, `as-needed:${EVENT_C}`]) {
+			const response = await app.inject({
+				method: "GET",
+				url: `/intake-journal/event/${encodeURIComponent(inaccessibleDoseId)}`,
+				headers: { cookie: ownerCookie },
+			});
+			expect(response.statusCode).toBe(404);
+			expect(response.json()).toMatchObject({ code: "DOSE_NOT_FOUND" });
+		}
+
+		const apiToken = "ma_read_as_needed_journal_123456789";
+		await insertReadOnlyApiKey(ownerId, apiToken);
+		expect(
+			(
+				await app.inject({
+					method: "GET",
+					url: "/intake-journal",
+					headers: { authorization: `Bearer ${apiToken}` },
+				})
+			).statusCode
+		).toBe(200);
+		const readOnlyMutation = await app.inject({
+			method: "PUT",
+			url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+			headers: { authorization: `Bearer ${apiToken}` },
+			payload: { note: "Must not be saved." },
+		});
+		expect(readOnlyMutation.statusCode).toBe(403);
+		expect(readOnlyMutation.json()).toMatchObject({ code: "API_KEY_SCOPE_FORBIDDEN" });
+
+		const reversed = await app.inject({
+			method: "POST",
+			url: `/as-needed-intakes/${EVENT_A}/reversal`,
+			headers: { cookie: ownerCookie, "idempotency-key": "00000000-0000-4000-8000-000000000010" },
+			payload: { expectedRevision: 1 },
+		});
+		expect(reversed.statusCode).toBe(200);
+
+		const reversedRead = await app.inject({
+			method: "GET",
+			url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+			headers: { cookie: ownerCookie },
+		});
+		expect(reversedRead.statusCode).toBe(200);
+		expect(reversedRead.json().entry).toMatchObject({ status: "reversed", note: "Used when needed." });
+
+		for (const mutation of [
+			{ method: "PUT", payload: { note: "Cannot alter reversed event." } },
+			{ method: "DELETE" },
+		] as const) {
+			const response = await app.inject({
+				method: mutation.method,
+				url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+				headers: { cookie: ownerCookie },
+				payload: mutation.payload,
+			});
+			expect(response.statusCode).toBe(409);
+			expect(response.json()).toMatchObject({ code: "EVENT_REVERSED" });
+		}
+	});
+
+	it("sorts and filters as-needed journal history by occurredAt rather than its journal timestamp", async () => {
+		const userId = await createTestUser(testClient, { username: "journal-history-time" });
+		const cookie = await buildTestSessionCookie(app, userId, "journal-history-time");
+		const medicationId = await seedMedication({ userId, name: "History timing medication" });
+		const first = await seedAsNeededEvent({
+			userId,
+			medicationId,
+			eventId: EVENT_A,
+			occurredAt: "2026-02-10T09:00:00.000Z",
+			journalScheduledFor: "2026-01-01T09:00:00.000Z",
+		});
+		const second = await seedAsNeededEvent({
+			userId,
+			medicationId,
+			eventId: EVENT_B,
+			occurredAt: "2026-02-11T09:00:00.000Z",
+			journalScheduledFor: "2026-01-02T09:00:00.000Z",
+		});
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/intake-journal?from=2026-02-10T00:00:00.000Z&to=2026-02-10T23:59:59.999Z",
+			headers: { cookie },
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json().entries).toEqual([
+			expect.objectContaining({ doseId: first.doseId, occurredAt: "2026-02-10T09:00:00.000Z", scheduledFor: null }),
+		]);
+
+		const all = await app.inject({ method: "GET", url: "/intake-journal", headers: { cookie } });
+		expect(all.statusCode).toBe(200);
+		expect(all.json().entries.map((entry: { doseId: string }) => entry.doseId)).toEqual([second.doseId, first.doseId]);
+	});
+
+	it("serializes a journal update racing an as-needed reversal and preserves the reversed read-only boundary", async () => {
+		const userId = await createTestUser(testClient, { username: "journal-reversal-race" });
+		const cookie = await buildTestSessionCookie(app, userId, "journal-reversal-race");
+		const medicationId = await seedMedication({ userId, name: "Reversal race medication" });
+		const { doseId } = await seedAsNeededEvent({
+			userId,
+			medicationId,
+			eventId: EVENT_C,
+			occurredAt: "2026-02-12T09:00:00.000Z",
+		});
+
+		const [journalUpdate, reversal] = await Promise.all([
+			app.inject({
+				method: "PUT",
+				url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+				headers: { cookie },
+				payload: { note: "Race-safe note" },
+			}),
+			app.inject({
+				method: "POST",
+				url: `/as-needed-intakes/${EVENT_C}/reversal`,
+				headers: { cookie, "idempotency-key": "00000000-0000-4000-8000-000000000011" },
+				payload: { expectedRevision: 1 },
+			}),
+		]);
+
+		expect(reversal.statusCode).toBe(200);
+		expect([200, 409]).toContain(journalUpdate.statusCode);
+		if (journalUpdate.statusCode === 409) {
+			expect(journalUpdate.json()).toMatchObject({ code: "EVENT_REVERSED" });
+		}
+
+		const afterRace = await app.inject({
+			method: "GET",
+			url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+			headers: { cookie },
+		});
+		expect(afterRace.statusCode).toBe(200);
+		expect(afterRace.json().entry).toMatchObject({ eventType: "as_needed", status: "reversed" });
+
+		const laterUpdate = await app.inject({
+			method: "PUT",
+			url: `/intake-journal/event/${encodeURIComponent(doseId)}`,
+			headers: { cookie },
+			payload: { note: "Cannot cross reversal boundary" },
+		});
+		expect(laterUpdate.statusCode).toBe(409);
+		expect(laterUpdate.json()).toMatchObject({ code: "EVENT_REVERSED" });
 	});
 
 	it("exports owner as-needed events in v1.9 without leaking anchors into scheduled history", async () => {


### PR DESCRIPTION
Closes #1017

## Summary

- add companion-authoritative discrimination between scheduled and as-needed journal events
- support owner-scoped as-needed journal create, update, read, history, and delete behavior while preserving scheduled semantics
- keep reversed as-needed records readable but reject their journal mutations, including race-safe immediate writes

## Scope boundary

No share/public mutation route or report totals is included. Fake reserved prefixes remain hidden, and this unlocks #1035.

## Validation

- focused journal coverage: 11 tests
- focused dose coverage: 28 tests
- full backend suite: 48 files, 941 tests
- lint, check, build, and diff check

Security review found no critical, major, or minor findings.