### PR TITLE
feat: add as-needed history actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
 } from "./context";
 import { useModalHistory } from "./hooks/useModalHistory";
 import { useScrollLock } from "./hooks/useScrollLock";
+import type { AsNeededIntakeEvent } from "./types";
 import { AppButton } from "./ui/primitives/AppButton";
 import { getMedicationIntakes } from "./utils/intake-schedule";
 
@@ -244,6 +245,7 @@ function AppContent() {
 		meds,
 		loadMeds,
 		recordAsNeededIntake,
+		reverseAsNeededIntake,
 		// Refill
 		showRefillModal,
 		setShowRefillModal,
@@ -324,6 +326,7 @@ function AppContent() {
 	const [showProfile, setShowProfile] = useState(false);
 	const [showAbout, setShowAbout] = useState(false);
 	const [detailRecordNowMedication, setDetailRecordNowMedication] = useState<(typeof meds)[number] | null>(null);
+	const [detailReplacementEvent, setDetailReplacementEvent] = useState<AsNeededIntakeEvent | null>(null);
 	const [asNeededHistoryRefreshVersion, setAsNeededHistoryRefreshVersion] = useState(0);
 	const [routeTransitionMaskActive, setRouteTransitionMaskActive] = useState(false);
 	const [showMainSwipeHint, setShowMainSwipeHint] = useState(shouldShowInitialMainSwipeHint);
@@ -345,6 +348,7 @@ function AppContent() {
 	}, []);
 	const dismissDetailRecordNow = useCallback(() => {
 		setDetailRecordNowMedication(null);
+		setDetailReplacementEvent(null);
 	}, []);
 	// History integration via the shared modal stack: pushes one entry on open,
 	// browser back (or closeModal) dismisses only the topmost modal.
@@ -354,7 +358,11 @@ function AppContent() {
 		Boolean(detailRecordNowMedication),
 		"detail-record-now",
 		dismissDetailRecordNow,
-		{ state: detailRecordNowMedication ? { medicationId: detailRecordNowMedication.id } : undefined }
+		{
+			state: detailRecordNowMedication
+				? { medicationId: detailRecordNowMedication.id, replacementEventId: detailReplacementEvent?.eventId }
+				: undefined,
+		}
 	);
 
 	// Get centralized stockThresholds from context
@@ -757,7 +765,17 @@ function AppContent() {
 						onCloseRefillModal={closeRefillModal}
 						onOpenMedicationEdit={handleOpenMedicationEdit}
 						onOpenEditStockModal={handleOpenEditStockFromDetail}
-						onOpenRecordNow={() => selectedMed && setDetailRecordNowMedication(selectedMed)}
+						onOpenRecordNow={() => {
+							if (!selectedMed) return;
+							setDetailReplacementEvent(null);
+							setDetailRecordNowMedication(selectedMed);
+						}}
+						onReplaceAsNeeded={(event) => {
+							if (!selectedMed) return;
+							setDetailReplacementEvent(event);
+							setDetailRecordNowMedication(selectedMed);
+						}}
+						onReverseAsNeeded={reverseAsNeededIntake}
 						onCloseEditStockModal={closeEditStockModal}
 						onOpenUserFilter={openUserFilter}
 						refillPacks={refillPacks}
@@ -787,6 +805,7 @@ function AppContent() {
 				<Suspense fallback={null}>
 					<RecordNowModal
 						medication={detailRecordNowMedication}
+						replacementEvent={detailReplacementEvent}
 						onClose={closeDetailRecordNow}
 						onRecord={async (input) => {
 							const result = await recordAsNeededIntake(input);

--- a/frontend/src/components/AsNeededIntakeHistory.module.css
+++ b/frontend/src/components/AsNeededIntakeHistory.module.css
@@ -107,6 +107,13 @@
 	overflow-wrap: anywhere;
 }
 
+.entryActions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	gap: 0.5rem;
+}
+
 @media (max-width: 600px) {
 	.headingRow {
 		align-items: flex-start;

--- a/frontend/src/components/AsNeededIntakeHistory.tsx
+++ b/frontend/src/components/AsNeededIntakeHistory.tsx
@@ -1,19 +1,33 @@
-import { Alert } from "@mantine/core";
+import { Alert, Stack, Text } from "@mantine/core";
 import { normalizeIntakeMood } from "@medassist/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
-import type { AsNeededIntakeEvent } from "../types";
+import { AsNeededIntakeRequestError, useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
+import { useModalHistory } from "../hooks/useModalHistory";
+import type { AsNeededIntakeEvent, AsNeededIntakeMutationResponse } from "../types";
 import { AppButton } from "../ui/primitives/AppButton";
 import { StatusBadge } from "../ui/primitives/StatusBadge";
 import { getNumericLocale, withFormattingTimezone } from "../utils/formatters";
 import { getIntakeMoodLabel } from "../utils/intake-mood";
 import classes from "./AsNeededIntakeHistory.module.css";
+import { ConfirmModal } from "./ConfirmModal";
 
 type AsNeededIntakeHistoryProps = {
 	medicationId: number;
 	canRecordNow: boolean;
 	onRecordNow: () => void;
+	onReplace?: (event: AsNeededIntakeEvent) => void;
+	onReverse?: (input: {
+		eventId: string;
+		expectedRevision: number;
+		idempotencyKey: string;
+	}) => Promise<AsNeededIntakeMutationResponse>;
+};
+
+type ReversalIntent = {
+	event: AsNeededIntakeEvent;
+	idempotencyKey: string;
+	replaceAfter: boolean;
 };
 
 function formatQuantity(value: number): string {
@@ -27,7 +41,21 @@ function formatTrustedDateTime(value: string): string {
 	);
 }
 
-export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow }: AsNeededIntakeHistoryProps) {
+function getReversalErrorKey(code: string): string {
+	if (code === "NETWORK_ERROR") return "asNeeded.reversal.errors.network";
+	if (code === "EVENT_VERSION_CONFLICT") return "asNeeded.reversal.errors.revision";
+	if (code === "IDEMPOTENCY_KEY_REUSED") return "asNeeded.reversal.errors.intentConflict";
+	if (code === "READ_ONLY" || code === "API_KEY_SCOPE_FORBIDDEN") return "asNeeded.errors.readOnly";
+	return "asNeeded.reversal.errors.generic";
+}
+
+export function AsNeededIntakeHistory({
+	medicationId,
+	canRecordNow,
+	onRecordNow,
+	onReplace,
+	onReverse,
+}: AsNeededIntakeHistoryProps) {
 	const { t } = useTranslation();
 	const { listAsNeededIntakes } = useAsNeededIntakes();
 	const [events, setEvents] = useState<AsNeededIntakeEvent[]>([]);
@@ -35,8 +63,24 @@ export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow 
 	const [loading, setLoading] = useState(true);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const [error, setError] = useState(false);
+	const [reversalIntent, setReversalIntent] = useState<ReversalIntent | null>(null);
+	const [reversalPending, setReversalPending] = useState(false);
+	const [reversalError, setReversalError] = useState<string | null>(null);
+	const [actionNotice, setActionNotice] = useState<{ tone: "green" | "yellow" | "red"; key: string } | null>(null);
+	const [replacementReady, setReplacementReady] = useState<AsNeededIntakeEvent | null>(null);
 	const requestVersionRef = useRef(0);
 	const firstPageAbortRef = useRef<AbortController | null>(null);
+	const actionFeedbackRef = useRef<HTMLDivElement>(null);
+	const dismissReversal = useCallback(() => {
+		setReversalIntent(null);
+		setReversalError(null);
+	}, []);
+	const { closeModal: closeReversal } = useModalHistory(
+		Boolean(reversalIntent),
+		"as-needed-reversal-confirm",
+		dismissReversal,
+		{ state: reversalIntent ? { eventId: reversalIntent.event.eventId } : undefined }
+	);
 
 	const loadFirstPage = useCallback(async () => {
 		firstPageAbortRef.current?.abort();
@@ -66,6 +110,10 @@ export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow 
 		};
 	}, [loadFirstPage]);
 
+	useEffect(() => {
+		if (actionNotice || reversalError) actionFeedbackRef.current?.focus();
+	}, [actionNotice, reversalError]);
+
 	const loadMore = async () => {
 		if (!nextCursor || loadingMore) return;
 		const requestVersion = requestVersionRef.current;
@@ -86,8 +134,62 @@ export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow 
 		}
 	};
 
+	const beginReversal = (event: AsNeededIntakeEvent, replaceAfter: boolean) => {
+		setReversalIntent({ event, idempotencyKey: crypto.randomUUID(), replaceAfter });
+		setReversalError(null);
+		setActionNotice(null);
+		setReplacementReady(null);
+	};
+
+	const submitReversal = async () => {
+		if (!reversalIntent || !onReverse || reversalPending) return;
+		setReversalPending(true);
+		setReversalError(null);
+		try {
+			const result = await onReverse({
+				eventId: reversalIntent.event.eventId,
+				expectedRevision: reversalIntent.event.revision,
+				idempotencyKey: reversalIntent.idempotencyKey,
+			});
+			setEvents((current) => current.map((event) => (event.eventId === result.event.eventId ? result.event : event)));
+			if (reversalIntent.replaceAfter) {
+				setReplacementReady(result.event);
+				setActionNotice({
+					tone: result.inventory.reconciliationRequired ? "yellow" : "green",
+					key: result.inventory.reconciliationRequired ? "correctionReadyReconciliation" : "correctionReady",
+				});
+			} else {
+				setActionNotice({
+					tone: result.inventory.reconciliationRequired ? "yellow" : "green",
+					key: result.inventory.reconciliationRequired ? "reconciliation" : "reversed",
+				});
+			}
+			closeReversal();
+		} catch (requestError) {
+			if (requestError instanceof AsNeededIntakeRequestError) {
+				if (requestError.code === "EVENT_VERSION_CONFLICT") {
+					closeReversal();
+					setActionNotice({ tone: "red", key: "revisionChanged" });
+					await loadFirstPage();
+				} else {
+					setReversalError(getReversalErrorKey(requestError.code));
+				}
+			} else {
+				setReversalError("asNeeded.reversal.errors.generic");
+			}
+		} finally {
+			setReversalPending(false);
+		}
+	};
+
 	if (!canRecordNow && !loading && !error && events.length === 0) return null;
 	const lifecycle = events[0]?.medication.lifecycle ?? (canRecordNow ? "active_no_schedule" : null);
+	let reversalConfirmLabel = t("asNeeded.reversal.confirm");
+	if (reversalPending) reversalConfirmLabel = t("asNeeded.reversal.saving");
+	else if (reversalError) reversalConfirmLabel = t("common.retry");
+	const replacedEventIds = new Set(
+		events.map((event) => event.replacementForEventId).filter((eventId): eventId is string => eventId !== null)
+	);
 
 	return (
 		<section className={classes.section} aria-labelledby="as-needed-history-title">
@@ -111,6 +213,30 @@ export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow 
 					<AppButton type="button" tone="secondary" size="xs" onClick={() => void loadFirstPage()}>
 						{t("asNeeded.history.retry")}
 					</AppButton>
+				</Alert>
+			) : null}
+			{actionNotice ? (
+				<Alert
+					ref={actionFeedbackRef}
+					tabIndex={-1}
+					color={actionNotice.tone}
+					title={t(`asNeeded.reversal.notice.${actionNotice.key}Title`)}
+				>
+					{t(`asNeeded.reversal.notice.${actionNotice.key}Message`)}
+					{replacementReady && onReplace ? (
+						<AppButton
+							type="button"
+							tone="primary"
+							size="xs"
+							onClick={() => {
+								onReplace(replacementReady);
+								setReplacementReady(null);
+								setActionNotice(null);
+							}}
+						>
+							{t("asNeeded.replacement.action")}
+						</AppButton>
+					) : null}
 				</Alert>
 			) : null}
 			{!loading && events.length === 0 ? <p className={classes.state}>{t("asNeeded.history.empty")}</p> : null}
@@ -162,6 +288,29 @@ export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow 
 									<p>{t("asNeeded.history.noJournal")}</p>
 								)}
 							</div>
+							{event.status === "active" && onReverse ? (
+								<div className={classes.entryActions}>
+									<AppButton type="button" tone="danger" size="xs" onClick={() => beginReversal(event, false)}>
+										{t("asNeeded.reversal.action")}
+									</AppButton>
+									{event.medication.recordEligibility.eligible && onReplace ? (
+										<AppButton type="button" tone="secondary" size="xs" onClick={() => beginReversal(event, true)}>
+											{t("asNeeded.replacement.correctAction")}
+										</AppButton>
+									) : null}
+								</div>
+							) : null}
+							{event.status === "reversed" &&
+							!replacedEventIds.has(event.eventId) &&
+							replacementReady?.eventId !== event.eventId &&
+							event.medication.recordEligibility.eligible &&
+							onReplace ? (
+								<div className={classes.entryActions}>
+									<AppButton type="button" tone="secondary" size="xs" onClick={() => onReplace(event)}>
+										{t("asNeeded.replacement.action")}
+									</AppButton>
+								</div>
+							) : null}
 						</article>
 					);
 				})}
