### PR TITLE
feat: add as-needed record now flow

### DIFF
--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -1,0 +1,70 @@
+import { authFile, createMedicationViaAPI, deleteAllMedicationsViaAPI, expect, navigateTo, test } from "./fixtures";
+
+const MEDICATION_NAME = "As-needed record now";
+
+test.describe("As-needed Record now", () => {
+	test.use({ storageState: authFile });
+	test.describe.configure({ timeout: 90000 });
+
+	test.beforeEach(async () => {
+		await deleteAllMedicationsViaAPI();
+		await createMedicationViaAPI({
+			name: MEDICATION_NAME,
+			packageType: "blister",
+			medicationForm: "tablet",
+			packCount: 1,
+			blistersPerPack: 1,
+			pillsPerBlister: 10,
+			looseTablets: 0,
+			intakes: [],
+		});
+	});
+
+	test.afterAll(async () => {
+		await deleteAllMedicationsViaAPI();
+	});
+
+	for (const viewport of [
+		{ name: "desktop", size: { width: 1280, height: 720 } },
+		{ name: "mobile", size: { width: 390, height: 844 } },
+	]) {
+		test(`${viewport.name} safely replays a lost response and reloads stock`, async ({ page }) => {
+			await page.setViewportSize(viewport.size);
+			await navigateTo(page, "/medications");
+			const medication = page.getByTestId("medication-row").filter({ hasText: MEDICATION_NAME });
+			await expect(medication).toBeVisible();
+			await medication.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+
+			let firstServerStatus: number | null = null;
+			let firstKey: string | null = null;
+			let lostResponse = true;
+			await page.route("**/api/medications/*/as-needed-intakes", async (route) => {
+				if (!lostResponse) return route.continue();
+				lostResponse = false;
+				firstKey = await route.request().headerValue("idempotency-key");
+				const response = await route.fetch();
+				firstServerStatus = response.status();
+				await route.abort("connectionreset");
+			});
+
+			await page.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+			await expect(page.getByText(/result is uncertain|Ergebnis.*unklar/i)).toBeVisible();
+
+			const replay = page.waitForResponse((response) => response.url().includes("/as-needed-intakes"));
+			const reload = page.waitForResponse((response) =>
+				response.url().includes("/api/medications?includeObsolete=true")
+			);
+			await page.getByRole("button", { name: /Retry|Erneut/i }).click();
+			const replayResponse = await replay;
+			const reloadResponse = await reload;
+			expect(firstServerStatus).toBe(201);
+			expect(replayResponse.status()).toBe(200);
+			expect(await replayResponse.request().headerValue("idempotency-key")).toBe(firstKey);
+			expect((await reloadResponse.json()) as Array<{ asNeededStockEffect?: number }>).toEqual(
+				expect.arrayContaining([expect.objectContaining({ asNeededStockEffect: 0.5 })])
+			);
+			await expect(page.getByText(/Intake recorded|Einnahme erfasst/i)).toBeVisible();
+			await expect(medication).toContainText(/9\.5\s*\/\s*10/);
+		});
+	}
+});

