### PR TITLE
feat: add as-needed report audit data

### DIFF
--- a/backend/src/routes/report.ts
+++ b/backend/src/routes/report.ts
@@ -1,9 +1,15 @@
-import { INTAKE_MOODS, type IntakeMood, normalizeIntakeMood } from "@medassist/shared";
+import {
+	AS_NEEDED_QUANTITY_UNITS,
+	type AsNeededQuantityUnit,
+	INTAKE_MOODS,
+	type IntakeMood,
+	normalizeIntakeMood,
+} from "@medassist/shared";
 import { and, eq, gte, inArray, lt } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { db } from "../db/client.js";
-import { doseTracking, intakeJournal, medications, refillHistory } from "../db/schema.js";
+import { asNeededIntakeEvents, doseTracking, intakeJournal, medications, refillHistory } from "../db/schema.js";
 import { getAnonymousUserId, requireAuth } from "../plugins/auth.js";
 import { env } from "../plugins/env.js";
 import { filterScheduledDoseRows } from "../services/as-needed-intakes-service.js";
@@ -125,6 +131,27 @@ function isWithinDateRange(timestampMs: number | null, range: { startMs: number;
 	return timestampMs >= range.startMs && timestampMs < range.endMs;
 }
 
+type AsNeededStatus = "active" | "reversed";
+type AsNeededStockEffectReason = "applied" | "non_measurable" | "before_correction" | "superseded_by_correction";
+
+type AsNeededReportEntry = {
+	eventId: string;
+	status: AsNeededStatus;
+	occurredAt: string;
+	recordedAt: string;
+	quantity: number;
+	quantityUnit: AsNeededQuantityUnit;
+	person: string | null;
+	source: "owner_as_needed";
+	stockEffect: number;
+	stockEffectReason: AsNeededStockEffectReason;
+	replacementForEventId: string | null;
+	reversedAt: string | null;
+	revision: number;
+	mood: IntakeMood | null;
+	note: string | null;
+};
+
 const reportDataResponseSchema = {
 	type: "object",
 	additionalProperties: {
@@ -133,6 +160,38 @@ const reportDataResponseSchema = {
 			dosesTaken: { type: "integer" },
 			automaticDosesTaken: { type: "integer" },
 			dosesSkipped: { type: "integer" },
+			asNeededIntakesTaken: { type: "integer" },
+			asNeededQuantityByUnit: {
+				type: "object",
+				properties: Object.fromEntries(AS_NEEDED_QUANTITY_UNITS.map((unit) => [unit, { type: "number" }])),
+				additionalProperties: false,
+			},
+			asNeededIntakes: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: {
+						eventId: { type: "string", format: "uuid" },
+						status: { type: "string", enum: ["active", "reversed"] },
+						occurredAt: { type: "string", format: "date-time" },
+						recordedAt: { type: "string", format: "date-time" },
+						quantity: { type: "number" },
+						quantityUnit: { type: "string", enum: AS_NEEDED_QUANTITY_UNITS },
+						person: { type: ["string", "null"] },
+						source: { type: "string", const: "owner_as_needed" },
+						stockEffect: { type: "number" },
+						stockEffectReason: {
+							type: "string",
+							enum: ["applied", "non_measurable", "before_correction", "superseded_by_correction"],
+						},
+						replacementForEventId: { type: ["string", "null"], format: "uuid" },
+						reversedAt: { type: ["string", "null"], format: "date-time" },
+						revision: { type: "integer", minimum: 1 },
+						mood: { type: ["string", "null"], enum: [...INTAKE_MOODS, null] },
+						note: { type: ["string", "null"] },
+					},
+				},
+			},
 			firstDoseAt: { type: "string" },
 			lastDoseAt: { type: "string" },
 			moodSummary: {
@@ -306,6 +365,60 @@ export async function reportRoutes(app: FastifyInstance) {
 				}
 			}
 
+			const asNeededFilters = [
+				eq(asNeededIntakeEvents.userId, userId),
+				inArray(asNeededIntakeEvents.medicationId, medicationIds),
+			];
+			if (dateRange) {
+				asNeededFilters.push(gte(asNeededIntakeEvents.occurredAt, new Date(dateRange.startMs)));
+				asNeededFilters.push(lt(asNeededIntakeEvents.occurredAt, new Date(dateRange.endMs)));
+			}
+			const asNeededRows = await db
+				.select({
+					event: asNeededIntakeEvents,
+					journalMood: intakeJournal.mood,
+					journalNote: intakeJournal.note,
+				})
+				.from(asNeededIntakeEvents)
+				.leftJoin(
+					intakeJournal,
+					and(
+						eq(intakeJournal.doseTrackingId, asNeededIntakeEvents.doseTrackingId),
+						eq(intakeJournal.userId, asNeededIntakeEvents.userId),
+						eq(intakeJournal.medicationId, asNeededIntakeEvents.medicationId)
+					)
+				)
+				.where(and(...asNeededFilters));
+
+			const replacementTargetIds = [
+				...new Set(
+					asNeededRows
+						.map(({ event }) => event.replacesEventId)
+						.filter((eventId): eventId is number => eventId !== null)
+				),
+			];
+			const replacementEventIdById = new Map<number, string>();
+			if (replacementTargetIds.length > 0) {
+				const replacementTargets = await db
+					.select({ id: asNeededIntakeEvents.id, eventId: asNeededIntakeEvents.eventId })
+					.from(asNeededIntakeEvents)
+					.where(and(eq(asNeededIntakeEvents.userId, userId), inArray(asNeededIntakeEvents.id, replacementTargetIds)));
+				for (const target of replacementTargets) {
+					replacementEventIdById.set(target.id, target.eventId);
+				}
+			}
+
+			const asNeededRowsByMed = new Map<number, (typeof asNeededRows)[number][]>();
+			for (const row of asNeededRows) {
+				const person = row.event.personName.trim();
+				if (normalizedTakenByFilter && !normalizedTakenByFilter.has(getPersonTagKey(person))) {
+					continue;
+				}
+				const medicationRows = asNeededRowsByMed.get(row.event.medicationId) ?? [];
+				medicationRows.push(row);
+				asNeededRowsByMed.set(row.event.medicationId, medicationRows);
+			}
+
 			// Fetch refill history for requested medications
 			const result: Record<
 				number,
@@ -316,6 +429,9 @@ export async function reportRoutes(app: FastifyInstance) {
 					firstDoseAt: string | null;
 					lastDoseAt: string | null;
 					moodSummary: Record<IntakeMood, number>;
+					asNeededIntakesTaken: number;
+					asNeededQuantityByUnit: Partial<Record<AsNeededQuantityUnit, number>>;
+					asNeededIntakes: AsNeededReportEntry[];
 					journalEntries: {
 						scheduledFor: string;
 						takenAt: string | null;
@@ -340,6 +456,7 @@ export async function reportRoutes(app: FastifyInstance) {
 				const takenDoses = doses.filter((d) => !d.dismissed);
 				const automaticTakenDoses = takenDoses.filter((d) => d.takenSource === "automatic");
 				const skippedDoses = doses.filter((d) => d.dismissed);
+				const asNeededRowsForMedication = asNeededRowsByMed.get(medId) ?? [];
 
 				const sortedTaken = takenDoses.map((d) => d.takenAt.getTime()).sort((a, b) => a - b);
 				const moodSummary = Object.fromEntries(INTAKE_MOODS.map((mood) => [mood, 0])) as Record<IntakeMood, number>;
@@ -374,6 +491,44 @@ export async function reportRoutes(app: FastifyInstance) {
 					})
 					.filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 					.sort((a, b) => new Date(a.scheduledFor).getTime() - new Date(b.scheduledFor).getTime());
+				const asNeededQuantityMilliByUnit: Partial<Record<AsNeededQuantityUnit, number>> = {};
+				const asNeededIntakes = asNeededRowsForMedication
+					.map(({ event, journalMood, journalNote }): AsNeededReportEntry => {
+						const mood = normalizeIntakeMood(journalMood);
+						if (event.status === "active") {
+							const unit = event.quantityUnit as AsNeededQuantityUnit;
+							asNeededQuantityMilliByUnit[unit] = (asNeededQuantityMilliByUnit[unit] ?? 0) + event.quantityMilli;
+							if (mood) {
+								moodSummary[mood] += 1;
+							}
+						}
+						return {
+							eventId: event.eventId,
+							status: event.status as AsNeededStatus,
+							occurredAt: event.occurredAt.toISOString(),
+							recordedAt: event.recordedAt.toISOString(),
+							quantity: event.quantityMilli / 1000,
+							quantityUnit: event.quantityUnit as AsNeededQuantityUnit,
+							person: event.personName.trim().length > 0 ? event.personName : null,
+							source: "owner_as_needed",
+							stockEffect: event.stockEffectMilli / 1000,
+							stockEffectReason: event.stockEffectReason as AsNeededStockEffectReason,
+							replacementForEventId: event.replacesEventId
+								? (replacementEventIdById.get(event.replacesEventId) ?? null)
+								: null,
+							reversedAt: event.reversedAt?.toISOString() ?? null,
+							revision: event.revision,
+							mood,
+							note: journalNote && journalNote.trim().length > 0 ? journalNote : null,
+						};
+					})
+					.sort((a, b) => {
+						const occurredDifference = new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime();
+						return occurredDifference !== 0 ? occurredDifference : b.eventId.localeCompare(a.eventId);
+					});
+				const asNeededQuantityByUnit = Object.fromEntries(
+					Object.entries(asNeededQuantityMilliByUnit).map(([unit, quantityMilli]) => [unit, quantityMilli / 1000])
+				) as Partial<Record<AsNeededQuantityUnit, number>>;
 				const medication = medMap.get(medId);
 				const pillsPerPack = Math.max(1, (medication?.blistersPerPack ?? 1) * (medication?.pillsPerBlister ?? 1));
 				const isAmountBased = medication?.packageType === "liquid_container" || medication?.packageType === "tube";
@@ -393,6 +548,9 @@ export async function reportRoutes(app: FastifyInstance) {
 					dosesTaken: takenDoses.length,
 					automaticDosesTaken: automaticTakenDoses.length,
 					dosesSkipped: skippedDoses.length,
+					asNeededIntakesTaken: asNeededRowsForMedication.filter(({ event }) => event.status === "active").length,
+					asNeededQuantityByUnit,
+					asNeededIntakes,
 					firstDoseAt: sortedTaken.length > 0 ? new Date(sortedTaken[0]).toISOString() : null,
 					lastDoseAt: sortedTaken.length > 0 ? new Date(sortedTaken[sortedTaken.length - 1]).toISOString() : null,
 					moodSummary,

--- a/backend/src/test/report.test.ts
+++ b/backend/src/test/report.test.ts
@@ -1,0 +1,360 @@
+import { existsSync, unlinkSync } from "node:fs";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildTestApp, buildTestSessionCookie, closeTestApp, createTestUser } from "./setup.js";
+
+const { testClient, testDb, testDbPath, mockedEnv } = vi.hoisted(() => {
+	const { createClient } = require("@libsql/client");
+	const { drizzle } = require("drizzle-orm/libsql");
+	const { tmpdir } = require("node:os");
+	const { join } = require("node:path");
+	const dbPath = join(tmpdir(), `medassist-report-routes-${process.pid}-${Date.now()}.db`);
+	const client = createClient({ url: `file:${dbPath}` });
+	return {
+		testClient: client,
+		testDb: drizzle(client),
+		testDbPath: dbPath,
+		mockedEnv: {
+			AUTH_ENABLED: true,
+			REGISTRATION_ENABLED: true,
+			FORM_LOGIN_ENABLED: true,
+			OIDC_ENABLED: false,
+			OIDC_PROVIDER_NAME: "SSO",
+			NODE_ENV: "test",
+			LOG_LEVEL: "silent",
+			PORT: 3000,
+			CORS_ORIGINS: "*",
+			JWT_SECRET: "test-jwt-secret",
+			REFRESH_SECRET: "test-refresh-secret",
+			COOKIE_SECRET: "test-cookie-secret",
+			ACCESS_TOKEN_TTL_MINUTES: 15,
+			REFRESH_TOKEN_TTL_DAYS: 7,
+			OPENAPI_DOCS_ENABLED: false,
+		},
+	};
+});
+
+vi.mock("../db/client.js", () => ({ db: testDb, migrationsReady: Promise.resolve() }));
+vi.mock("../plugins/env.js", () => ({ env: mockedEnv }));
+
+const { reportRoutes } = await import("../routes/report.js");
+
+const EVENT_A = "00000000-0000-4000-8000-000000000001";
+const EVENT_B = "00000000-0000-4000-8000-000000000002";
+const EVENT_C = "00000000-0000-4000-8000-000000000003";
+const EVENT_D = "00000000-0000-4000-8000-000000000004";
+
+async function clearTables() {
+	await testClient.execute("DELETE FROM intake_journal");
+	await testClient.execute("DELETE FROM as_needed_intake_events");
+	await testClient.execute("DELETE FROM dose_tracking");
+	await testClient.execute("DELETE FROM refill_history");
+	await testClient.execute("DELETE FROM share_tokens");
+	await testClient.execute("DELETE FROM api_keys");
+	await testClient.execute("DELETE FROM refresh_tokens");
+	await testClient.execute("DELETE FROM user_settings");
+	await testClient.execute("DELETE FROM medications");
+	await testClient.execute("DELETE FROM users");
+}
+
+async function seedMedication(userId: number, name: string) {
+	const start = "2026-02-01T08:00:00.000Z";
+	const result = await testClient.execute({
+		sql: `INSERT INTO medications (
+		  user_id, name, generic_name, taken_by_json, medication_form, package_type,
+		  pack_count, blisters_per_pack, pills_per_blister, loose_tablets,
+		  usage_json, every_json, start_json, intakes_json, stock_adjustment, intake_reminders_enabled
+		) VALUES (?, ?, ?, '[]', 'tablet', 'blister', 1, 1, 10, 0, '[1]', '[1]', ?, ?, 0, 0) RETURNING id`,
+		args: [
+			userId,
+			name,
+			`${name} Generic`,
+			start,
+			JSON.stringify([{ usage: 1, every: 1, start, takenBy: null, intakeRemindersEnabled: false }]),
+		],
+	});
+	return Number(result.rows[0].id);
+}
+
+async function seedAsNeededEvent(input: {
+	userId: number;
+	medicationId: number;
+	eventId: string;
+	occurredAt: string;
+	recordedAt?: string;
+	quantityMilli: number;
+	quantityUnit: "pills" | "ml" | "application";
+	person?: string;
+	status?: "active" | "reversed";
+	stockEffectMilli?: number;
+	stockEffectReason?: "applied" | "non_measurable";
+	replacesEventId?: number;
+	revision?: number;
+	journal?: { mood: "good" | "bad" | "neutral"; note: string };
+}) {
+	const occurredAt = new Date(input.occurredAt);
+	const recordedAt = new Date(input.recordedAt ?? input.occurredAt);
+	const anchor = await testClient.execute({
+		sql: "INSERT INTO dose_tracking (user_id, dose_id, taken_at) VALUES (?, ?, ?) RETURNING id",
+		args: [input.userId, `as-needed:${input.eventId}`, Math.floor(occurredAt.getTime() / 1000)],
+	});
+	const doseTrackingId = Number(anchor.rows[0].id);
+	const event = await testClient.execute({
+		sql: `INSERT INTO as_needed_intake_events (
+		  event_id, user_id, medication_id, dose_tracking_id, idempotency_key_hash, request_fingerprint,
+		  occurred_at, recorded_at, quantity_milli, quantity_unit, person_name, status,
+		  stock_effect_milli, stock_effect_reason, replaces_event_id, reversed_at, revision
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+		args: [
+			input.eventId,
+			input.userId,
+			input.medicationId,
+			doseTrackingId,
+			input.eventId.replaceAll("-", "").padEnd(64, "0"),
+			"f".repeat(64),
+			Math.floor(occurredAt.getTime() / 1000),
+			Math.floor(recordedAt.getTime() / 1000),
+			input.quantityMilli,
+			input.quantityUnit,
+			input.person ?? "",
+			input.status ?? "active",
+			input.stockEffectMilli ?? input.quantityMilli,
+			input.stockEffectReason ?? "applied",
+			input.replacesEventId ?? null,
+			input.status === "reversed" ? Math.floor(recordedAt.getTime() / 1000) : null,
+			input.revision ?? 1,
+		],
+	});
+
+	if (input.journal) {
+		await testClient.execute({
+			sql: `INSERT INTO intake_journal (
+			  user_id, dose_tracking_id, medication_id, scheduled_for, mood, note, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				input.userId,
+				doseTrackingId,
+				input.medicationId,
+				Math.floor(occurredAt.getTime() / 1000),
+				input.journal.mood,
+				input.journal.note,
+				Math.floor(occurredAt.getTime() / 1000),
+				Math.floor(occurredAt.getTime() / 1000),
+			],
+		});
+	}
+
+	return { id: Number(event.rows[0].id), doseTrackingId };
+}
+
+describe("Report route as-needed audit data", () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		const context = await buildTestApp({ client: testClient });
+		app = context.app;
+		await app.register(reportRoutes);
+		await app.ready();
+	});
+
+	afterAll(async () => {
+		await closeTestApp({ app, db: testDb, client: testClient });
+		for (const path of [testDbPath, `${testDbPath}-shm`, `${testDbPath}-wal`]) {
+			if (existsSync(path)) unlinkSync(path);
+		}
+	});
+
+	beforeEach(async () => {
+		await clearTables();
+	});
+
+	it("keeps active quantities and moods separate from reversed audit events with deterministic ordering", async () => {
+		const ownerId = await createTestUser(testClient, { username: "report-audit-owner" });
+		const otherId = await createTestUser(testClient, { username: "report-audit-other" });
+		const cookie = await buildTestSessionCookie(app, ownerId, "report-audit-owner");
+		const medicationId = await seedMedication(ownerId, "Audit medication");
+		const otherMedicationId = await seedMedication(otherId, "Other medication");
+		const replacementTarget = await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_A,
+			occurredAt: "2026-02-01T08:00:00.000Z",
+			quantityMilli: 1000,
+			quantityUnit: "pills",
+		});
+		await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_B,
+			occurredAt: "2026-02-10T09:00:00.000Z",
+			recordedAt: "2026-02-20T09:00:00.000Z",
+			quantityMilli: 2500,
+			quantityUnit: "pills",
+			person: "Alice",
+			replacesEventId: replacementTarget.id,
+			revision: 3,
+			journal: { mood: "good", note: "Steady effect" },
+		});
+		await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_C,
+			occurredAt: "2026-02-11T10:00:00.000Z",
+			quantityMilli: 1000,
+			quantityUnit: "ml",
+			person: "Alice",
+			status: "reversed",
+			revision: 2,
+			journal: { mood: "bad", note: "Reversed note" },
+		});
+		await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_D,
+			occurredAt: "2026-02-11T10:00:00.000Z",
+			quantityMilli: 2000,
+			quantityUnit: "application",
+			person: "Alice",
+			stockEffectMilli: 0,
+			stockEffectReason: "non_measurable",
+		});
+		await seedAsNeededEvent({
+			userId: otherId,
+			medicationId: otherMedicationId,
+			eventId: "00000000-0000-4000-8000-000000000005",
+			occurredAt: "2026-02-11T11:00:00.000Z",
+			quantityMilli: 9000,
+			quantityUnit: "pills",
+			journal: { mood: "good", note: "Other owner note" },
+		});
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/medications/report-data",
+			headers: { cookie },
+			payload: {
+				medicationIds: [medicationId],
+				startDate: "2026-02-10T00:00:00.000Z",
+				endDate: "2026-02-12T00:00:00.000Z",
+			},
+		});
+		expect(response.statusCode).toBe(200);
+		const report = response.json()[medicationId];
+		expect(report.asNeededIntakesTaken).toBe(2);
+		expect(report.asNeededQuantityByUnit).toEqual({ pills: 2.5, application: 2 });
+		expect(report.moodSummary).toMatchObject({ good: 1, bad: 0 });
+		expect(report.asNeededIntakes.map((entry: { eventId: string }) => entry.eventId)).toEqual([
+			EVENT_D,
+			EVENT_C,
+			EVENT_B,
+		]);
+		expect(report.asNeededIntakes).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					eventId: EVENT_B,
+					status: "active",
+					occurredAt: "2026-02-10T09:00:00.000Z",
+					recordedAt: "2026-02-20T09:00:00.000Z",
+					person: "Alice",
+					source: "owner_as_needed",
+					stockEffect: 2.5,
+					stockEffectReason: "applied",
+					replacementForEventId: EVENT_A,
+					revision: 3,
+					mood: "good",
+					note: "Steady effect",
+				}),
+				expect.objectContaining({
+					eventId: EVENT_C,
+					status: "reversed",
+					stockEffect: 1,
+					reversedAt: "2026-02-11T10:00:00.000Z",
+					mood: "bad",
+					note: "Reversed note",
+				}),
+				expect.objectContaining({ eventId: EVENT_D, stockEffect: 0, stockEffectReason: "non_measurable" }),
+			])
+		);
+	});
+
+	it("uses occurredAt with inclusive-start/exclusive-end and preserves scheduled report filtering", async () => {
+		const ownerId = await createTestUser(testClient, { username: "report-filter-owner" });
+		const cookie = await buildTestSessionCookie(app, ownerId, "report-filter-owner");
+		const medicationId = await seedMedication(ownerId, "Filter medication");
+		await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_A,
+			occurredAt: "2026-02-10T00:00:00.000Z",
+			recordedAt: "2026-03-01T00:00:00.000Z",
+			quantityMilli: 1000,
+			quantityUnit: "pills",
+			person: " ALIce ",
+		});
+		await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_B,
+			occurredAt: "2026-02-11T00:00:00.000Z",
+			quantityMilli: 1000,
+			quantityUnit: "pills",
+			person: "Alice",
+		});
+		await seedAsNeededEvent({
+			userId: ownerId,
+			medicationId,
+			eventId: EVENT_C,
+			occurredAt: "2026-02-10T12:00:00.000Z",
+			quantityMilli: 1000,
+			quantityUnit: "pills",
+			person: "",
+		});
+		const scheduledDose = await testClient.execute({
+			sql: "INSERT INTO dose_tracking (user_id, dose_id, taken_at, dismissed) VALUES (?, ?, ?, 0) RETURNING id",
+			args: [
+				ownerId,
+				`${medicationId}-0-${Date.parse("2026-02-10T08:00:00.000Z")}-Alice`,
+				Math.floor(Date.parse("2026-02-10T08:05:00.000Z") / 1000),
+			],
+		});
+		await testClient.execute({
+			sql: `INSERT INTO intake_journal (user_id, dose_tracking_id, medication_id, scheduled_for, mood, note)
+		      VALUES (?, ?, ?, ?, 'neutral', 'Scheduled snapshot')`,
+			args: [
+				ownerId,
+				Number(scheduledDose.rows[0].id),
+				medicationId,
+				Math.floor(Date.parse("2026-02-10T08:00:00.000Z") / 1000),
+			],
+		});
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/medications/report-data",
+			headers: { cookie },
+			payload: {
+				medicationIds: [medicationId],
+				startDate: "2026-02-10T00:00:00.000Z",
+				endDate: "2026-02-11T00:00:00.000Z",
+				takenByFilter: ["alice"],
+			},
+		});
+		expect(response.statusCode).toBe(200);
+		const report = response.json()[medicationId];
+		expect(report.asNeededIntakesTaken).toBe(1);
+		expect(report.asNeededIntakes).toEqual([expect.objectContaining({ eventId: EVENT_A, person: " ALIce " })]);
+		expect(report.dosesTaken).toBe(1);
+		expect(report.moodSummary).toMatchObject({ neutral: 1 });
+		expect(report.journalEntries).toEqual([
+			expect.objectContaining({
+				scheduledFor: "2026-02-10T08:00:00.000Z",
+				takenAt: "2026-02-10T08:05:00.000Z",
+				dismissed: false,
+				takenSource: "manual",
+				takenByPerson: "Alice",
+				mood: "neutral",
+				note: "Scheduled snapshot",
+			}),
+		]);
+	});
+});


### PR DESCRIPTION
Closes #1035

## Summary

- add active as-needed intake counts and exact quantity totals grouped by unit to owner reports
- expose active and reversed as-needed audit rows with timing, person, source, stock effect, replacement, revision, and journal context
- apply occurred-at and person filters while excluding reversed events from consumption and mood aggregates

## Scope boundary

Scheduled report behavior remains unchanged. No share/public mutation surface or frontend work is included. This unlocks UI issues #1018 and #1019.

## Validation

- focused report coverage: 2 tests
- full backend suite: 49 files, 943 tests
- lint, check, build, and diff check

Security review found no critical, major, or minor findings.