@@ -170,6 +319,45 @@ export function AsNeededIntakeHistory({ medicationId, canRecordNow, onRecordNow 
 				<AppButton type="button" tone="secondary" onClick={() => void loadMore()} disabled={loadingMore}>
 					{loadingMore ? t("asNeeded.history.loadingMore") : t("asNeeded.history.loadMore")}
 				</AppButton>
+			) : null}
+			{reversalIntent ? (
+				<ConfirmModal
+					title={t(
+						reversalIntent.replaceAfter ? "asNeeded.replacement.reverseTitle" : "asNeeded.reversal.confirmTitle"
+					)}
+					message={
+						<Stack gap="sm">
+							<Text>
+								{t(
+									reversalIntent.replaceAfter
+										? "asNeeded.replacement.reverseMessage"
+										: "asNeeded.reversal.confirmMessage",
+									{
+										quantity: formatQuantity(reversalIntent.event.quantity),
+										unit: t(`asNeeded.units.${reversalIntent.event.quantityUnit}`, {
+											count: reversalIntent.event.quantity,
+										}),
+									}
+								)}
+							</Text>
+							{reversalError ? (
+								<Alert ref={actionFeedbackRef} tabIndex={-1} color="red">
+									{t(reversalError)}
+								</Alert>
+							) : null}
+						</Stack>
+					}
+					confirmLabel={reversalConfirmLabel}
+					cancelLabel={t("common.cancel")}
+					onConfirm={() => void submitReversal()}
+					onCancel={() => {
+						if (!reversalPending) closeReversal();
+					}}
+					isLoading={reversalPending}
+					confirmVariant="danger"
+					overlayClassName="nested-confirm"
+					captureEscape
+				/>
 			) : null}
 		</section>
 	);

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -4,6 +4,7 @@
 
 import { Stack, Text } from "@mantine/core";
 import type { ReactNode } from "react";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
 import { AppButton } from "../ui/primitives/AppButton";
 