--- a/frontend/src/components/FormNumberStepper.tsx
+++ b/frontend/src/components/FormNumberStepper.tsx
@@ -2,6 +2,7 @@ import { Minus, Plus } from "lucide-react";
 import classes from "./FormNumberStepper.module.css";
 
 interface FormNumberStepperProps {
+	inputId?: string;
 	value: string;
 	onChange: (nextValue: string) => void;
 	min?: number;
@@ -50,6 +51,7 @@ function parseInputValue(raw: string, allowDecimal: boolean): number | null {
 }
 
 export function FormNumberStepper({
+	inputId,
 	value,
 	onChange,
 	min = 0,
@@ -88,6 +90,7 @@ export function FormNumberStepper({
 			{/* Input first in DOM so <label> associates with it, not the decrement button.
 			    CSS order restores the visual layout: [−] [input] [+]. */}
 			<input
+				id={inputId}
 				type="text"
 				inputMode={allowDecimal ? "decimal" : "numeric"}
 				pattern={allowDecimal ? "[0-9]*\\.?[0-9]*" : "[0-9]*"}

--- a/frontend/src/components/RecordNowModal.tsx
+++ b/frontend/src/components/RecordNowModal.tsx
@@ -1,0 +1,218 @@
+import { Alert, Group, Stack, Text } from "@mantine/core";
+import { getAsNeededQuantityProfile, normalizeAsNeededQuantityMilli } from "@medassist/shared";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AsNeededIntakeRequestError } from "../hooks/useAsNeededIntakes";
+import type { AsNeededIntakeMutationResponse, Medication } from "../types";
+import { getMedDisplayName } from "../types";
+import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
+import { AppButton } from "../ui/primitives/AppButton";
+import { AppSelect } from "../ui/primitives/AppSelect";
+import { getNumericLocale, withFormattingTimezone } from "../utils/formatters";
+import { FormNumberStepper } from "./FormNumberStepper";
+import { MedicationAvatar } from "./MedicationAvatar";
+
+type RecordNowModalProps = {
+	medication: Medication | null;
+	onClose: () => void;
+	onRecord: (input: {
+		medicationId: number;
+		quantity: number;
+		person: string | null;
+		idempotencyKey: string;
+	}) => Promise<AsNeededIntakeMutationResponse>;
+};
+
+function getErrorKey(code: string): string {
+	if (code === "NETWORK_ERROR") return "asNeeded.errors.network";
+	if (code === "INSUFFICIENT_STOCK") return "asNeeded.errors.insufficientStock";
+	if (code === "STOCK_UNRESOLVABLE") return "asNeeded.errors.stockUnresolvable";
+	if (code === "MEDICATION_NOT_ELIGIBLE") return "asNeeded.errors.notEligible";
+	if (code === "INVALID_PERSON") return "asNeeded.errors.invalidPerson";
+	if (code === "INVALID_QUANTITY") return "asNeeded.errors.invalidQuantity";
+	if (code === "TOO_MANY_NEW_INTAKES") return "asNeeded.errors.rateLimited";
+	if (code === "IDEMPOTENCY_KEY_REUSED") return "asNeeded.errors.intentConflict";
+	if (code === "READ_ONLY" || code === "API_KEY_SCOPE_FORBIDDEN") return "asNeeded.errors.readOnly";
+	return "asNeeded.errors.generic";
+}
+
+function formatQuantity(value: number): string {
+	return value.toLocaleString(undefined, { maximumFractionDigits: 3 });
+}
+
+function formatTrustedDateTime(value: string): string {
+	return new Date(value).toLocaleString(
+		getNumericLocale(),
+		withFormattingTimezone({ year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })
+	);
+}
+
+export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModalProps) {
+	const { t } = useTranslation();
+	const profile = useMemo(() => getAsNeededQuantityProfile(medication ?? {}), [medication]);
+	const [quantity, setQuantity] = useState(String(profile.defaultQuantity));
+	const [person, setPerson] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+	const [pending, setPending] = useState(false);
+	const [attempted, setAttempted] = useState(false);
+	const [error, setError] = useState<{ code: string; retryAfterSeconds: number | null } | null>(null);
+	const [result, setResult] = useState<AsNeededIntakeMutationResponse | null>(null);
+	const feedbackRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!medication) return;
+		const nextProfile = getAsNeededQuantityProfile(medication);
+		setQuantity(String(nextProfile.defaultQuantity));
+		setPerson("");
+		setIdempotencyKey(crypto.randomUUID());
+		setPending(false);
+		setAttempted(false);
+		setError(null);
+		setResult(null);
+	}, [medication]);
+
+	useEffect(() => {
+		if (error || result) feedbackRef.current?.focus();
+	}, [error, result]);
+
+	if (!medication) return null;
+
+	const numericQuantity = Number.parseFloat(quantity);
+	const quantityIsValid = normalizeAsNeededQuantityMilli(numericQuantity, profile) !== null;
+	const unitLabel = t(`asNeeded.units.${profile.unit}`, { count: numericQuantity });
+	const locked = pending || attempted;
+	let submitLabel = t("asNeeded.record.confirm");
+	if (pending) {
+		submitLabel = t("asNeeded.record.saving");
+	} else if (error) {
+		submitLabel = t("common.retry");
+	}
+
+	const close = () => {
+		if (!pending) onClose();
+	};
+
+	const submit = async () => {
+		if (pending || result || !quantityIsValid || !idempotencyKey) return;
+		setPending(true);
+		setAttempted(true);
+		setError(null);
+		try {
+			setResult(
+				await onRecord({
+					medicationId: medication.id,
+					quantity: numericQuantity,
+					person: person || null,
+					idempotencyKey,
+				})
+			);
+		} catch (requestError) {
+			if (requestError instanceof AsNeededIntakeRequestError) {
+				setError({ code: requestError.code, retryAfterSeconds: requestError.retryAfterSeconds });
+			} else {
+				setError({ code: "UNKNOWN_ERROR", retryAfterSeconds: null });
+			}
+		} finally {
+			setPending(false);
+		}
+	};
+
+	return (
+		<AppModal
+			closeButtonProps={{ "aria-label": t("common.close"), disabled: pending }}
+			onClose={close}
+			opened
+			size={480}
+			title={t("asNeeded.record.title")}
+			withCloseButton
+		>
+			<Stack gap="md">
+				<Group gap="sm" wrap="nowrap">
+					<MedicationAvatar name={getMedDisplayName(medication)} imageUrl={medication.imageUrl} size="lg" />
+					<div>
+						<Text fw={700}>{getMedDisplayName(medication)}</Text>
+						<Text c="dimmed" size="sm">
+							{t("form.blisters.noRegularSchedule")}
+						</Text>
+					</div>
+				</Group>
+
+				{result ? (
+					<Alert ref={feedbackRef} tabIndex={-1} color="green" title={t("asNeeded.record.successTitle")}>
+						{t("asNeeded.record.successMessage", {
+							quantity: formatQuantity(result.event.quantity),
+							unit: t(`asNeeded.units.${result.event.quantityUnit}`, { count: result.event.quantity }),
+							time: formatTrustedDateTime(result.event.occurredAt),
+							stock: formatQuantity(result.inventory.currentStock),
+						})}
+						{result.inventory.reconciliationRequired ? ` ${t("asNeeded.record.reconciliationRequired")}` : ""}
+					</Alert>
+				) : (
+					<>
+						<Text size="sm">{t("asNeeded.record.trustedTime")}</Text>
+						<fieldset disabled={locked} style={{ border: 0, margin: 0, padding: 0 }}>
+							<Stack gap="md">
+								<label htmlFor="record-now-quantity">
+									<Text component="span" fw={600} size="sm">
+										{t("asNeeded.record.quantity", { unit: unitLabel })}
+									</Text>
+									<FormNumberStepper
+										allowDecimal={!profile.wholeUnitsOnly}
+										decrementLabel={t("asNeeded.record.decreaseQuantity")}
+										incrementLabel={t("asNeeded.record.increaseQuantity")}
+										inputId="record-now-quantity"
+										max={profile.unit === "application" ? 1 : undefined}
+										min={profile.uiStep}
+										onChange={setQuantity}
+										step={profile.uiStep}
+										value={quantity}
+									/>
+								</label>
+								<AppSelect
+									data={[
+										{ value: "", label: t("asNeeded.record.noPerson") },
+										...medication.takenBy.map((name) => ({ value: name, label: name })),
+									]}
+									label={t("asNeeded.record.person")}
+									onChange={(event) => setPerson(event.currentTarget.value)}
+									value={person}
+								/>
+							</Stack>
+						</fieldset>
+						<Text c="dimmed" size="sm">
+							{profile.measurable
+								? t("asNeeded.record.stockEffect", { quantity: formatQuantity(numericQuantity), unit: unitLabel })
+								: t("asNeeded.record.noStockEffect")}
+						</Text>
+						{!quantityIsValid && quantity.length > 0 ? (
+							<Text c="red" role="alert" size="sm">
+								{t("asNeeded.errors.invalidQuantity")}
+							</Text>
+						) : null}
+						{pending ? (
+							<Text aria-live="polite" role="status" size="sm">
+								{t("asNeeded.record.saving")}
+							</Text>
+						) : null}
+						{error ? (
+							<Alert ref={feedbackRef} tabIndex={-1} color="red" title={t("asNeeded.record.failedTitle")}>
+								{t(getErrorKey(error.code), { seconds: error.retryAfterSeconds ?? 0 })}
+							</Alert>
+						) : null}
+					</>
+				)}
+			</Stack>
+
+			<AppModalFooter>
+				<AppButton type="button" tone="secondary" onClick={close} disabled={pending}>
+					{result ? t("common.close") : t("common.cancel")}
+				</AppButton>
+				{!result ? (
+					<AppButton type="button" tone="primary" onClick={() => void submit()} disabled={pending || !quantityIsValid}>
+						{submitLabel}
+					</AppButton>
+				) : null}
+			</AppModalFooter>
+		</AppModal>
+	);
+}

