### PR TITLE
feat: add as-needed detail history

### DIFF
--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -67,4 +67,44 @@ test.describe("As-needed Record now", () => {
 			await expect(medication).toContainText(/9\.5\s*\/\s*10/);
 		});
 	}
+
+	for (const viewport of [
+		{ name: "desktop detail", size: { width: 1280, height: 720 } },
+		{ name: "mobile detail", size: { width: 390, height: 844 } },
+	]) {
+		test(`${viewport.name} records from medication detail and refreshes its history`, async ({ page }) => {
+			await page.setViewportSize(viewport.size);
+			await navigateTo(page, "/dashboard");
+			const overview = page.getByTestId("dashboard-overview-table");
+			await expect(overview).toBeVisible();
+			await overview
+				.getByTestId("dashboard-overview-row")
+				.filter({ hasText: MEDICATION_NAME })
+				.getByRole("button", { name: MEDICATION_NAME })
+				.click();
+
+			const detail = page
+				.getByRole("dialog")
+				.filter({ has: page.getByRole("heading", { name: MEDICATION_NAME }) })
+				.last();
+			await expect(detail).toBeVisible();
+			await expect(detail.getByText(/As-needed history|Bei-Bedarf-Verlauf/i)).toBeVisible();
+			await detail.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+
+			const create = page.waitForResponse(
+				(response) => response.url().includes("/as-needed-intakes") && response.request().method() === "POST"
+			);
+			await page.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+			expect((await create).status()).toBe(201);
+			await expect(page.getByText(/Intake recorded|Einnahme erfasst/i)).toBeVisible();
+			await page.goBack();
+			await expect(detail).toBeVisible();
+			await expect(detail.locator("article").first()).toContainText(/0\.5/);
+			await detail
+				.getByLabel(/Close|Schließen/i)
+				.first()
+				.click();
+			await expect(detail).toBeHidden();
+		});
+	}
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import {
 import { useModalHistory } from "./hooks/useModalHistory";
 import { useScrollLock } from "./hooks/useScrollLock";
 import { AppButton } from "./ui/primitives/AppButton";
+import { getMedicationIntakes } from "./utils/intake-schedule";
 
 const DashboardPage = lazy(() => import("./pages/DashboardPage").then((module) => ({ default: module.DashboardPage })));
 const MedicationsPage = lazy(() =>
@@ -36,6 +37,9 @@ const AboutModal = lazy(() => import("./components/AboutModal"));
 const ProfileModal = lazy(() => import("./components/ProfileModal"));
 const MedDetailModal = lazy(() =>
 	import("./components/MedDetailModal").then((module) => ({ default: module.MedDetailModal }))
+);
+const RecordNowModal = lazy(() =>
+	import("./components/RecordNowModal").then((module) => ({ default: module.RecordNowModal }))
 );
 const ShareDialog = lazy(() => import("./components/ShareDialog").then((module) => ({ default: module.ShareDialog })));
 const UserFilterModal = lazy(() =>
@@ -239,6 +243,7 @@ function AppContent() {
 		// Medications
 		meds,
 		loadMeds,
+		recordAsNeededIntake,
 		// Refill
 		showRefillModal,
 		setShowRefillModal,
@@ -318,6 +323,8 @@ function AppContent() {
 	// Local-only state (not shared across components)
 	const [showProfile, setShowProfile] = useState(false);
 	const [showAbout, setShowAbout] = useState(false);
+	const [detailRecordNowMedication, setDetailRecordNowMedication] = useState<(typeof meds)[number] | null>(null);
+	const [asNeededHistoryRefreshVersion, setAsNeededHistoryRefreshVersion] = useState(0);
 	const [routeTransitionMaskActive, setRouteTransitionMaskActive] = useState(false);
 	const [showMainSwipeHint, setShowMainSwipeHint] = useState(shouldShowInitialMainSwipeHint);
 	const [mainSwipeHintViewport, setMainSwipeHintViewport] = useState(isMobileRouteSwipeEnabled);
@@ -336,10 +343,19 @@ function AppContent() {
 	const dismissAbout = useCallback(() => {
 		setShowAbout(false);
 	}, []);
+	const dismissDetailRecordNow = useCallback(() => {
+		setDetailRecordNowMedication(null);
+	}, []);
 	// History integration via the shared modal stack: pushes one entry on open,
 	// browser back (or closeModal) dismisses only the topmost modal.
 	const { closeModal: closeProfile } = useModalHistory(showProfile, "profile", dismissProfile);
 	const { closeModal: closeAbout } = useModalHistory(showAbout, "about", dismissAbout);
+	const { closeModal: closeDetailRecordNow } = useModalHistory(
+		Boolean(detailRecordNowMedication),
+		"detail-record-now",
+		dismissDetailRecordNow,
+		{ state: detailRecordNowMedication ? { medicationId: detailRecordNowMedication.id } : undefined }
+	);
 
 	// Get centralized stockThresholds from context
 	const { stockThresholds } = ctx;
@@ -358,6 +374,10 @@ function AppContent() {
 			if (e.key !== "Escape") return;
 			if (e.defaultPrevented) return;
 
+			if (detailRecordNowMedication) {
+				closeDetailRecordNow();
+				return;
+			}
 			if (scheduleLightboxImage) {
 				closeScheduleLightbox();
 				return;
@@ -398,6 +418,7 @@ function AppContent() {
 		document.addEventListener("keydown", handleEscape);
 		return () => document.removeEventListener("keydown", handleEscape);
 	}, [
+		detailRecordNowMedication,
 		showImageLightbox,
 		scheduleLightboxImage,
 		showEditStockModal,
@@ -416,12 +437,14 @@ function AppContent() {
 		closeProfile,
 		closeUserFilter,
 		closeMedDetail,
+		closeDetailRecordNow,
 	]);
 
 	// Prevent background scroll when any modal is open
 	useScrollLock(
 		!!(
 			selectedMed ||
+			detailRecordNowMedication ||
 			selectedUser ||
 			showProfile ||
 			showAbout ||
@@ -435,6 +458,7 @@ function AppContent() {
 
 	const hasBlockingOverlay = !!(
 		selectedMed ||
+		detailRecordNowMedication ||
 		selectedUser ||
 		showProfile ||
 		showAbout ||
@@ -568,6 +592,13 @@ function AppContent() {
 	}, [meds, selectedMed, setSelectedMed]);
 
 	const stockCorrectionMed = selectedMed ?? (showEditStockModal ? editStockMedication : null);
+	const canRecordAsNeeded = (() => {
+		if (!selectedMed || selectedMed.isObsolete || getMedicationIntakes(selectedMed).length > 0) return false;
+		if (!selectedMed.medicationEndDate) return true;
+		const timezone = ctx.settings.timezone || ctx.settings.serverTimezone || undefined;
+		const today = new Date().toLocaleDateString("en-CA", { timeZone: timezone });
+		return selectedMed.medicationEndDate.slice(0, 10) >= today;
+	})();
 
 	const handleSubmitStockCorrection = async (medId: number) => {
 		if (!stockCorrectionMed) return;
@@ -716,6 +747,9 @@ function AppContent() {
 						showRefillModal={showRefillModal}
 						showEditStockModal={showEditStockModal}
 						editStockOnly={showEditStockModal && !selectedMed}
+						showAsNeededHistory={Boolean(selectedMed)}
+						canRecordAsNeeded={canRecordAsNeeded}
+						asNeededHistoryRefreshVersion={asNeededHistoryRefreshVersion}
 						onClose={closeMedDetail}
 						onOpenImageLightbox={openImageLightbox}
 						onCloseImageLightbox={closeImageLightbox}
@@ -723,6 +757,7 @@ function AppContent() {
 						onCloseRefillModal={closeRefillModal}
 						onOpenMedicationEdit={handleOpenMedicationEdit}
 						onOpenEditStockModal={handleOpenEditStockFromDetail}
+						onOpenRecordNow={() => selectedMed && setDetailRecordNowMedication(selectedMed)}
 						onCloseEditStockModal={closeEditStockModal}
 						onOpenUserFilter={openUserFilter}
 						refillPacks={refillPacks}
@@ -744,6 +779,20 @@ function AppContent() {
 						onEditStockLoosePillsChange={setEditStockLoosePills}
 						editStockSaving={editStockSaving}
 						onSubmitStockCorrection={handleSubmitStockCorrection}
+					/>
+				</Suspense>
+			)}
+
+			{detailRecordNowMedication && (
+				<Suspense fallback={null}>
+					<RecordNowModal
+						medication={detailRecordNowMedication}
+						onClose={closeDetailRecordNow}
+						onRecord={async (input) => {
+							const result = await recordAsNeededIntake(input);
+							setAsNeededHistoryRefreshVersion((version) => version + 1);
+							return result;
+						}}
 					/>
 				</Suspense>
 			)}

--- a/frontend/src/components/AsNeededIntakeHistory.module.css
+++ b/frontend/src/components/AsNeededIntakeHistory.module.css
@@ -1,0 +1,119 @@
+.section {
+	margin-bottom: 1.5rem;
+	padding-bottom: 1.5rem;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.headingRow,
+.headingBlock,
+.entryHeading {
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+}
+
+.headingRow {
+	justify-content: space-between;
+}
+
+.headingBlock {
+	flex-wrap: wrap;
+}
+
+.headingBlock h3 {
+	margin: 0;
+	color: var(--text-secondary);
+	font-size: 0.85rem;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.description,
+.state,
+.entry time,
+.entry p {
+	color: var(--text-secondary);
+	font-size: 0.875rem;
+}
+
+.description {
+	margin: 0.55rem 0 0.9rem;
+}
+
+.state {
+	margin: 0.75rem 0;
+}
+
+.list {
+	display: grid;
+	gap: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
+.entry {
+	display: grid;
+	gap: 0.55rem;
+	padding: 0.85rem;
+	border: 1px solid var(--border-primary);
+	border-radius: 10px;
+	background: var(--bg-secondary);
+}
+
+.entryHeading {
+	justify-content: space-between;
+	flex-wrap: wrap;
+}
+
+.entry p {
+	margin: 0;
+}
+
+.meta {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.65rem;
+	margin: 0;
+}
+
+.meta div,
+.journal {
+	min-width: 0;
+	padding: 0.6rem;
+	border-radius: 8px;
+	background: var(--bg-primary);
+}
+
+.meta dt {
+	color: var(--text-secondary);
+	font-size: 0.75rem;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+.meta dd {
+	margin: 0.2rem 0 0;
+	overflow-wrap: anywhere;
+}
+
+.meta dd span {
+	display: block;
+	color: var(--text-secondary);
+	font-size: 0.75rem;
+}
+
+.journal p {
+	margin-top: 0.25rem;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
+@media (max-width: 600px) {
+	.headingRow {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.meta {
+		grid-template-columns: 1fr;
+	}
+}

--- a/frontend/src/components/AsNeededIntakeHistory.tsx
+++ b/frontend/src/components/AsNeededIntakeHistory.tsx
@@ -1,0 +1,176 @@
+import { Alert } from "@mantine/core";
+import { normalizeIntakeMood } from "@medassist/shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
+import type { AsNeededIntakeEvent } from "../types";
+import { AppButton } from "../ui/primitives/AppButton";
+import { StatusBadge } from "../ui/primitives/StatusBadge";
+import { getNumericLocale, withFormattingTimezone } from "../utils/formatters";
+import { getIntakeMoodLabel } from "../utils/intake-mood";
+import classes from "./AsNeededIntakeHistory.module.css";
+
+type AsNeededIntakeHistoryProps = {
+	medicationId: number;
+	canRecordNow: boolean;
+	onRecordNow: () => void;
+};
+
+function formatQuantity(value: number): string {
+	return value.toLocaleString(getNumericLocale(), { maximumFractionDigits: 3 });
+}
+
+function formatTrustedDateTime(value: string): string {
+	return new Date(value).toLocaleString(
+		getNumericLocale(),
+		withFormattingTimezone({ year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })
+	);
+}
+
+export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow }: AsNeededIntakeHistoryProps) {
+	const { t } = useTranslation();
+	const { listAsNeededIntakes } = useAsNeededIntakes();
+	const [events, setEvents] = useState<AsNeededIntakeEvent[]>([]);
+	const [nextCursor, setNextCursor] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [loadingMore, setLoadingMore] = useState(false);
+	const [error, setError] = useState(false);
+	const requestVersionRef = useRef(0);
+	const firstPageAbortRef = useRef<AbortController | null>(null);
+
+	const loadFirstPage = useCallback(async () => {
+		firstPageAbortRef.current?.abort();
+		const controller = new AbortController();
+		firstPageAbortRef.current = controller;
+		const requestVersion = ++requestVersionRef.current;
+		setLoading(true);
+		setLoadingMore(false);
+		setError(false);
+		try {
+			const result = await listAsNeededIntakes(medicationId, undefined, controller.signal);
+			if (requestVersion !== requestVersionRef.current) return;
+			setEvents(result.events);
+			setNextCursor(result.nextCursor);
+		} catch {
+			if (requestVersion === requestVersionRef.current) setError(true);
+		} finally {
+			if (requestVersion === requestVersionRef.current) setLoading(false);
+		}
+	}, [listAsNeededIntakes, medicationId]);
+
+	useEffect(() => {
+		void loadFirstPage();
+		return () => {
+			firstPageAbortRef.current?.abort();
+			requestVersionRef.current += 1;
+		};
+	}, [loadFirstPage]);
+
+	const loadMore = async () => {
+		if (!nextCursor || loadingMore) return;
+		const requestVersion = requestVersionRef.current;
+		setLoadingMore(true);
+		setError(false);
+		try {
+			const result = await listAsNeededIntakes(medicationId, nextCursor);
+			if (requestVersion !== requestVersionRef.current) return;
+			setEvents((current) => {
+				const knownIds = new Set(current.map((event) => event.eventId));
+				return [...current, ...result.events.filter((event) => !knownIds.has(event.eventId))];
+			});
+			setNextCursor(result.nextCursor);
+		} catch {
+			if (requestVersion === requestVersionRef.current) setError(true);
+		} finally {
+			if (requestVersion === requestVersionRef.current) setLoadingMore(false);
+		}
+	};
+
+	if (!canRecordNow && !loading && !error && events.length === 0) return null;
+	const lifecycle = events[0]?.medication.lifecycle ?? (canRecordNow ? "active_no_schedule" : null);
+
+	return (
+		<section className={classes.section} aria-labelledby="as-needed-history-title">
+			<div className={classes.headingRow}>
+				<div className={classes.headingBlock}>
+					<h3 id="as-needed-history-title">{t("asNeeded.history.title")}</h3>
+					{lifecycle ? <StatusBadge tone="info">{t(`asNeeded.lifecycle.${lifecycle}`)}</StatusBadge> : null}
+				</div>
+				{canRecordNow ? (
+					<AppButton type="button" tone="primary" size="xs" onClick={onRecordNow}>
+						{t("asNeeded.record.action")}
+					</AppButton>
+				) : null}
+			</div>
+			<p className={classes.description}>{t("asNeeded.history.description")}</p>
+
+			{loading ? <p className={classes.state}>{t("asNeeded.history.loading")}</p> : null}
+			{error ? (
+				<Alert color="red" title={t("asNeeded.history.errorTitle")}>
+					{t("asNeeded.history.errorMessage")}
+					<AppButton type="button" tone="secondary" size="xs" onClick={() => void loadFirstPage()}>
+						{t("asNeeded.history.retry")}
+					</AppButton>
+				</Alert>
+			) : null}
+			{!loading && events.length === 0 ? <p className={classes.state}>{t("asNeeded.history.empty")}</p> : null}
+
+			<div className={classes.list}>
+				{events.map((event) => {
+					const mood = normalizeIntakeMood(event.journal?.mood);
+					return (
+						<article className={classes.entry} key={event.eventId}>
+							<div className={classes.entryHeading}>
+								<strong>
+									{formatQuantity(event.quantity)}{" "}
+									{t(`asNeeded.units.${event.quantityUnit}`, { count: event.quantity })}
+								</strong>
+								<StatusBadge tone={event.status === "active" ? "success" : "danger"}>
+									{t(`asNeeded.history.status.${event.status}`)}
+								</StatusBadge>
+							</div>
+							<time dateTime={event.occurredAt}>{formatTrustedDateTime(event.occurredAt)}</time>
+							<dl className={classes.meta}>
+								<div>
+									<dt>{t("asNeeded.history.person")}</dt>
+									<dd>{event.person ?? t("asNeeded.record.noPerson")}</dd>
+								</div>
+								<div>
+									<dt>{t("asNeeded.history.stockEffect")}</dt>
+									<dd>
+										{event.stockEffect > 0 ? "−" : ""}
+										{formatQuantity(event.stockEffect)}{" "}
+										{t(`asNeeded.units.${event.quantityUnit}`, { count: event.stockEffect })}
+										<span>{t(`asNeeded.history.stockReason.${event.stockEffectReason}`)}</span>
+									</dd>
+								</div>
+							</dl>
+							{event.reversedAt ? (
+								<p>{t("asNeeded.history.reversedAt", { time: formatTrustedDateTime(event.reversedAt) })}</p>
+							) : null}
+							{event.replacementForEventId ? (
+								<p>{t("asNeeded.history.replacementFor", { eventId: event.replacementForEventId })}</p>
+							) : null}
+							<div className={classes.journal}>
+								<strong>{t("asNeeded.history.journal")}</strong>
+								{event.journal ? (
+									<p>
+										{[mood ? getIntakeMoodLabel(mood, t) : null, event.journal.note].filter(Boolean).join(" · ") ||
+											t("journal.history.noNote")}
+									</p>
+								) : (
+									<p>{t("asNeeded.history.noJournal")}</p>
+								)}
+							</div>
+						</article>
+					);
+				})}
+			</div>
+			{nextCursor ? (
+				<AppButton type="button" tone="secondary" onClick={() => void loadMore()} disabled={loadingMore}>
+					{loadingMore ? t("asNeeded.history.loadingMore") : t("asNeeded.history.loadMore")}
+				</AppButton>
+			) : null}
+		</section>
+	);
+}

--- a/frontend/src/components/MedDetailModal.tsx
+++ b/frontend/src/components/MedDetailModal.tsx
@@ -55,6 +55,7 @@ import { getIntakeFrequencyText, getMedicationIntakes } from "../utils/intake-sc
 import { getLiquidCountUnitLabel } from "../utils/intake-units";
 import { getStockStatus } from "../utils/schedule";
 import { splitCurrentBlisterStock } from "../utils/stock";
+import { AsNeededIntakeHistory } from "./AsNeededIntakeHistory";
 import stepperClasses from "./FormNumberStepper.module.css";
 import { Lightbox } from "./Lightbox";
 import classes from "./MedDetailModal.module.css";
@@ -132,8 +133,12 @@ export interface MedDetailModalProps {
 	onCloseRefillModal: () => void;
 	onOpenMedicationEdit?: () => void;
 	onOpenEditStockModal?: () => void;
+	onOpenRecordNow?: () => void;
 	onCloseEditStockModal: () => void;
 	onOpenUserFilter?: (person: string) => void;
+	showAsNeededHistory?: boolean;
+	canRecordAsNeeded?: boolean;
+	asNeededHistoryRefreshVersion?: number;
 	// Refill state
 	refillPacks: number;
 	onRefillPacksChange: (value: number) => void;
@@ -172,8 +177,12 @@ export function MedDetailModal({
 	onCloseRefillModal,
 	onOpenMedicationEdit,
 	onOpenEditStockModal,
+	onOpenRecordNow,
 	onCloseEditStockModal,
 	onOpenUserFilter,
+	showAsNeededHistory = false,
+	canRecordAsNeeded = false,
+	asNeededHistoryRefreshVersion = 0,
 	refillPacks,
 	onRefillPacksChange,
 	refillLoose,
@@ -302,7 +311,7 @@ export function MedDetailModal({
 	const structuralMax = isAmountBasedPackageType(selectedMed.packageType)
 		? stockDisplayCapacity
 		: selectedMed.packCount * selectedMed.blistersPerPack * selectedMed.pillsPerBlister;
-	const currentStock = medCoverage ? Math.round(medCoverage.medsLeft) : getMedTotal(selectedMed);
+	const currentStock = medCoverage ? medCoverage.medsLeft : getMedTotal(selectedMed);
 	const status =
 		medCoverage && hasRegularSchedule ? getStockStatus(medCoverage.daysLeft, medCoverage.medsLeft, settings) : null;
 	const textClass = getValueToneClass(status?.className);
@@ -913,6 +922,15 @@ export function MedDetailModal({
 							</div>
 						</div>
 					</div>
+
+					{showAsNeededHistory ? (
+						<AsNeededIntakeHistory
+							key={`${selectedMed.id}:${asNeededHistoryRefreshVersion}`}
+							medicationId={selectedMed.id}
+							canRecordNow={canRecordAsNeeded}
+							onRecordNow={() => onOpenRecordNow?.()}
+						/>
+					) : null}
 
 					{/* Package Details Section */}
 					<div className={classes["med-detail-section"]}>

--- a/frontend/src/hooks/useAsNeededIntakes.ts
+++ b/frontend/src/hooks/useAsNeededIntakes.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useAuth } from "../components/Auth";
-import type { AsNeededIntakeMutationResponse } from "../types";
+import type { AsNeededIntakeListResponse, AsNeededIntakeMutationResponse } from "../types";
 
 export class AsNeededIntakeRequestError extends Error {
 	constructor(
@@ -14,6 +14,22 @@ export class AsNeededIntakeRequestError extends Error {
 
 export function useAsNeededIntakes() {
 	const { authFetch } = useAuth();
+	const listAsNeededIntakes = useCallback(
+		async (medicationId: number, cursor?: string, signal?: AbortSignal): Promise<AsNeededIntakeListResponse> => {
+			const query = new URLSearchParams({ includeReversed: "true", limit: "10" });
+			if (cursor) query.set("cursor", cursor);
+
+			let response: Response;
+			try {
+				response = await authFetch(`/api/medications/${medicationId}/as-needed-intakes?${query}`, { signal });
+			} catch {
+				throw new AsNeededIntakeRequestError("NETWORK_ERROR");
+			}
+			if (!response.ok) throw new AsNeededIntakeRequestError("HISTORY_UNAVAILABLE");
+			return (await response.json()) as AsNeededIntakeListResponse;
+		},
+		[authFetch]
+	);
 
 	const recordAsNeededIntake = useCallback(
 		async (input: {
@@ -50,5 +66,5 @@ export function useAsNeededIntakes() {
 		[authFetch]
 	);
 
-	return { recordAsNeededIntake };
+	return { listAsNeededIntakes, recordAsNeededIntake };
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -246,6 +246,39 @@
       "successMessage": "{{quantity}} {{unit}} um {{time}} erfasst. Aktueller Bestand: {{stock}}.",
       "reconciliationRequired": "Packungskonfiguration und aktueller Bestand sollten geprüft werden."
     },
+    "lifecycle": {
+      "active_no_schedule": "Aktiv ohne Einnahmeplan",
+      "active_scheduled": "Aktiv mit Einnahmeplan",
+      "ended": "Beendet",
+      "obsolete": "Obsolet"
+    },
+    "history": {
+      "title": "Bedarfseinnahmen",
+      "description": "Erfasste Bedarfseinnahmen einschließlich Korrekturen und Tagebuchkontext.",
+      "loading": "Bedarfseinnahmen werden geladen...",
+      "loadingMore": "Weitere Einträge werden geladen...",
+      "empty": "Noch keine Bedarfseinnahmen erfasst.",
+      "loadMore": "Mehr laden",
+      "retry": "Erneut versuchen",
+      "errorTitle": "Verlauf nicht verfügbar",
+      "errorMessage": "Der Verlauf der Bedarfseinnahmen konnte nicht geladen werden. Versuche es erneut.",
+      "person": "Person",
+      "stockEffect": "Bestandswirkung",
+      "reversedAt": "Storniert am {{time}}",
+      "replacementFor": "Korrektur des Ereignisses {{eventId}}",
+      "journal": "Tagebuch",
+      "noJournal": "Kein Tagebucheintrag.",
+      "status": {
+        "active": "Aktiv",
+        "reversed": "Storniert"
+      },
+      "stockReason": {
+        "applied": "Auf den aktuellen Bestand angewendet",
+        "non_measurable": "Keine messbare Bestandswirkung",
+        "before_correction": "Vor der Bestandskorrektur",
+        "superseded_by_correction": "In einer späteren Bestandskorrektur enthalten"
+      }
+    },
     "units": {
       "pills": "Tabletten",
       "pills_one": "Tablette",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -246,6 +246,39 @@
       "successMessage": "Recorded {{quantity}} {{unit}} at {{time}}. Current stock: {{stock}}.",
       "reconciliationRequired": "The package configuration and current stock should be checked."
     },
+    "lifecycle": {
+      "active_no_schedule": "Active without schedule",
+      "active_scheduled": "Active with schedule",
+      "ended": "Ended",
+      "obsolete": "Obsolete"
+    },
+    "history": {
+      "title": "As-needed history",
+      "description": "Recorded as-needed intakes, including corrections and journal context.",
+      "loading": "Loading as-needed history...",
+      "loadingMore": "Loading more...",
+      "empty": "No as-needed intakes recorded yet.",
+      "loadMore": "Load more",
+      "retry": "Retry",
+      "errorTitle": "History unavailable",
+      "errorMessage": "The as-needed history could not be loaded. Try again.",
+      "person": "Person",
+      "stockEffect": "Stock effect",
+      "reversedAt": "Reversed {{time}}",
+      "replacementFor": "Correction of event {{eventId}}",
+      "journal": "Journal",
+      "noJournal": "No journal entry.",
+      "status": {
+        "active": "Active",
+        "reversed": "Reversed"
+      },
+      "stockReason": {
+        "applied": "Applied to current stock",
+        "non_measurable": "No measurable stock effect",
+        "before_correction": "Before the stock correction",
+        "superseded_by_correction": "Included in a later stock correction"
+      }
+    },
     "units": {
       "pills": "pills",
       "pills_one": "pill",

--- a/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
+++ b/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AsNeededIntakeHistory } from "../../components/AsNeededIntakeHistory";
+import type { AsNeededIntakeEvent } from "../../types";
+
+const listAsNeededIntakes = vi.fn();
+
+vi.mock("../../hooks/useAsNeededIntakes", () => ({
+	useAsNeededIntakes: () => ({ listAsNeededIntakes }),
+}));
+
+function event(overrides: Partial<AsNeededIntakeEvent> = {}): AsNeededIntakeEvent {
+	return {
+		eventType: "as_needed",
+		eventId: "event-1",
+		medicationId: 9,
+		medication: {
+			name: "Pain relief",
+			genericName: null,
+			medicationForm: "tablet",
+			packageType: "blister",
+			isObsolete: false,
+			hasRegularSchedule: false,
+			lifecycle: "active_no_schedule",
+			recordEligibility: { eligible: true, reason: "eligible" },
+		},
+		occurredAt: "2026-08-15T12:30:00.000Z",
+		recordedAt: "2026-08-15T12:30:01.000Z",
+		quantity: 0.5,
+		quantityUnit: "pills",
+		person: "Alex",
+		source: "owner_as_needed",
+		status: "active",
+		revision: 1,
+		stockEffect: 0.5,
+		stockEffectReason: "applied",
+		stockCutoffAt: null,
+		replacementForEventId: null,
+		reversedAt: null,
+		journal: null,
+		...overrides,
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe("AsNeededIntakeHistory", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders active and reversed corrections with trusted times, journal context, person and stock reason", async () => {
+		listAsNeededIntakes.mockResolvedValueOnce({
+			events: [
+				event({
+					journal: {
+						doseId: "as-needed:event-1",
+						mood: "better",
+						note: "Helped quickly",
+						createdAt: "x",
+						updatedAt: "x",
+					},
+				}),
+				event({
+					eventId: "event-0",
+					status: "reversed",
+					person: null,
+					stockEffect: 0,
+					stockEffectReason: "superseded_by_correction",
+					reversedAt: "2026-08-15T13:00:00.000Z",
+					replacementForEventId: "event-1",
+					journal: null,
+				}),
+			],
+			nextCursor: null,
+		});
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
+
+		await screen.findByText("asNeeded.history.title");
+		expect(screen.getByText("asNeeded.lifecycle.active_no_schedule")).toBeInTheDocument();
+		expect(screen.getByText("Alex")).toBeInTheDocument();
+		expect(screen.getByText("asNeeded.record.noPerson")).toBeInTheDocument();
+		expect(screen.getByText("asNeeded.history.stockReason.applied")).toBeInTheDocument();
+		expect(screen.getByText("asNeeded.history.stockReason.superseded_by_correction")).toBeInTheDocument();
+		expect(screen.getByText("asNeeded.history.replacementFor")).toBeInTheDocument();
+		expect(screen.getByText("asNeeded.history.noJournal")).toBeInTheDocument();
+		expect(screen.getByText(/Helped quickly/)).toBeInTheDocument();
+		const times = document.querySelectorAll("time");
+		expect(times).toHaveLength(2);
+		expect(times[0]).toHaveAttribute("dateTime", "2026-08-15T12:30:00.000Z");
+	});
+
+	it("hides empty history when intake is ineligible, but keeps the eligible empty state and Record now action", async () => {
+		listAsNeededIntakes.mockResolvedValue({ events: [], nextCursor: null });
+		const { rerender } = render(<AsNeededIntakeHistory medicationId={9} canRecordNow={false} onRecordNow={vi.fn()} />);
+		await waitFor(() => expect(screen.queryByText("asNeeded.history.title")).not.toBeInTheDocument());
+
+		const onRecordNow = vi.fn();
+		rerender(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={onRecordNow} />);
+		await screen.findByText("asNeeded.history.empty");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.action" }));
+		expect(onRecordNow).toHaveBeenCalledOnce();
+	});
+
+	it("retries safe failures and deduplicates cursor pages", async () => {
+		listAsNeededIntakes
+			.mockRejectedValueOnce(new Error("offline"))
+			.mockResolvedValueOnce({ events: [event()], nextCursor: "cursor-2" })
+			.mockResolvedValueOnce({ events: [event(), event({ eventId: "event-2", person: "Bea" })], nextCursor: null });
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
+
+		await screen.findByText("asNeeded.history.errorMessage");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.retry" }));
+		await screen.findByText("Alex");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.loadMore" }));
+		await screen.findByText("Bea");
+		expect(screen.getAllByText("Alex")).toHaveLength(1);
+		expect(screen.getAllByText("Bea")).toHaveLength(1);
+		expect(listAsNeededIntakes).toHaveBeenLastCalledWith(9, "cursor-2");
+	});
+
+	it("aborts stale first-page work and ignores its late response after medication changes", async () => {
+		const first = deferred<{ events: AsNeededIntakeEvent[]; nextCursor: string | null }>();
+		listAsNeededIntakes.mockImplementationOnce((_id: number, _cursor: string | undefined, signal: AbortSignal) => {
+			expect(signal.aborted).toBe(false);
+			return first.promise;
+		});
+		listAsNeededIntakes.mockResolvedValueOnce({
+			events: [event({ medicationId: 10, person: "New" })],
+			nextCursor: null,
+		});
+		const { rerender } = render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
+		rerender(<AsNeededIntakeHistory medicationId={10} canRecordNow onRecordNow={vi.fn()} />);
+
+		await screen.findByText("New");
+		first.resolve({ events: [event({ person: "Stale" })], nextCursor: null });
+		await waitFor(() => expect(screen.queryByText("Stale")).not.toBeInTheDocument());
+		expect(listAsNeededIntakes.mock.calls[0][2].aborted).toBe(true);
+	});
+});

--- a/frontend/src/test/hooks/useAsNeededIntakes.test.ts
+++ b/frontend/src/test/hooks/useAsNeededIntakes.test.ts
@@ -63,4 +63,30 @@ describe("useAsNeededIntakes", () => {
 			result.current.recordAsNeededIntake({ medicationId: 1, quantity: 1, person: null, idempotencyKey: "network-key" })
 		).rejects.toEqual(expect.objectContaining({ code: "NETWORK_ERROR" }));
 	});
+
+	it("lists corrected history with a bounded cursor request and forwards cancellation", async () => {
+		const response = { events: [], nextCursor: "next-page" };
+		const controller = new AbortController();
+		authFetchMock.mockResolvedValue({ ok: true, json: async () => response });
+		const { result } = renderHook(() => useAsNeededIntakes());
+
+		await expect(result.current.listAsNeededIntakes(42, "cursor-1", controller.signal)).resolves.toBe(response);
+		expect(authFetchMock).toHaveBeenCalledWith(
+			"/api/medications/42/as-needed-intakes?includeReversed=true&limit=10&cursor=cursor-1",
+			{ signal: controller.signal }
+		);
+	});
+
+	it("maps unavailable history responses and transport failures to safe errors", async () => {
+		const { result } = renderHook(() => useAsNeededIntakes());
+		authFetchMock.mockResolvedValueOnce({ ok: false });
+		await expect(result.current.listAsNeededIntakes(1)).rejects.toEqual(
+			expect.objectContaining({ code: "HISTORY_UNAVAILABLE" })
+		);
+
+		authFetchMock.mockRejectedValueOnce(new Error("offline"));
+		await expect(result.current.listAsNeededIntakes(1)).rejects.toEqual(
+			expect.objectContaining({ code: "NETWORK_ERROR" })
+		);
+	});
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -221,6 +221,11 @@ export type AsNeededIntakeMutationResponse = {
 	};
 };
 
+export type AsNeededIntakeListResponse = {
+	events: AsNeededIntakeEvent[];
+	nextCursor: string | null;
+};
+
 export type PlannerRow = {
 	medicationId: number;
 	medicationName: string;


### PR DESCRIPTION
Closes #1038

## Summary

- add a detail-level Record now entry point and cursor-paginated newest-first as-needed history
- display active/reversed lifecycle, person, timezone, stock-effect/reconciliation, replacement, and nullable journal context read-only
- make history loading retryable, deduplicated, and latest-wins with AbortController cancellation in the nested modal flow

## Scope boundary

No reversal, replacement, or journal mutation action is included; those remain in #1040.

## Validation

- full frontend suite: 79 files, 1,151 tests
- detail Playwright coverage: 5 tests; stable modal-layout coverage: 10 tests
- frontend/root lint, check, build, i18n parity (1,007), and diff check

Security review found no critical, major, or minor findings.