@@ -17,6 +18,7 @@ export interface ConfirmModalProps {
 	isLoading?: boolean;
 	confirmVariant?: "primary" | "danger" | "success" | "warning";
 	overlayClassName?: string;
+	captureEscape?: boolean;
 }
 
 export function ConfirmModal({
@@ -29,10 +31,14 @@ export function ConfirmModal({
 	isLoading = false,
 	confirmVariant = "primary",
 	overlayClassName,
+	captureEscape = false,
 }: ConfirmModalProps) {
+	useEscapeKey(captureEscape, onCancel, { capture: true });
 	return (
 		<AppModal
-			closeButtonProps={{ "aria-label": "Close" }}
+			closeButtonProps={{ "aria-label": "Close", disabled: captureEscape && isLoading }}
+			closeOnEscape={false}
+			manageEscape={!captureEscape}
 			onClose={onCancel}
 			opened
 			rootClassName={overlayClassName}

--- a/frontend/src/components/MedDetailModal.tsx
+++ b/frontend/src/components/MedDetailModal.tsx
@@ -25,7 +25,14 @@ import {
 import { Fragment, type MouseEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import type { Coverage, Medication, RefillEntry, StockThresholds } from "../types";
+import type {
+	AsNeededIntakeEvent,
+	AsNeededIntakeMutationResponse,
+	Coverage,
+	Medication,
+	RefillEntry,
+	StockThresholds,
+} from "../types";
 import {
 	allowsPillFormSelection,
 	getMedDisplayName,
@@ -134,6 +141,12 @@ export interface MedDetailModalProps {
 	onOpenMedicationEdit?: () => void;
 	onOpenEditStockModal?: () => void;
 	onOpenRecordNow?: () => void;
+	onReplaceAsNeeded?: (event: AsNeededIntakeEvent) => void;
+	onReverseAsNeeded?: (input: {
+		eventId: string;
+		expectedRevision: number;
+		idempotencyKey: string;
+	}) => Promise<AsNeededIntakeMutationResponse>;
 	onCloseEditStockModal: () => void;
 	onOpenUserFilter?: (person: string) => void;
 	showAsNeededHistory?: boolean;
@@ -178,6 +191,8 @@ export function MedDetailModal({
 	onOpenMedicationEdit,
 	onOpenEditStockModal,
 	onOpenRecordNow,
+	onReplaceAsNeeded,
+	onReverseAsNeeded,
 	onCloseEditStockModal,
 	onOpenUserFilter,
 	showAsNeededHistory = false,
@@ -929,6 +944,8 @@ export function MedDetailModal({
 							medicationId={selectedMed.id}
 							canRecordNow={canRecordAsNeeded}
 							onRecordNow={() => onOpenRecordNow?.()}
+							onReplace={onReplaceAsNeeded}
+							onReverse={onReverseAsNeeded}
 						/>
 					) : null}
 

--- a/frontend/src/components/RecordNowModal.tsx
+++ b/frontend/src/components/RecordNowModal.tsx
@@ -3,7 +3,7 @@ import { getAsNeededQuantityProfile, normalizeAsNeededQuantityMilli } from "@med
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AsNeededIntakeRequestError } from "../hooks/useAsNeededIntakes";
-import type { AsNeededIntakeMutationResponse, Medication } from "../types";
+import type { AsNeededIntakeEvent, AsNeededIntakeMutationResponse, Medication } from "../types";
 import { getMedDisplayName } from "../types";
 import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
 import { AppButton } from "../ui/primitives/AppButton";
@@ -14,12 +14,14 @@ import { MedicationAvatar } from "./MedicationAvatar";
 
 type RecordNowModalProps = {
 	medication: Medication | null;
+	replacementEvent?: AsNeededIntakeEvent | null;
 	onClose: () => void;
 	onRecord: (input: {
 		medicationId: number;
 		quantity: number;
 		person: string | null;
 		idempotencyKey: string;
+		replacementForEventId?: string | null;
 	}) => Promise<AsNeededIntakeMutationResponse>;
 };
 
@@ -32,6 +34,7 @@ function getErrorKey(code: string): string {
 	if (code === "INVALID_QUANTITY") return "asNeeded.errors.invalidQuantity";
 	if (code === "TOO_MANY_NEW_INTAKES") return "asNeeded.errors.rateLimited";
 	if (code === "IDEMPOTENCY_KEY_REUSED") return "asNeeded.errors.intentConflict";
+	if (code === "REPLACEMENT_NOT_ALLOWED" || code === "EVENT_NOT_FOUND") return "asNeeded.errors.replacementUnavailable";
 	if (code === "READ_ONLY" || code === "API_KEY_SCOPE_FORBIDDEN") return "asNeeded.errors.readOnly";
 	return "asNeeded.errors.generic";
 }
@@ -47,7 +50,7 @@ function formatTrustedDateTime(value: string): string {
 	);
 }
 
-export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModalProps) {
+export function RecordNowModal({ medication, replacementEvent = null, onClose, onRecord }: RecordNowModalProps) {
 	const { t } = useTranslation();
 	const profile = useMemo(() => getAsNeededQuantityProfile(medication ?? {}), [medication]);
 	const [quantity, setQuantity] = useState(String(profile.defaultQuantity));
@@ -62,14 +65,16 @@ export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModal
 	useEffect(() => {
 		if (!medication) return;
 		const nextProfile = getAsNeededQuantityProfile(medication);
-		setQuantity(String(nextProfile.defaultQuantity));
-		setPerson("");
+		setQuantity(String(replacementEvent?.quantity ?? nextProfile.defaultQuantity));
+		setPerson(
+			replacementEvent?.person && medication.takenBy.includes(replacementEvent.person) ? replacementEvent.person : ""
+		);
 		setIdempotencyKey(crypto.randomUUID());
 		setPending(false);
 		setAttempted(false);
 		setError(null);
 		setResult(null);
-	}, [medication]);
+	}, [medication, replacementEvent]);
 
 	useEffect(() => {
 		if (error || result) feedbackRef.current?.focus();
@@ -81,7 +86,7 @@ export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModal
 	const quantityIsValid = normalizeAsNeededQuantityMilli(numericQuantity, profile) !== null;
 	const unitLabel = t(`asNeeded.units.${profile.unit}`, { count: numericQuantity });
 	const locked = pending || attempted;
-	let submitLabel = t("asNeeded.record.confirm");
+	let submitLabel = t(replacementEvent ? "asNeeded.replacement.confirm" : "asNeeded.record.confirm");
 	if (pending) {
 		submitLabel = t("asNeeded.record.saving");
 	} else if (error) {
@@ -104,6 +109,7 @@ export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModal
 					quantity: numericQuantity,
 					person: person || null,
 					idempotencyKey,
+					...(replacementEvent ? { replacementForEventId: replacementEvent.eventId } : {}),
 				})
 			);
 		} catch (requestError) {
@@ -123,7 +129,7 @@ export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModal
 			onClose={close}
 			opened
 			size={480}
-			title={t("asNeeded.record.title")}
+			title={t(replacementEvent ? "asNeeded.replacement.title" : "asNeeded.record.title")}
 			withCloseButton
 		>
 			<Stack gap="md">
@@ -138,7 +144,12 @@ export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModal
 				</Group>
 
 				{result ? (
-					<Alert ref={feedbackRef} tabIndex={-1} color="green" title={t("asNeeded.record.successTitle")}>
+					<Alert
+						ref={feedbackRef}
+						tabIndex={-1}
+						color="green"
+						title={t(replacementEvent ? "asNeeded.replacement.successTitle" : "asNeeded.record.successTitle")}
+					>
 						{t("asNeeded.record.successMessage", {
 							quantity: formatQuantity(result.event.quantity),
 							unit: t(`asNeeded.units.${result.event.quantityUnit}`, { count: result.event.quantity }),
@@ -149,6 +160,11 @@ export function RecordNowModal({ medication, onClose, onRecord }: RecordNowModal
 					</Alert>
 				) : (
 					<>
+						{replacementEvent ? (
+							<Text size="sm">
+								{t("asNeeded.replacement.description", { time: formatTrustedDateTime(replacementEvent.occurredAt) })}
+							</Text>
+						) : null}
 						<Text size="sm">{t("asNeeded.record.trustedTime")}</Text>
 						<fieldset disabled={locked} style={{ border: 0, margin: 0, padding: 0 }}>
 							<Stack gap="md">

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -69,6 +69,7 @@ export interface AppContextValue {
 	uploadMedImage: (medId: number, file: File) => Promise<void>;
 	deleteMedImage: (medId: number) => Promise<void>;
 	recordAsNeededIntake: ReturnType<typeof useAsNeededIntakes>["recordAsNeededIntake"];
+	reverseAsNeededIntake: ReturnType<typeof useAsNeededIntakes>["reverseAsNeededIntake"];
 
 	// From useSettings (selected fields)
 	settings: ReturnType<typeof useSettings>["settings"];
@@ -318,6 +319,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 			return result;
 		},
 		[asNeededIntakes.recordAsNeededIntake, medications.loadMeds]
+	);
+	const reverseAsNeededIntake = useCallback(
+		async (input: Parameters<typeof asNeededIntakes.reverseAsNeededIntake>[0]) => {
+			const result = await asNeededIntakes.reverseAsNeededIntake(input);
+			medications.loadMeds();
+			return result;
+		},
+		[asNeededIntakes.reverseAsNeededIntake, medications.loadMeds]
 	);
 
 	// Schedule UI state
@@ -671,6 +680,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 			// From useMedications
 			...medications,
 			recordAsNeededIntake,
+			reverseAsNeededIntake,
 
 			// From useSettings
 			settings: settingsHook.settings,
@@ -853,6 +863,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		[
 			medications,
 			recordAsNeededIntake,
+			reverseAsNeededIntake,
 			settingsHook,
 			doses,
 			intakeJournal,

--- a/frontend/src/hooks/useAsNeededIntakes.ts
+++ b/frontend/src/hooks/useAsNeededIntakes.ts
@@ -5,11 +5,28 @@ import type { AsNeededIntakeListResponse, AsNeededIntakeMutationResponse } from 
 export class AsNeededIntakeRequestError extends Error {
 	constructor(
 		public readonly code: string,
-		public readonly retryAfterSeconds: number | null = null
+		public readonly retryAfterSeconds: number | null = null,
+		public readonly currentRevision: number | null = null
 	) {
 		super(code);
 		this.name = "AsNeededIntakeRequestError";
 	}
+}
+
+async function getMutationError(response: Response): Promise<AsNeededIntakeRequestError> {
+	const retryAfter = Number.parseInt(response.headers.get("Retry-After") ?? "", 10);
+	let code = "UNKNOWN_ERROR";
+	let currentRevision: number | null = null;
+	try {
+		const body = (await response.json()) as { code?: unknown; currentRevision?: unknown };
+		if (typeof body.code === "string") code = body.code;
+		if (typeof body.currentRevision === "number" && Number.isSafeInteger(body.currentRevision)) {
+			currentRevision = body.currentRevision;
+		}
+	} catch {
+		// The translated UI uses stable fallbacks for malformed error responses.
+	}
+	return new AsNeededIntakeRequestError(code, Number.isFinite(retryAfter) ? retryAfter : null, currentRevision);
 }
 
 export function useAsNeededIntakes() {
@@ -37,34 +54,51 @@ export function useAsNeededIntakes() {
 			quantity: number;
 			person: string | null;
 			idempotencyKey: string;
+			replacementForEventId?: string | null;
 		}): Promise<AsNeededIntakeMutationResponse> => {
 			let response: Response;
 			try {
 				response = await authFetch(`/api/medications/${input.medicationId}/as-needed-intakes`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json", "Idempotency-Key": input.idempotencyKey },
-					body: JSON.stringify({ quantity: input.quantity, person: input.person }),
+					body: JSON.stringify({
+						quantity: input.quantity,
+						person: input.person,
+						...(input.replacementForEventId ? { replacementForEventId: input.replacementForEventId } : {}),
+					}),
 				});
 			} catch {
 				throw new AsNeededIntakeRequestError("NETWORK_ERROR");
 			}
 
-			if (!response.ok) {
-				const retryAfter = Number.parseInt(response.headers.get("Retry-After") ?? "", 10);
-				let code = "UNKNOWN_ERROR";
-				try {
-					const body = (await response.json()) as { code?: unknown };
-					if (typeof body.code === "string") code = body.code;
-				} catch {
-					// The translated UI uses the stable fallback code for malformed error responses.
-				}
-				throw new AsNeededIntakeRequestError(code, Number.isFinite(retryAfter) ? retryAfter : null);
-			}
+			if (!response.ok) throw await getMutationError(response);
 
 			return (await response.json()) as AsNeededIntakeMutationResponse;
 		},
 		[authFetch]
 	);
 
-	return { listAsNeededIntakes, recordAsNeededIntake };
+	const reverseAsNeededIntake = useCallback(
+		async (input: {
+			eventId: string;
+			expectedRevision: number;
+			idempotencyKey: string;
+		}): Promise<AsNeededIntakeMutationResponse> => {
+			let response: Response;
+			try {
+				response = await authFetch(`/api/as-needed-intakes/${input.eventId}/reversal`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json", "Idempotency-Key": input.idempotencyKey },
+					body: JSON.stringify({ expectedRevision: input.expectedRevision }),
+				});
+			} catch {
+				throw new AsNeededIntakeRequestError("NETWORK_ERROR");
+			}
+			if (!response.ok) throw await getMutationError(response);
+			return (await response.json()) as AsNeededIntakeMutationResponse;
+		},
+		[authFetch]
+	);
+
+	return { listAsNeededIntakes, recordAsNeededIntake, reverseAsNeededIntake };
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -301,8 +301,44 @@
       "invalidQuantity": "Gib eine für diesen Packungstyp gültige Menge ein.",
       "rateLimited": "Es wurden zu viele neue Einnahmen angefordert. Versuche dieselbe Einnahme nach {{seconds}} Sekunden erneut.",
       "intentConflict": "Diese Anfrage kollidiert mit einer früheren Anfrage. Schließe den Dialog und beginne erneut.",
+      "replacementUnavailable": "Diese Korrektur kann nicht mehr mit der ausgewählten Einnahme verknüpft werden. Aktualisiere den Verlauf und versuche es erneut.",
       "readOnly": "Mit diesem schreibgeschützten Zugriff kann keine Einnahme erfasst werden.",
       "generic": "Die Einnahme konnte nicht erfasst werden. Versuche dieselbe Einnahme erneut oder brich ab."
+    },
+    "replacement": {
+      "action": "Korrektur erfassen",
+      "correctAction": "Korrigieren",
+      "title": "Korrigierte Einnahme erfassen",
+      "description": "Dies erstellt eine separate Einnahme, die mit dem stornierten Ereignis vom {{time}} verknüpft ist.",
+      "confirm": "Korrektur erfassen",
+      "successTitle": "Korrektur erfasst",
+      "reverseTitle": "Einnahme korrigieren",
+      "reverseMessage": "Die ursprüngliche Einnahme von {{quantity}} {{unit}} muss zuerst storniert werden. Ihr Prüfverlauf bleibt erhalten, auch wenn du abbrichst oder die Ersetzung fehlschlägt."
+    },
+    "reversal": {
+      "action": "Stornieren",
+      "confirmTitle": "Einnahme stornieren",
+      "confirmMessage": "Die erfasste Einnahme von {{quantity}} {{unit}} stornieren? Nur ihre gespeicherte Bestandswirkung wird wiederhergestellt und der Prüfverlauf bleibt erhalten.",
+      "confirm": "Einnahme stornieren",
+      "saving": "Wird storniert...",
+      "errors": {
+        "network": "Das Ergebnis ist wegen einer unterbrochenen Verbindung unklar. Erneut versuchen verwendet sicher dieselbe Stornierung.",
+        "revision": "Diese Einnahme wurde geändert. Der Verlauf wurde aktualisiert; prüfe ihn vor einem neuen Versuch.",
+        "intentConflict": "Diese Stornierung kollidiert mit einer anderen Einnahme. Schließe die Bestätigung und beginne erneut.",
+        "generic": "Die Einnahme konnte nicht storniert werden. Versuche dieselbe Stornierung erneut oder brich ab."
+      },
+      "notice": {
+        "reversedTitle": "Einnahme storniert",
+        "reversedMessage": "Die gespeicherte Bestandswirkung wurde wiederhergestellt und das Original bleibt im Verlauf.",
+        "reconciliationTitle": "Einnahme storniert – Bestand prüfen",
+        "reconciliationMessage": "Die gespeicherte Bestandswirkung wurde wiederhergestellt, aber der aktuelle Bestand übersteigt nun die konfigurierte Packungskapazität.",
+        "correctionReadyTitle": "Ursprüngliche Einnahme storniert",
+        "correctionReadyMessage": "Erfasse die Korrektur jetzt als separate Einnahme oder kehre später zu diesem stornierten Ereignis zurück.",
+        "correctionReadyReconciliationTitle": "Original storniert – Bestand prüfen",
+        "correctionReadyReconciliationMessage": "Der Bestand übersteigt nun die konfigurierte Kapazität. Prüfe ihn und erfasse die Korrektur anschließend bei Bedarf separat.",
+        "revisionChangedTitle": "Verlauf aktualisiert",
+        "revisionChangedMessage": "Die Einnahme wurde geändert, bevor die Stornierung abgeschlossen war. Prüfe den aktualisierten Eintrag."
+      }
     }
   },
   "form": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -301,8 +301,44 @@
       "invalidQuantity": "Enter a valid quantity for this package type.",
       "rateLimited": "Too many new intakes were requested. Retry the same intake after {{seconds}} seconds.",
       "intentConflict": "This intake request conflicts with an earlier request. Close the dialog and start again.",
+      "replacementUnavailable": "This correction can no longer be linked to the selected intake. Refresh the history and try again.",
       "readOnly": "This account access is read-only and cannot record an intake.",
       "generic": "The intake could not be recorded. Retry the same intake or cancel."
+    },
+    "replacement": {
+      "action": "Record correction",
+      "correctAction": "Correct",
+      "title": "Record corrected intake",
+      "description": "This creates a separate intake linked to the reversed event from {{time}}.",
+      "confirm": "Record correction",
+      "successTitle": "Correction recorded",
+      "reverseTitle": "Correct intake",
+      "reverseMessage": "The original {{quantity}} {{unit}} intake must first be reversed. Its audit record remains even if you cancel or the replacement fails."
+    },
+    "reversal": {
+      "action": "Reverse",
+      "confirmTitle": "Reverse intake",
+      "confirmMessage": "Reverse the recorded {{quantity}} {{unit}} intake? This restores only its stored stock effect and keeps the audit record.",
+      "confirm": "Reverse intake",
+      "saving": "Reversing...",
+      "errors": {
+        "network": "The result is uncertain because the connection was interrupted. Retry safely uses the same reversal request.",
+        "revision": "This intake changed. The history has been refreshed; review it before trying again.",
+        "intentConflict": "This reversal request conflicts with another intake. Close the confirmation and start again.",
+        "generic": "The intake could not be reversed. Retry the same reversal or cancel."
+      },
+      "notice": {
+        "reversedTitle": "Intake reversed",
+        "reversedMessage": "The stored stock effect was restored and the original remains in history.",
+        "reconciliationTitle": "Intake reversed — check stock",
+        "reconciliationMessage": "The stored stock effect was restored, but current stock now exceeds the configured package capacity.",
+        "correctionReadyTitle": "Original intake reversed",
+        "correctionReadyMessage": "Record the correction as a separate intake now, or return to this reversed event later.",
+        "correctionReadyReconciliationTitle": "Original reversed — check stock",
+        "correctionReadyReconciliationMessage": "Stock now exceeds configured capacity. Review it, then record the correction separately if appropriate.",
+        "revisionChangedTitle": "History updated",
+        "revisionChangedMessage": "The intake changed before the reversal completed. Review the refreshed entry."
+      }
     }
   },
   "form": {

--- a/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
+++ b/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AsNeededIntakeHistory } from "../../components/AsNeededIntakeHistory";
+import { AsNeededIntakeRequestError } from "../../hooks/useAsNeededIntakes";
 import type { AsNeededIntakeEvent } from "../../types";
 
 const listAsNeededIntakes = vi.fn();
 
-vi.mock("../../hooks/useAsNeededIntakes", () => ({
+vi.mock("../../hooks/useAsNeededIntakes", async (importActual) => ({
+	...(await importActual<typeof import("../../hooks/useAsNeededIntakes")>()),
 	useAsNeededIntakes: () => ({ listAsNeededIntakes }),
 }));
 
@@ -48,6 +50,22 @@ function deferred<T>() {
 		resolve = resolvePromise;
 	});
 	return { promise, resolve };
+}
+
+function reversalResponse(source: AsNeededIntakeEvent): {
+	event: AsNeededIntakeEvent;
+	inventory: { reconciliationRequired: boolean };
+} {
+	return {
+		event: {
+			...source,
+			status: "reversed",
+			revision: source.revision + 1,
+			stockEffect: 0,
+			reversedAt: "2026-08-15T13:00:00.000Z",
+		},
+		inventory: { reconciliationRequired: false },
+	};
 }
 
 describe("AsNeededIntakeHistory", () => {
@@ -142,5 +160,75 @@ describe("AsNeededIntakeHistory", () => {
 		first.resolve({ events: [event({ person: "Stale" })], nextCursor: null });
 		await waitFor(() => expect(screen.queryByText("Stale")).not.toBeInTheDocument());
 		expect(listAsNeededIntakes.mock.calls[0][2].aborted).toBe(true);
+	});
+
+	it("reverses only active events, retries with the same key, and retains the reversed audit entry", async () => {
+		const active = event();
+		const reversed = event({
+			eventId: "event-old",
+			status: "reversed",
+			stockEffect: 0,
+			reversedAt: "2026-08-15T13:00:00.000Z",
+		});
+		const onReverse = vi
+			.fn()
+			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
+			.mockResolvedValueOnce(reversalResponse(active));
+		listAsNeededIntakes.mockResolvedValueOnce({ events: [active, reversed], nextCursor: null });
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} onReverse={onReverse} />);
+
+		await screen.findByText("asNeeded.reversal.action");
+		expect(screen.getAllByText("asNeeded.reversal.action")).toHaveLength(1);
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.action" }));
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.confirm" }));
+		await screen.findByText("asNeeded.reversal.errors.network");
+		fireEvent.click(screen.getByRole("button", { name: "common.retry" }));
+		await screen.findByText("asNeeded.reversal.notice.reversedTitle");
+		expect(onReverse).toHaveBeenCalledTimes(2);
+		expect(onReverse.mock.calls[0][0]).toEqual(onReverse.mock.calls[1][0]);
+		expect(onReverse.mock.calls[0][0]).toMatchObject({ eventId: "event-1", expectedRevision: 1 });
+		expect(screen.getAllByText("asNeeded.history.status.reversed")).toHaveLength(2);
+	});
+
+	it("closes the stale confirmation, refreshes, and never applies a 409 reversal locally", async () => {
+		const active = event();
+		const onReverse = vi.fn().mockRejectedValue(new AsNeededIntakeRequestError("EVENT_VERSION_CONFLICT", null, 2));
+		listAsNeededIntakes.mockResolvedValueOnce({ events: [active], nextCursor: null }).mockResolvedValueOnce({
+			events: [event({ eventId: "event-new", revision: 2, person: "Refreshed" })],
+			nextCursor: null,
+		});
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} onReverse={onReverse} />);
+
+		await screen.findByText("asNeeded.reversal.action");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.action" }));
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.confirm" }));
+		await screen.findByText("asNeeded.reversal.notice.revisionChangedTitle");
+		await screen.findByText("Refreshed");
+		expect(screen.queryByText("asNeeded.reversal.confirmTitle")).not.toBeInTheDocument();
+		expect(listAsNeededIntakes).toHaveBeenCalledTimes(2);
+	});
+
+	it("offers correction only after a successful reversal and passes the reversed event to Record now", async () => {
+		const active = event();
+		const onReverse = vi.fn().mockResolvedValue(reversalResponse(active));
+		const onReplace = vi.fn();
+		listAsNeededIntakes.mockResolvedValueOnce({ events: [active], nextCursor: null });
+		render(
+			<AsNeededIntakeHistory
+				medicationId={9}
+				canRecordNow
+				onRecordNow={vi.fn()}
+				onReverse={onReverse}
+				onReplace={onReplace}
+			/>
+		);
+
+		await screen.findByText("asNeeded.replacement.correctAction");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.correctAction" }));
+		expect(onReplace).not.toHaveBeenCalled();
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.confirm" }));
+		await screen.findByText("asNeeded.reversal.notice.correctionReadyTitle");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.action" }));
+		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ eventId: "event-1", status: "reversed" }));
 	});
 });