--- a/frontend/src/components/medications/MedicationListSection.module.css
+++ b/frontend/src/components/medications/MedicationListSection.module.css
@@ -275,6 +275,8 @@
 }
 
 .noRegularSchedule {
+	align-items: center;
+	justify-content: space-between;
 	border-style: dashed;
 	font-weight: 600;
 }

--- a/frontend/src/components/medications/MedicationListSection.tsx
+++ b/frontend/src/components/medications/MedicationListSection.tsx
@@ -32,6 +32,8 @@ type MedicationListSectionProps = {
 	onNewEntry: () => void;
 	onOpenReport: () => void;
 	onEdit: (med: Medication) => void;
+	onRecordNow?: (med: Medication) => void;
+	canRecordNow?: (med: Medication) => boolean;
 	onView: (med: Medication) => void;
 	onMarkObsolete: (med: Medication) => void;
 	onDelete: (med: Medication) => void;
@@ -53,6 +55,8 @@ export function MedicationListSection({
 	onNewEntry,
 	onOpenReport,
 	onEdit,
+	onRecordNow,
+	canRecordNow,
 	onView,
 	onMarkObsolete,
 	onDelete,
@@ -118,9 +122,7 @@ export function MedicationListSection({
 							const displayName = getMedDisplayName(med);
 							const medicationIntakes = getMedicationIntakes(med);
 							const stockDisplayCapacity = getStockDisplayCapacity(med);
-							const currentStock = coverageByMed[displayName]
-								? Math.round(coverageByMed[displayName].medsLeft)
-								: getMedTotal(med);
+							const currentStock = coverageByMed[displayName] ? coverageByMed[displayName].medsLeft : getMedTotal(med);
 							const fillPct =
 								stockDisplayCapacity > 0
 									? Math.max(0, Math.min(100, Math.round((currentStock / stockDisplayCapacity) * 100)))
@@ -232,7 +234,18 @@ export function MedicationListSection({
 									<div className={classes.blisterList}>
 										{medicationIntakes.length === 0 && (
 											<div className={cx(classes.blisterRowSimple, classes.noRegularSchedule)}>
-												{t("form.blisters.noRegularSchedule")}
+												<span>{t("form.blisters.noRegularSchedule")}</span>
+												{canRecordNow?.(med) ? (
+													<AppButton
+														type="button"
+														tone="primary"
+														size="xs"
+														leftSection={<Plus size={14} aria-hidden="true" />}
+														onClick={() => onRecordNow?.(med)}
+													>
+														{t("asNeeded.record.action")}
+													</AppButton>
+												) : null}
 											</div>
 										)}
 										{medicationIntakes.map((intake) => (

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
+import { useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
 import { useCollapsedDays } from "../hooks/useCollapsedDays";
 import { useDoses } from "../hooks/useDoses";
 import { useIntakeJournal } from "../hooks/useIntakeJournal";
@@ -67,6 +68,7 @@ export interface AppContextValue {
 	deleteMed: (id: number, editingId: number | null, resetForm: () => void) => Promise<void>;
 	uploadMedImage: (medId: number, file: File) => Promise<void>;
 	deleteMedImage: (medId: number) => Promise<void>;
+	recordAsNeededIntake: ReturnType<typeof useAsNeededIntakes>["recordAsNeededIntake"];
 
 	// From useSettings (selected fields)
 	settings: ReturnType<typeof useSettings>["settings"];
@@ -296,6 +298,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
 	// Compose hooks
 	const medications = useMedications();
+	const asNeededIntakes = useAsNeededIntakes();
 	const settingsHook = useSettings({ autoLoad: false });
 	const doses = useDoses({ loadOnMount: false });
 	const intakeJournal = useIntakeJournal();
@@ -308,6 +311,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		doses.loadTakenDoses();
 	}, [medications.loadMeds, settingsHook.loadSettings, doses.loadTakenDoses]);
 	const importExport = useImportExport({ onImportComplete: handleImportComplete });
+	const recordAsNeededIntake = useCallback(
+		async (input: Parameters<typeof asNeededIntakes.recordAsNeededIntake>[0]) => {
+			const result = await asNeededIntakes.recordAsNeededIntake(input);
+			medications.loadMeds();
+			return result;
+		},
+		[asNeededIntakes.recordAsNeededIntake, medications.loadMeds]
+	);
 
 	// Schedule UI state
 	const [scheduleDays, setScheduleDays] = useState<number>(30);
@@ -659,6 +670,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		() => ({
 			// From useMedications
 			...medications,
+			recordAsNeededIntake,
 
 			// From useSettings
 			settings: settingsHook.settings,
@@ -840,6 +852,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		}),
 		[
 			medications,
+			recordAsNeededIntake,
 			settingsHook,
 			doses,
 			intakeJournal,

--- a/frontend/src/hooks/useAsNeededIntakes.ts
+++ b/frontend/src/hooks/useAsNeededIntakes.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+import { useAuth } from "../components/Auth";
+import type { AsNeededIntakeMutationResponse } from "../types";
+
+export class AsNeededIntakeRequestError extends Error {
+	constructor(
+		public readonly code: string,
+		public readonly retryAfterSeconds: number | null = null
+	) {
+		super(code);
+		this.name = "AsNeededIntakeRequestError";
+	}
+}
+
+export function useAsNeededIntakes() {
+	const { authFetch } = useAuth();
+
+	const recordAsNeededIntake = useCallback(
+		async (input: {
+			medicationId: number;
+			quantity: number;
+			person: string | null;
+			idempotencyKey: string;
+		}): Promise<AsNeededIntakeMutationResponse> => {
+			let response: Response;
+			try {
+				response = await authFetch(`/api/medications/${input.medicationId}/as-needed-intakes`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json", "Idempotency-Key": input.idempotencyKey },
+					body: JSON.stringify({ quantity: input.quantity, person: input.person }),
+				});
+			} catch {
+				throw new AsNeededIntakeRequestError("NETWORK_ERROR");
+			}
+
+			if (!response.ok) {
+				const retryAfter = Number.parseInt(response.headers.get("Retry-After") ?? "", 10);
+				let code = "UNKNOWN_ERROR";
+				try {
+					const body = (await response.json()) as { code?: unknown };
+					if (typeof body.code === "string") code = body.code;
+				} catch {
+					// The translated UI uses the stable fallback code for malformed error responses.
+				}
+				throw new AsNeededIntakeRequestError(code, Number.isFinite(retryAfter) ? retryAfter : null);
+			}
+
+			return (await response.json()) as AsNeededIntakeMutationResponse;
+		},
+		[authFetch]
+	);
+
+	return { recordAsNeededIntake };
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -227,6 +227,51 @@
       "message": "Möchtest du \"{{name}}\" wirklich als obsolet markieren?"
     }
   },
+  "asNeeded": {
+    "record": {
+      "action": "Jetzt erfassen",
+      "title": "Bedarfseinnahme erfassen",
+      "trustedTime": "Der Dienst erfasst beim Bestätigen die aktuelle Uhrzeit.",
+      "quantity": "Menge ({{unit}})",
+      "person": "Person",
+      "noPerson": "Keine Person / selbst",
+      "decreaseQuantity": "Menge verringern",
+      "increaseQuantity": "Menge erhöhen",
+      "stockEffect": "Der Bestand wird um {{quantity}} {{unit}} verringert.",
+      "noStockEffect": "Eine Anwendung wird erfasst, ohne den messbaren Bestand zu verändern.",
+      "confirm": "Einnahme erfassen",
+      "saving": "Einnahme wird erfasst...",
+      "failedTitle": "Einnahme wurde nicht erfasst",
+      "successTitle": "Einnahme erfasst",
+      "successMessage": "{{quantity}} {{unit}} um {{time}} erfasst. Aktueller Bestand: {{stock}}.",
+      "reconciliationRequired": "Packungskonfiguration und aktueller Bestand sollten geprüft werden."
+    },
+    "units": {
+      "pills": "Tabletten",
+      "pills_one": "Tablette",
+      "pills_other": "Tabletten",
+      "ml": "ml",
+      "puffs": "Hübe",
+      "puffs_one": "Hub",
+      "puffs_other": "Hübe",
+      "injections": "Injektionen",
+      "injections_one": "Injektion",
+      "injections_other": "Injektionen",
+      "application": "Anwendung"
+    },
+    "errors": {
+      "network": "Das Ergebnis ist wegen einer unterbrochenen Verbindung unklar. Erneut versuchen prüft sicher dieselbe Einnahme.",
+      "insufficientStock": "Für diese Menge ist nicht genug Bestand vorhanden. Prüfe den echten Bestand vor dem nächsten Versuch.",
+      "stockUnresolvable": "Der aktuelle Bestand kann nicht sicher bestimmt werden. Korrigiere ihn, bevor du eine Einnahme erfasst.",
+      "notEligible": "Dieses Medikament kann nicht mehr ohne Einnahmeplan erfasst werden. Aktualisiere die Medikamentenliste.",
+      "invalidPerson": "Die ausgewählte Person ist diesem Medikament nicht mehr zugeordnet.",
+      "invalidQuantity": "Gib eine für diesen Packungstyp gültige Menge ein.",
+      "rateLimited": "Es wurden zu viele neue Einnahmen angefordert. Versuche dieselbe Einnahme nach {{seconds}} Sekunden erneut.",
+      "intentConflict": "Diese Anfrage kollidiert mit einer früheren Anfrage. Schließe den Dialog und beginne erneut.",
+      "readOnly": "Mit diesem schreibgeschützten Zugriff kann keine Einnahme erfasst werden.",
+      "generic": "Die Einnahme konnte nicht erfasst werden. Versuche dieselbe Einnahme erneut oder brich ab."
+    }
+  },
   "form": {
     "editEntry": "Bearbeiten",
     "editEntryWithName": "Bearbeiten: {{name}}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -227,6 +227,51 @@
       "message": "Do you really want to mark \"{{name}}\" as obsolete?"
     }
   },
+  "asNeeded": {
+    "record": {
+      "action": "Record now",
+      "title": "Record as-needed intake",
+      "trustedTime": "The service records the current time when you confirm.",
+      "quantity": "Quantity ({{unit}})",
+      "person": "Person",
+      "noPerson": "None / self",
+      "decreaseQuantity": "Decrease quantity",
+      "increaseQuantity": "Increase quantity",
+      "stockEffect": "This will reduce stock by {{quantity}} {{unit}}.",
+      "noStockEffect": "This records one application without changing the measured stock.",
+      "confirm": "Record intake",
+      "saving": "Recording intake...",
+      "failedTitle": "Intake was not recorded",
+      "successTitle": "Intake recorded",
+      "successMessage": "Recorded {{quantity}} {{unit}} at {{time}}. Current stock: {{stock}}.",
+      "reconciliationRequired": "The package configuration and current stock should be checked."
+    },
+    "units": {
+      "pills": "pills",
+      "pills_one": "pill",
+      "pills_other": "pills",
+      "ml": "ml",
+      "puffs": "puffs",
+      "puffs_one": "puff",
+      "puffs_other": "puffs",
+      "injections": "injections",
+      "injections_one": "injection",
+      "injections_other": "injections",
+      "application": "application"
+    },
+    "errors": {
+      "network": "The result is uncertain because the connection was interrupted. Retry to safely check the same intake.",
+      "insufficientStock": "There is not enough stock for this quantity. Check the real stock before trying again.",
+      "stockUnresolvable": "The current stock cannot be determined safely. Correct the stock before recording an intake.",
+      "notEligible": "This medication can no longer be recorded without a schedule. Refresh the medication list.",
+      "invalidPerson": "The selected person is no longer assigned to this medication.",
+      "invalidQuantity": "Enter a valid quantity for this package type.",
+      "rateLimited": "Too many new intakes were requested. Retry the same intake after {{seconds}} seconds.",
+      "intentConflict": "This intake request conflicts with an earlier request. Close the dialog and start again.",
+      "readOnly": "This account access is read-only and cannot record an intake.",
+      "generic": "The intake could not be recorded. Retry the same intake or cancel."
+    }
+  },
   "form": {
     "editEntry": "Edit",
     "editEntryWithName": "Edit: {{name}}",

--- a/frontend/src/pages/MedicationsPage.tsx
+++ b/frontend/src/pages/MedicationsPage.tsx
@@ -16,6 +16,7 @@ import { MedicationDialogs } from "../components/medications/MedicationDialogs";
 import { MedicationEditCoordinator } from "../components/medications/MedicationEditCoordinator";
 import formClasses from "../components/medications/MedicationForm.module.css";
 import { MedicationListSection } from "../components/medications/MedicationListSection";
+import { RecordNowModal } from "../components/RecordNowModal";
 import { useAppContext, useUnsavedChanges } from "../context";
 import { useFeedback } from "../context/FeedbackContext";
 import { MEDICATION_FORM_FIELD_LIMITS } from "../hooks/medicationFormModel";
@@ -60,6 +61,7 @@ import { combineDateAndTime, formatNumber, toMonthEndDateValue } from "../utils/
 import { MAX_IMAGE_UPLOAD_BYTES, resolveImageUploadError } from "../utils/image-upload";
 import {
 	getIntakeScheduleMode,
+	getMedicationIntakes,
 	getWeekdayLabel,
 	hasSelectedWeekdays,
 	toggleWeekdaySelection,
@@ -246,6 +248,8 @@ export function MedicationsPage() {
 		uploadingImage,
 		existingPeople,
 		coverageByMed,
+		settings,
+		recordAsNeededIntake,
 	} = useAppContext();
 
 	// Use the medication form hook
@@ -289,6 +293,17 @@ export function MedicationsPage() {
 	const [lightboxImage, setLightboxImage] = useState<{ src: string; alt: string } | null>(null);
 	const closeLightbox = useCallback(() => setLightboxImage(null), []);
 	const [activeTab, setActiveTab] = useState<"general" | "stock" | "prescription" | "schedule">("general");
+	const [recordNowMedication, setRecordNowMedication] = useState<Medication | null>(null);
+	const canRecordNow = useCallback(
+		(medication: Medication) => {
+			if (viewMode !== "grid" || medication.isObsolete || getMedicationIntakes(medication).length > 0) return false;
+			if (!medication.medicationEndDate) return true;
+			const timezone = settings.timezone || settings.serverTimezone || undefined;
+			const today = new Date().toLocaleDateString("en-CA", { timeZone: timezone });
+			return medication.medicationEndDate.slice(0, 10) >= today;
+		},
+		[settings.serverTimezone, settings.timezone, viewMode]
+	);
 
 	// Mobile modal state (declared early because it's used in useEffect below)
 	const [showEditModal, setShowEditModal] = useState(pendingEditTransition && window.innerWidth <= 768);
@@ -1581,9 +1596,11 @@ export function MedicationsPage() {
 				isCompact={viewMode === "form"}
 				showObsolete={showObsolete}
 				coverageByMed={coverageByMed}
+				canRecordNow={canRecordNow}
 				onNewEntry={handleNewEntryClick}
 				onOpenReport={() => setShowReportModal(true)}
 				onEdit={handleEditClick}
+				onRecordNow={setRecordNowMedication}
 				onView={handleViewClick}
 				onMarkObsolete={requestMarkObsolete}
 				onDelete={requestDeleteMed}
@@ -2378,6 +2395,12 @@ export function MedicationsPage() {
 					{/* end schedule tab */}
 				</fieldset>
 			</MedicationEditCoordinator>
+
+			<RecordNowModal
+				medication={recordNowMedication}
+				onClose={() => setRecordNowMedication(null)}
+				onRecord={recordAsNeededIntake}
+			/>
 
 			<MedicationDialogs
 				mobileEditModal={

--- a/frontend/src/test/components/MedicationListSection.test.tsx
+++ b/frontend/src/test/components/MedicationListSection.test.tsx
@@ -26,7 +26,12 @@ function createMedication(overrides: Partial<Medication>): Medication {
 	};
 }
 
-function renderSection(props: { orderedMeds: Medication[]; onImagePreview?: (med: Medication) => void }) {
+function renderSection(props: {
+	orderedMeds: Medication[];
+	onImagePreview?: (med: Medication) => void;
+	canRecordNow?: (med: Medication) => boolean;
+	onRecordNow?: (med: Medication) => void;
+}) {
 	return render(
 		<MedicationListSection
 			orderedMeds={props.orderedMeds}
@@ -37,6 +42,8 @@ function renderSection(props: { orderedMeds: Medication[]; onImagePreview?: (med
 			onNewEntry={vi.fn()}
 			onOpenReport={vi.fn()}
 			onEdit={vi.fn()}
+			canRecordNow={props.canRecordNow}
+			onRecordNow={props.onRecordNow}
 			onView={vi.fn()}
 			onMarkObsolete={vi.fn()}
 			onDelete={vi.fn()}
@@ -59,6 +66,24 @@ describe("MedicationListSection", () => {
 		});
 
 		expect(screen.getByText("form.blisters.noRegularSchedule")).toBeInTheDocument();
+	});
+
+	it("offers Record now only when the page has confirmed an active zero-schedule medication", () => {
+		const onRecordNow = vi.fn();
+		const eligible = createMedication({ intakes: [] });
+		const scheduled = createMedication({
+			id: 2,
+			intakes: [{ usage: 1, every: 1, start: "2026-01-01T08:00:00", takenBy: "", intakeRemindersEnabled: false }],
+		});
+		renderSection({
+			orderedMeds: [eligible, scheduled],
+			canRecordNow: (med) => med.id === eligible.id,
+			onRecordNow,
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.action" }));
+		expect(onRecordNow).toHaveBeenCalledWith(eligible);
+		expect(screen.getAllByText("form.blisters.noRegularSchedule")).toHaveLength(1);
 	});
 
 	it("opens the medication image preview from a clickable avatar", () => {

--- a/frontend/src/test/components/RecordNowModal.test.tsx
+++ b/frontend/src/test/components/RecordNowModal.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordNowModal } from "../../components/RecordNowModal";
+import { AsNeededIntakeRequestError } from "../../hooks/useAsNeededIntakes";
+import type { AsNeededIntakeMutationResponse, Medication } from "../../types";
+import { setDefaultFormattingTimezone } from "../../utils/formatters";
+
+function medication(overrides: Partial<Medication> = {}): Medication {
+	return {
+		id: 8,
+		name: "As-needed medicine",
+		genericName: "",
+		packageType: "blister",
+		medicationForm: "tablet",
+		packCount: 1,
+		blistersPerPack: 1,
+		pillsPerBlister: 10,
+		looseTablets: 10,
+		takenBy: ["Alex"],
+		intakes: [],
+		blisters: [],
+		intakeRemindersEnabled: false,
+		notes: "",
+		expiryDate: "",
+		imageUrl: null,
+		updatedAt: null,
+		...overrides,
+	};
+}
+
+function response(): AsNeededIntakeMutationResponse {
+	return {
+		event: {
+			eventType: "as_needed",
+			eventId: "event-8",
+			medicationId: 8,
+			medication: {
+				name: "As-needed medicine",
+				genericName: null,
+				medicationForm: "tablet",
+				packageType: "blister",
+				isObsolete: false,
+				hasRegularSchedule: false,
+				lifecycle: "active_no_schedule",
+				recordEligibility: { eligible: true, reason: "eligible" },
+			},
+			occurredAt: "2026-08-15T08:30:00.000Z",
+			recordedAt: "2026-08-15T08:30:01.000Z",
+			quantity: 0.5,
+			quantityUnit: "pills",
+			person: null,
+			source: "owner_as_needed",
+			status: "active",
+			revision: 1,
+			stockEffect: 0.5,
+			stockEffectReason: "applied",
+			stockCutoffAt: null,
+			replacementForEventId: null,
+			reversedAt: null,
+			journal: null,
+		},
+		inventory: { currentStock: 9.5, unit: "pills", capacity: 10, reconciliationRequired: false },
+	};
+}
+
+describe("RecordNowModal", () => {
+	beforeEach(() => {
+		vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "modal-intent-key") });
+		setDefaultFormattingTimezone("Europe/Berlin");
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		setDefaultFormattingTimezone(null);
+	});
+
+	it("uses package defaults, supports None/self, and sends the stable key on retry", async () => {
+		const onRecord = vi
+			.fn()
+			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
+			.mockResolvedValueOnce(response());
+		render(<RecordNowModal medication={medication()} onClose={vi.fn()} onRecord={onRecord} />);
+
+		expect(screen.getByRole("textbox")).toHaveValue("0.5");
+		expect(screen.getByText("asNeeded.record.stockEffect")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.confirm" }));
+		await screen.findByText("asNeeded.errors.network");
+		fireEvent.click(screen.getByRole("button", { name: "common.retry" }));
+
+		await screen.findByText("asNeeded.record.successTitle");
+		expect(onRecord).toHaveBeenCalledTimes(2);
+		expect(onRecord.mock.calls[0][0]).toEqual(onRecord.mock.calls[1][0]);
+		expect(onRecord).toHaveBeenLastCalledWith({
+			medicationId: 8,
+			quantity: 0.5,
+			person: null,
+			idempotencyKey: "modal-intent-key",
+		});
+		expect(screen.getByTestId("app-modal-footer")).toBeInTheDocument();
+		await waitFor(() => expect(document.activeElement).toHaveTextContent("asNeeded.record.successTitle"));
+	});
+
+	it("enforces topical one-application semantics and leaves no measured stock effect", () => {
+		render(
+			<RecordNowModal
+				medication={medication({ packageType: "tube", medicationForm: "topical" })}
+				onClose={vi.fn()}
+				onRecord={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByRole("textbox")).toHaveValue("1");
+		expect(screen.getByText("asNeeded.record.noStockEffect")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "asNeeded.record.increaseQuantity" })).toBeDisabled();
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "2" } });
+		expect(screen.getByText("asNeeded.errors.invalidQuantity")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "asNeeded.record.confirm" })).toBeDisabled();
+	});
+
+	it("keeps the dialog pending and blocks duplicate submits until the latest response arrives", async () => {
+		let resolveRequest: ((value: AsNeededIntakeMutationResponse) => void) | undefined;
+		const onRecord = vi.fn(
+			() =>
+				new Promise<AsNeededIntakeMutationResponse>((resolve) => {
+					resolveRequest = resolve;
+				})
+		);
+		render(<RecordNowModal medication={medication()} onClose={vi.fn()} onRecord={onRecord} />);
+
+		const confirm = screen.getByRole("button", { name: "asNeeded.record.confirm" });
+		fireEvent.click(confirm);
+		fireEvent.click(confirm);
+		expect(onRecord).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("status")).toHaveTextContent("asNeeded.record.saving");
+		expect(screen.getByRole("button", { name: "common.cancel" })).toBeDisabled();
+
+		resolveRequest?.(response());
+		await screen.findByText("asNeeded.record.successTitle");
+	});
+});

--- a/frontend/src/test/hooks/useAsNeededIntakes.test.ts
+++ b/frontend/src/test/hooks/useAsNeededIntakes.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AsNeededIntakeRequestError, useAsNeededIntakes } from "../../hooks/useAsNeededIntakes";
+
+const authFetchMock = vi.fn();
+
+vi.mock("../../components/Auth", () => ({
+	useAuth: () => ({ authFetch: authFetchMock }),
+}));
+
+describe("useAsNeededIntakes", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("posts the owner-scoped endpoint with one stable intent key and payload", async () => {
+		const response = { event: { eventId: "event-1" }, inventory: { currentStock: 9 } };
+		authFetchMock.mockResolvedValue({ ok: true, json: async () => response });
+		const { result } = renderHook(() => useAsNeededIntakes());
+
+		let received: unknown;
+		await act(async () => {
+			received = await result.current.recordAsNeededIntake({
+				medicationId: 42,
+				quantity: 0.5,
+				person: null,
+				idempotencyKey: "stable-intent-key",
+			});
+		});
+
+		expect(authFetchMock).toHaveBeenCalledWith(
+			"/api/medications/42/as-needed-intakes",
+			expect.objectContaining({
+				method: "POST",
+				headers: { "Content-Type": "application/json", "Idempotency-Key": "stable-intent-key" },
+				body: JSON.stringify({ quantity: 0.5, person: null }),
+			})
+		);
+		expect(received).toBe(response);
+	});
+
+	it("preserves server codes and Retry-After for a safe same-intent retry", async () => {
+		authFetchMock.mockResolvedValue({
+			ok: false,
+			headers: new Headers({ "Retry-After": "17" }),
+			json: async () => ({ code: "TOO_MANY_NEW_INTAKES" }),
+		});
+		const { result } = renderHook(() => useAsNeededIntakes());
+
+		await expect(
+			result.current.recordAsNeededIntake({ medicationId: 1, quantity: 1, person: "Alex", idempotencyKey: "retry-key" })
+		).rejects.toEqual(expect.objectContaining({ code: "TOO_MANY_NEW_INTAKES", retryAfterSeconds: 17 }));
+	});
+
+	it("maps a transport failure to the translated uncertain-result state", async () => {
+		authFetchMock.mockRejectedValue(new Error("connection dropped"));
+		const { result } = renderHook(() => useAsNeededIntakes());
+
+		await expect(
+			result.current.recordAsNeededIntake({ medicationId: 1, quantity: 1, person: null, idempotencyKey: "network-key" })
+		).rejects.toBeInstanceOf(AsNeededIntakeRequestError);
+		await expect(
+			result.current.recordAsNeededIntake({ medicationId: 1, quantity: 1, person: null, idempotencyKey: "network-key" })
+		).rejects.toEqual(expect.objectContaining({ code: "NETWORK_ERROR" }));
+	});
+});

--- a/frontend/src/test/pages/MedicationsPage.test.tsx
+++ b/frontend/src/test/pages/MedicationsPage.test.tsx
@@ -53,6 +53,7 @@ const createMockContext = (overrides = {}) => ({
 	refillSaving: false,
 	submitRefill: vi.fn(),
 	coverageByMed: {},
+	settings: { timezone: "Europe/Berlin", serverTimezone: "Europe/Berlin" },
 	...overrides,
 });
 

--- a/frontend/src/test/types.test.ts
+++ b/frontend/src/test/types.test.ts
@@ -49,6 +49,20 @@ describe("getMedTotal", () => {
 		expect(getMedTotal(med)).toBe(8.5);
 	});
 
+	it("subtracts only the active as-needed stock effect with millistock-safe schedule projection", () => {
+		const med = {
+			packageType: "bottle" as const,
+			packCount: 0,
+			blistersPerPack: 1,
+			pillsPerBlister: 1,
+			looseTablets: 10,
+			scheduleStockRebaseMilli: 500,
+			asNeededStockEffect: 1.5,
+		};
+
+		expect(getMedTotal(med)).toBe(9);
+	});
+
 	it("handles undefined stock adjustment", () => {
 		const med = {
 			packCount: 1,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -147,6 +147,7 @@ export type Medication = {
 	looseTablets: number; // For blister: extra loose pills; for bottle: current stock
 	stockAdjustment?: number;
 	scheduleStockRebaseMilli?: number;
+	asNeededStockEffect?: number;
 	hasRegularSchedule?: boolean;
 	lastStockCorrectionAt?: string | null;
 	pillWeightMg?: number | null;
@@ -174,6 +175,50 @@ export type Medication = {
 	obsoleteAt?: string | null;
 	dismissedUntil?: string | null; // ISO date string (YYYY-MM-DD) - all past doses until this date are dismissed
 	updatedAt: string | number | null;
+};
+
+export type AsNeededQuantityUnit = "pills" | "ml" | "puffs" | "injections" | "application";
+export type AsNeededLifecycle = "active_no_schedule" | "active_scheduled" | "ended" | "obsolete";
+export type AsNeededEligibilityReason = "eligible" | "has_regular_schedule" | "ended" | "obsolete";
+
+export type AsNeededIntakeEvent = {
+	eventType: "as_needed";
+	eventId: string;
+	medicationId: number;
+	medication: {
+		name: string;
+		genericName: string | null;
+		medicationForm: string;
+		packageType: string;
+		isObsolete: boolean;
+		hasRegularSchedule: boolean;
+		lifecycle: AsNeededLifecycle;
+		recordEligibility: { eligible: boolean; reason: AsNeededEligibilityReason };
+	};
+	occurredAt: string;
+	recordedAt: string;
+	quantity: number;
+	quantityUnit: AsNeededQuantityUnit;
+	person: string | null;
+	source: "owner_as_needed";
+	status: "active" | "reversed";
+	revision: number;
+	stockEffect: number;
+	stockEffectReason: "applied" | "non_measurable" | "before_correction" | "superseded_by_correction";
+	stockCutoffAt: string | null;
+	replacementForEventId: string | null;
+	reversedAt: string | null;
+	journal: null | { doseId: string; mood: string | null; note: string | null; createdAt: string; updatedAt: string };
+};
+
+export type AsNeededIntakeMutationResponse = {
+	event: AsNeededIntakeEvent;
+	inventory: {
+		currentStock: number;
+		unit: AsNeededQuantityUnit;
+		capacity: number | null;
+		reconciliationRequired: boolean;
+	};
 };
 
 export type PlannerRow = {
@@ -410,6 +455,7 @@ type MedLike = Pick<
 > & {
 	stockAdjustment?: number;
 	scheduleStockRebaseMilli?: number;
+	asNeededStockEffect?: number;
 	packageType?: PackageType;
 	totalPills?: number | null;
 };
@@ -417,8 +463,9 @@ type MedLike = Pick<
 /** Calculate total stock including persisted projection adjustments. */
 export function getMedTotal(med: MedLike): number {
 	const projectionAdjustment = (med.scheduleStockRebaseMilli ?? 0) / 1000;
+	const asNeededStockEffect = med.asNeededStockEffect ?? 0;
 	if (isDiscreteCountPackageType(med.packageType)) {
-		return med.looseTablets + (med.stockAdjustment ?? 0) + projectionAdjustment;
+		return med.looseTablets + (med.stockAdjustment ?? 0) + projectionAdjustment - asNeededStockEffect;
 	}
 
 	// Amount-based package types use the same canonical base field as the backend:
@@ -426,14 +473,15 @@ export function getMedTotal(med: MedLike): number {
 	// for compatibility and UI helpers.
 	if (isPackageAmountPackageType(med.packageType)) {
 		const baseStock = med.looseTablets ?? med.totalPills ?? 0;
-		return baseStock + (med.stockAdjustment ?? 0) + projectionAdjustment;
+		return baseStock + (med.stockAdjustment ?? 0) + projectionAdjustment - asNeededStockEffect;
 	}
 	// For blister type, calculate from packs + loose
 	return (
 		med.packCount * med.blistersPerPack * med.pillsPerBlister +
 		med.looseTablets +
 		(med.stockAdjustment ?? 0) +
-		projectionAdjustment
+		projectionAdjustment -
+		asNeededStockEffect
 	);
 }
 


### PR DESCRIPTION
Closes #1018

## Summary

- add the accessible Record now medication-list action and modal for eligible active zero-schedule medications
- create owner as-needed intakes with stable UUID idempotency, same-key retry, package/person/topical rules, timezone handling, and exact stock refresh
- preserve desktop/mobile parity, pending state, and existing scheduled-medication actions

## Scope boundary

No detail/history, reversal, replacement, journal, or reconciliation UI is included; those remain in #1038.

## Validation

- full frontend suite: 78 files, 1,145 tests
- Playwright: 12 tests, including desktop/mobile `201 -> same-key 200`, decimal stock, and modal layout
- shared build, root lint/check/build, changed-file Biome, and diff check

The unavailable `modal-footer-contract.test.ts` is not part of the repository; stable modal layout coverage passed.