--- a/frontend/src/test/components/ConfirmModal.test.tsx
+++ b/frontend/src/test/components/ConfirmModal.test.tsx
@@ -106,4 +106,14 @@ describe("ConfirmModal", () => {
 		fireEvent.keyDown(document, { key: "Escape" });
 		expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
 	});
+
+	it("captures Escape for a nested confirmation before a parent modal can close", () => {
+		const parentEscape = vi.fn();
+		document.addEventListener("keydown", parentEscape);
+		render(<ConfirmModal {...defaultProps} captureEscape />);
+		fireEvent.keyDown(document, { key: "Escape" });
+		document.removeEventListener("keydown", parentEscape);
+		expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+		expect(parentEscape).not.toHaveBeenCalled();
+	});
 });

--- a/frontend/src/test/components/RecordNowModal.test.tsx
+++ b/frontend/src/test/components/RecordNowModal.test.tsx
@@ -137,4 +137,35 @@ describe("RecordNowModal", () => {
 		resolveRequest?.(response());
 		await screen.findByText("asNeeded.record.successTitle");
 	});
+
+	it("creates a replacement only with the durable reversed event and replays the exact request", async () => {
+		const replacementEvent = response().event;
+		const onRecord = vi
+			.fn()
+			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
+			.mockResolvedValueOnce({
+				...response(),
+				event: { ...response().event, replacementForEventId: replacementEvent.eventId },
+			});
+		render(
+			<RecordNowModal
+				medication={medication()}
+				replacementEvent={{ ...replacementEvent, status: "reversed", revision: 2, stockEffect: 0 }}
+				onClose={vi.fn()}
+				onRecord={onRecord}
+			/>
+		);
+
+		expect(screen.getByText("asNeeded.replacement.description")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.confirm" }));
+		await screen.findByText("asNeeded.errors.network");
+		fireEvent.click(screen.getByRole("button", { name: "common.retry" }));
+		await screen.findByText("asNeeded.replacement.successTitle");
+		expect(onRecord).toHaveBeenCalledTimes(2);
+		expect(onRecord.mock.calls[0][0]).toEqual(onRecord.mock.calls[1][0]);
+		expect(onRecord.mock.calls[0][0]).toMatchObject({
+			replacementForEventId: "event-8",
+			idempotencyKey: "modal-intent-key",
+		});
+	});
 });

--- a/frontend/src/test/hooks/useAsNeededIntakes.test.ts
+++ b/frontend/src/test/hooks/useAsNeededIntakes.test.ts
@@ -52,6 +52,47 @@ describe("useAsNeededIntakes", () => {
 		).rejects.toEqual(expect.objectContaining({ code: "TOO_MANY_NEW_INTAKES", retryAfterSeconds: 17 }));
 	});
 
+	it("posts a reversal with its stable intent key and exposes the current revision from a conflict", async () => {
+		authFetchMock.mockResolvedValue({
+			ok: false,
+			headers: new Headers(),
+			json: async () => ({ code: "EVENT_VERSION_CONFLICT", currentRevision: 3 }),
+		});
+		const { result } = renderHook(() => useAsNeededIntakes());
+
+		await expect(
+			result.current.reverseAsNeededIntake({ eventId: "event-42", expectedRevision: 2, idempotencyKey: "reverse-key" })
+		).rejects.toEqual(expect.objectContaining({ code: "EVENT_VERSION_CONFLICT", currentRevision: 3 }));
+		expect(authFetchMock).toHaveBeenCalledWith(
+			"/api/as-needed-intakes/event-42/reversal",
+			expect.objectContaining({
+				method: "POST",
+				headers: { "Content-Type": "application/json", "Idempotency-Key": "reverse-key" },
+				body: JSON.stringify({ expectedRevision: 2 }),
+			})
+		);
+	});
+
+	it("includes a replacement link only when the caller supplies one", async () => {
+		authFetchMock.mockResolvedValue({ ok: true, json: async () => ({ event: {}, inventory: {} }) });
+		const { result } = renderHook(() => useAsNeededIntakes());
+
+		await result.current.recordAsNeededIntake({
+			medicationId: 42,
+			quantity: 1,
+			person: null,
+			idempotencyKey: "replacement-key",
+			replacementForEventId: "reversed-event",
+		});
+
+		expect(authFetchMock).toHaveBeenCalledWith(
+			"/api/medications/42/as-needed-intakes",
+			expect.objectContaining({
+				body: JSON.stringify({ quantity: 1, person: null, replacementForEventId: "reversed-event" }),
+			})
+		);
+	});
+
 	it("maps a transport failure to the translated uncertain-result state", async () => {
 		authFetchMock.mockRejectedValue(new Error("connection dropped"));
 		const { result } = renderHook(() => useAsNeededIntakes());


### PR DESCRIPTION
Closes #1040

## Summary

- add accessible reversal confirmation with stable idempotency keys, current-revision guards, retries, conflict refresh, and exact stock/history updates
- add replacement correction via a fresh Record now key only after durable reversal, retaining the original tombstone on replacement failure
- ensure ordinary create requests omit `replacementForEventId` entirely while replacement requests include it

## Scope boundary

No journal editing is included; it remains in #1042.

## Validation

- focused frontend coverage: 34 tests; full frontend suite: 79 files, 1,158 tests
- authenticated desktop/mobile Playwright: 14 tests including modal behavior
- root/frontend lint, check, build, i18n parity (1,035), and diff check

Security review found no critical, major, or minor findings.