### PR TITLE
feat: add as-needed journal editing

### DIFF
--- a/frontend/src/components/AsNeededIntakeHistory.module.css
+++ b/frontend/src/components/AsNeededIntakeHistory.module.css
@@ -107,6 +107,13 @@
 	overflow-wrap: anywhere;
 }
 
+.journalHeading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+}
+
 .entryActions {
 	display: flex;
 	flex-wrap: wrap;

--- a/frontend/src/components/AsNeededIntakeHistory.tsx
+++ b/frontend/src/components/AsNeededIntakeHistory.tsx
@@ -3,6 +3,7 @@ import { normalizeIntakeMood } from "@medassist/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AsNeededIntakeRequestError, useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
+import { useIntakeJournal } from "../hooks/useIntakeJournal";
 import { useModalHistory } from "../hooks/useModalHistory";
 import type { AsNeededIntakeEvent, AsNeededIntakeMutationResponse } from "../types";
 import { AppButton } from "../ui/primitives/AppButton";
@@ -11,6 +12,7 @@ import { getNumericLocale, withFormattingTimezone } from "../utils/formatters";
 import { getIntakeMoodLabel } from "../utils/intake-mood";
 import classes from "./AsNeededIntakeHistory.module.css";
 import { ConfirmModal } from "./ConfirmModal";
+import { IntakeJournalModal } from "./intake-journal/IntakeJournalModal";
 
 type AsNeededIntakeHistoryProps = {
 	medicationId: number;
@@ -49,6 +51,12 @@ function getReversalErrorKey(code: string): string {
 	return "asNeeded.reversal.errors.generic";
 }
 
+function getJournalActionKey(event: AsNeededIntakeEvent): string {
+	if (event.status === "reversed") return "journal.actions.view";
+	if (event.journal) return "journal.actions.edit";
+	return "journal.actions.add";
+}
+
 export function AsNeededIntakeHistory({
 	medicationId,
 	canRecordNow,
@@ -68,9 +76,19 @@ export function AsNeededIntakeHistory({
 	const [reversalError, setReversalError] = useState<string | null>(null);
 	const [actionNotice, setActionNotice] = useState<{ tone: "green" | "yellow" | "red"; key: string } | null>(null);
 	const [replacementReady, setReplacementReady] = useState<AsNeededIntakeEvent | null>(null);
+	const [journalTargetStatus, setJournalTargetStatus] = useState<AsNeededIntakeEvent["status"] | null>(null);
 	const requestVersionRef = useRef(0);
 	const firstPageAbortRef = useRef<AbortController | null>(null);
 	const actionFeedbackRef = useRef<HTMLDivElement>(null);
+	const refreshHistoryRef = useRef<() => Promise<void>>(async () => undefined);
+	const handleJournalEventReversed = useCallback(() => {
+		setActionNotice({ tone: "yellow", key: "journalReconciled" });
+		void refreshHistoryRef.current();
+	}, []);
+	const intakeJournal = useIntakeJournal({
+		manageProgrammaticClose: true,
+		onEventReversed: handleJournalEventReversed,
+	});
 	const dismissReversal = useCallback(() => {
 		setReversalIntent(null);
 		setReversalError(null);
@@ -101,6 +119,7 @@ export function AsNeededIntakeHistory({
 			if (requestVersion === requestVersionRef.current) setLoading(false);
 		}
 	}, [listAsNeededIntakes, medicationId]);
+	refreshHistoryRef.current = loadFirstPage;
 
 	useEffect(() => {
 		void loadFirstPage();
@@ -182,6 +201,32 @@ export function AsNeededIntakeHistory({
 		}
 	};
 
+	const openJournal = (event: AsNeededIntakeEvent) => {
+		setJournalTargetStatus(event.status);
+		void intakeJournal.openJournalEditor(event.journal?.doseId ?? `as-needed:${event.eventId}`);
+	};
+
+	const closeJournal = () => {
+		setJournalTargetStatus(null);
+		intakeJournal.closeJournalEditor();
+	};
+
+	const saveJournal = async (
+		note: string,
+		mood: Parameters<typeof intakeJournal.saveJournalNote>[1]
+	): Promise<boolean> => {
+		const saved = await intakeJournal.saveJournalNote(note, mood);
+		if (saved) await loadFirstPage();
+		return saved;
+	};
+
+	const deleteJournal = async () => {
+		const deleted = await intakeJournal.deleteJournalNote();
+		if (!deleted) return;
+		await loadFirstPage();
+		closeJournal();
+	};
+
 	if (!canRecordNow && !loading && !error && events.length === 0) return null;
 	const lifecycle = events[0]?.medication.lifecycle ?? (canRecordNow ? "active_no_schedule" : null);
 	let reversalConfirmLabel = t("asNeeded.reversal.confirm");
@@ -244,6 +289,7 @@ export function AsNeededIntakeHistory({
 			<div className={classes.list}>
 				{events.map((event) => {
 					const mood = normalizeIntakeMood(event.journal?.mood);
+					const canOpenJournal = event.status === "active" || event.journal !== null;
 					return (
 						<article className={classes.entry} key={event.eventId}>
 							<div className={classes.entryHeading}>
@@ -278,7 +324,14 @@ export function AsNeededIntakeHistory({
 								<p>{t("asNeeded.history.replacementFor", { eventId: event.replacementForEventId })}</p>
 							) : null}
 							<div className={classes.journal}>
-								<strong>{t("asNeeded.history.journal")}</strong>
+								<div className={classes.journalHeading}>
+									<strong>{t("asNeeded.history.journal")}</strong>
+									{canOpenJournal ? (
+										<AppButton type="button" tone="ghost" size="xs" onClick={() => openJournal(event)}>
+											{t(getJournalActionKey(event))}
+										</AppButton>
+									) : null}
+								</div>
 								{event.journal ? (
 									<p>
 										{[mood ? getIntakeMoodLabel(mood, t) : null, event.journal.note].filter(Boolean).join(" · ") ||
@@ -359,6 +412,21 @@ export function AsNeededIntakeHistory({
 					captureEscape
 				/>
 			) : null}
+			<IntakeJournalModal
+				isOpen={intakeJournal.journalEditorOpen}
+				entry={intakeJournal.journalEvent}
+				isLoading={intakeJournal.journalEventLoading}
+				isSaving={intakeJournal.journalEventSaving}
+				isDeleting={intakeJournal.journalEventDeleting}
+				error={intakeJournal.journalEventError}
+				onClose={closeJournal}
+				onSave={saveJournal}
+				onDelete={deleteJournal}
+				readOnly={
+					journalTargetStatus === "reversed" ||
+					(intakeJournal.journalEvent?.eventType === "as_needed" && intakeJournal.journalEvent.status === "reversed")
+				}
+			/>
 		</section>
 	);
 }

--- a/frontend/src/components/intake-journal/IntakeJournalModal.module.css
+++ b/frontend/src/components/intake-journal/IntakeJournalModal.module.css
@@ -49,6 +49,16 @@
 	background: var(--bg-primary);
 }
 
+.readOnlyNotice {
+	margin-bottom: 1rem;
+	padding: 0.75rem 0.9rem;
+	border: 1px solid var(--border-primary);
+	border-radius: 10px;
+	background: var(--bg-secondary);
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+}
+
 .eventMedication {
 	display: flex;
 	align-items: center;
@@ -163,6 +173,12 @@
 	background: color-mix(in srgb, var(--accent-bg) 75%, var(--bg-primary));
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
 	color: var(--accent);
+}
+
+.moodField:disabled .moodOption {
+	cursor: default;
+	opacity: 0.75;
+	transform: none;
 }
 
 .noteInput {

--- a/frontend/src/components/intake-journal/IntakeJournalModal.tsx
+++ b/frontend/src/components/intake-journal/IntakeJournalModal.tsx
@@ -22,6 +22,7 @@ interface IntakeJournalModalProps {
 	onSave: (note: string, mood: IntakeMood | null) => Promise<boolean> | boolean;
 	onDelete: () => Promise<void> | void;
 	allowDelete?: boolean;
+	readOnly?: boolean;
 }
 
 export function IntakeJournalModal({
@@ -35,6 +36,7 @@ export function IntakeJournalModal({
 	onSave,
 	onDelete,
 	allowDelete = true,
+	readOnly = false,
 }: IntakeJournalModalProps) {
 	const { t } = useTranslation();
 	const [note, setNote] = useState("");
@@ -42,6 +44,7 @@ export function IntakeJournalModal({
 	const [showSavedState, setShowSavedState] = useState(false);
 	const activeDoseTrackingIdRef = useRef<number | null>(null);
 	const wasSavingRef = useRef(false);
+	const errorRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		if (!isOpen) {
@@ -85,6 +88,10 @@ export function IntakeJournalModal({
 		}
 	}, [entry, error, isOpen, isSaving, mood, note]);
 
+	useEffect(() => {
+		if (error) errorRef.current?.focus();
+	}, [error]);
+
 	if (!isOpen) {
 		return null;
 	}
@@ -97,14 +104,21 @@ export function IntakeJournalModal({
 	};
 
 	const scheduledForLabel = formatJournalDisplayDateTime(entry?.scheduledFor ?? null);
+	const occurredAtLabel = formatJournalDisplayDateTime(entry?.occurredAt ?? null);
 	const takenAtLabel = formatJournalDisplayDateTime(entry?.takenAt ?? null);
-	const title = entry?.note || entry?.mood ? t("journal.editor.editTitle") : t("journal.editor.addTitle");
+	let title = t("journal.editor.addTitle");
+	if (entry?.note || entry?.mood) title = t("journal.editor.editTitle");
+	if (readOnly) title = t("journal.editor.readOnlyTitle");
 	const saveLabel = showSavedState ? t("common.saved") : t("common.save");
 	let bodyContent: React.ReactNode;
 
 	if (isLoading) {
 		bodyContent = <div className={classes.state}>{t("journal.editor.loading")}</div>;
 	} else if (entry) {
+		const isAsNeeded = entry.eventType === "as_needed";
+		const statusLabel = isAsNeeded
+			? t(`asNeeded.history.status.${entry.status}`)
+			: t(entry.dismissed ? "journal.context.statusSkipped" : "journal.context.statusTaken");
 		bodyContent = (
 			<>
 				<div className={classes.eventCard}>
@@ -112,18 +126,27 @@ export function IntakeJournalModal({
 						<MedicationAvatar name={entry.medicationName} size="sm" />
 						<div>
 							<strong>{entry.medicationName}</strong>
-							<p>{entry.dismissed ? t("journal.context.statusSkipped") : t("journal.context.statusTaken")}</p>
+							<p>{statusLabel}</p>
 						</div>
 					</div>
 					<div className={classes.eventGrid}>
-						<div>
-							<span>{t("journal.context.scheduledFor")}</span>
-							<strong>{scheduledForLabel ?? t("common.notAvailable")}</strong>
-						</div>
-						<div>
-							<span>{t("journal.context.takenAt")}</span>
-							<strong>{takenAtLabel ?? t("journal.context.notRecorded")}</strong>
-						</div>
+						{isAsNeeded ? (
+							<div>
+								<span>{t("journal.context.occurredAt")}</span>
+								<strong>{occurredAtLabel ?? t("common.notAvailable")}</strong>
+							</div>
+						) : (
+							<>
+								<div>
+									<span>{t("journal.context.scheduledFor")}</span>
+									<strong>{scheduledForLabel ?? t("common.notAvailable")}</strong>
+								</div>
+								<div>
+									<span>{t("journal.context.takenAt")}</span>
+									<strong>{takenAtLabel ?? t("journal.context.notRecorded")}</strong>
+								</div>
+							</>
+						)}
 						<div>
 							<span>{t("journal.context.markedBy")}</span>
 							<strong>{entry.markedBy ?? t("journal.context.self")}</strong>
@@ -134,8 +157,9 @@ export function IntakeJournalModal({
 						</div>
 					</div>
 				</div>
+				{readOnly ? <div className={classes.readOnlyNotice}>{t("journal.editor.readOnlyDescription")}</div> : null}
 
-				<fieldset className={classes.moodField}>
+				<fieldset className={classes.moodField} disabled={readOnly}>
 					<legend className={classes.fieldLabel}>{t("journal.mood.label")}</legend>
 					{mood ? (
 						<div className={classes.moodHeader}>
@@ -190,10 +214,15 @@ export function IntakeJournalModal({
 						setShowSavedState(false);
 					}}
 					placeholder={t("journal.editor.notePlaceholder")}
+					readOnly={readOnly}
 					value={note}
 				/>
 
-				{error && <div className={classes.inlineError}>{error}</div>}
+				{error && (
+					<div ref={errorRef} className={classes.inlineError} role="alert" tabIndex={-1}>
+						{error}
+					</div>
+				)}
 			</>
 		);
 	} else {
@@ -208,13 +237,15 @@ export function IntakeJournalModal({
 			}}
 			closeButtonProps={{ "aria-label": t("common.close") }}
 			contentClassName={`${classes.modal} journal-modal`}
-			onClose={onClose}
+			onClose={() => {
+				if (!isSaving && !isDeleting) onClose();
+			}}
 			opened={isOpen}
 			size={720}
 			title={
 				<div className={classes.titleBlock}>
 					<h2>{title}</h2>
-					<p>{t("journal.editor.description")}</p>
+					<p>{t(readOnly ? "journal.editor.readOnlyIntro" : "journal.editor.description")}</p>
 				</div>
 			}
 			withCloseButton
@@ -223,7 +254,7 @@ export function IntakeJournalModal({
 
 			<AppModalFooter
 				left={
-					allowDelete ? (
+					allowDelete && !readOnly ? (
 						<AppButton
 							type="button"
 							tone="ghost"
@@ -236,16 +267,18 @@ export function IntakeJournalModal({
 				}
 			>
 				<AppButton type="button" tone="secondary" onClick={onClose} disabled={isSaving || isDeleting}>
-					{t("common.cancel")}
+					{t(readOnly ? "common.close" : "common.cancel")}
 				</AppButton>
-				<AppButton
-					type="button"
-					tone="primary"
-					onClick={() => void handleSave()}
-					disabled={isLoading || isSaving || isDeleting || !entry}
-				>
-					{saveLabel}
-				</AppButton>
+				{readOnly ? null : (
+					<AppButton
+						type="button"
+						tone="primary"
+						onClick={() => void handleSave()}
+						disabled={isLoading || isSaving || isDeleting || !entry}
+					>
+						{saveLabel}
+					</AppButton>
+				)}
 			</AppModalFooter>
 		</AppModal>
 	);

--- a/frontend/src/hooks/useIntakeJournal.ts
+++ b/frontend/src/hooks/useIntakeJournal.ts
@@ -1,18 +1,22 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../components/Auth";
 import type { IntakeMood } from "../utils/intake-mood";
 import { useModalHistory } from "./useModalHistory";
 
 export type IntakeJournalEntry = {
+	eventType?: "scheduled" | "as_needed";
+	eventId?: string | null;
 	doseTrackingId: number;
 	doseId: string;
 	medicationId: number;
 	medicationName: string;
-	scheduledFor: string;
+	scheduledFor: string | null;
+	occurredAt?: string | null;
+	status?: "taken" | "skipped" | "active" | "reversed";
 	takenAt: string | null;
 	dismissed: boolean;
-	takenSource: "manual" | "automatic" | "notification";
+	takenSource: "manual" | "automatic" | "notification" | "owner_as_needed";
 	markedBy: string | null;
 	mood: IntakeMood | null;
 	note: string | null;
@@ -52,6 +56,11 @@ export interface UseIntakeJournalReturn {
 	reopenJournalHistoryEntry: (doseId: string) => Promise<void>;
 }
 
+type UseIntakeJournalOptions = {
+	manageProgrammaticClose?: boolean;
+	onEventReversed?: () => void;
+};
+
 const DEFAULT_HISTORY_FILTERS: IntakeJournalHistoryFilters = {
 	medicationId: null,
 	from: "",
@@ -59,20 +68,28 @@ const DEFAULT_HISTORY_FILTERS: IntakeJournalHistoryFilters = {
 	limit: 100,
 };
 
-async function readErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
+async function readErrorCode(response: Response): Promise<string | null> {
 	try {
-		const data = (await response.json()) as { error?: string; code?: string };
-		if (typeof data.error === "string" && data.error.trim().length > 0) {
-			return data.error;
-		}
+		const data = (await response.json()) as { code?: string };
 		if (typeof data.code === "string" && data.code.trim().length > 0) {
 			return data.code;
 		}
 	} catch {
-		// Fall back to the supplied message when the response body is not JSON.
+		// The caller maps missing or malformed error bodies to a translated fallback.
 	}
 
-	return fallbackMessage;
+	return null;
+}
+
+function getJournalErrorMessage(
+	code: string | null,
+	fallbackKey: "loadFailed" | "historyFailed" | "saveFailed" | "deleteFailed",
+	t: (key: string) => string
+): string {
+	if (code === "EVENT_REVERSED") return t("journal.errors.eventReversed");
+	if (code === "API_KEY_SCOPE_FORBIDDEN" || code === "READ_ONLY") return t("journal.errors.readOnly");
+	if (code === "DOSE_NOT_FOUND") return t("journal.errors.notFound");
+	return t(`journal.errors.${fallbackKey}`);
 }
 
 function buildHistoryQuery(filters: IntakeJournalHistoryFilters): string {
@@ -92,7 +109,7 @@ function buildHistoryQuery(filters: IntakeJournalHistoryFilters): string {
 	return query.length > 0 ? `?${query}` : "";
 }
 
-export function useIntakeJournal(): UseIntakeJournalReturn {
+export function useIntakeJournal(options: UseIntakeJournalOptions = {}): UseIntakeJournalReturn {
 	const { authFetch } = useAuth();
 	const { t } = useTranslation();
 	const [journalEditorOpen, setJournalEditorOpen] = useState(false);
@@ -108,8 +125,16 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 		useState<IntakeJournalHistoryFilters>(DEFAULT_HISTORY_FILTERS);
 	const [journalHistoryLoading, setJournalHistoryLoading] = useState(false);
 	const [journalHistoryError, setJournalHistoryError] = useState<string | null>(null);
+	const editorRequestVersionRef = useRef(0);
+	const editorAbortRef = useRef<AbortController | null>(null);
+
+	useEffect(() => {
+		return () => editorAbortRef.current?.abort();
+	}, []);
 
 	const resetJournalState = useCallback(() => {
+		editorAbortRef.current?.abort();
+		editorRequestVersionRef.current += 1;
 		setJournalEditorOpen(false);
 		setJournalHistoryOpen(false);
 		setJournalTargetDoseId(null);
@@ -126,26 +151,35 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 
 	const loadJournalEvent = useCallback(
 		async (doseId: string) => {
+			editorAbortRef.current?.abort();
+			const controller = new AbortController();
+			editorAbortRef.current = controller;
+			const requestVersion = ++editorRequestVersionRef.current;
 			setJournalEventLoading(true);
 			setJournalEventError(null);
 
 			try {
-				const response = await authFetch(`/api/intake-journal/event/${encodeURIComponent(doseId)}`);
+				const response = await authFetch(`/api/intake-journal/event/${encodeURIComponent(doseId)}`, {
+					signal: controller.signal,
+				});
 
 				if (!response.ok) {
-					const message = await readErrorMessage(response, t("journal.errors.loadFailed"));
+					const code = await readErrorCode(response);
+					if (requestVersion !== editorRequestVersionRef.current) return;
 					setJournalEvent(null);
-					setJournalEventError(message);
+					setJournalEventError(getJournalErrorMessage(code, "loadFailed", t));
 					return;
 				}
 
 				const data = (await response.json()) as { entry: IntakeJournalEntry };
+				if (requestVersion !== editorRequestVersionRef.current) return;
 				setJournalEvent(data.entry);
 			} catch {
+				if (requestVersion !== editorRequestVersionRef.current) return;
 				setJournalEvent(null);
 				setJournalEventError(t("journal.errors.loadFailed"));
 			} finally {
-				setJournalEventLoading(false);
+				if (requestVersion === editorRequestVersionRef.current) setJournalEventLoading(false);
 			}
 		},
 		[authFetch, t]
@@ -160,9 +194,9 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 				const response = await authFetch(`/api/intake-journal${buildHistoryQuery(filters)}`);
 
 				if (!response.ok) {
-					const message = await readErrorMessage(response, t("journal.errors.historyFailed"));
+					const code = await readErrorCode(response);
 					setJournalHistoryEntries([]);
-					setJournalHistoryError(message);
+					setJournalHistoryError(getJournalErrorMessage(code, "historyFailed", t));
 					return;
 				}
 
@@ -197,7 +231,9 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 		[loadJournalEvent]
 	);
 
-	const closeJournalEditor = useCallback(() => {
+	const dismissJournalEditor = useCallback(() => {
+		editorAbortRef.current?.abort();
+		editorRequestVersionRef.current += 1;
 		setJournalEditorOpen(false);
 		setJournalTargetDoseId(null);
 		setJournalEvent(null);
@@ -206,6 +242,12 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 		setJournalEventSaving(false);
 		setJournalEventDeleting(false);
 	}, []);
+	const { closeModal: closeJournalEditorWithHistory } = useModalHistory(
+		journalEditorOpen,
+		"intake-journal-editor",
+		dismissJournalEditor
+	);
+	const closeJournalEditor = options.manageProgrammaticClose ? closeJournalEditorWithHistory : dismissJournalEditor;
 
 	const saveJournalNote = useCallback(
 		async (note: string, mood: IntakeMood | null = null) => {
@@ -225,8 +267,13 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 				});
 
 				if (!response.ok) {
-					const message = await readErrorMessage(response, t("journal.errors.saveFailed"));
-					setJournalEventError(message);
+					const code = await readErrorCode(response);
+					setJournalEventError(getJournalErrorMessage(code, "saveFailed", t));
+					if (code === "EVENT_REVERSED") {
+						await loadJournalEvent(journalTargetDoseId);
+						setJournalEventError(t("journal.errors.eventReversed"));
+						options.onEventReversed?.();
+					}
 					return false;
 				}
 
@@ -243,7 +290,16 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 				setJournalEventSaving(false);
 			}
 		},
-		[authFetch, journalHistoryFilters, journalHistoryOpen, journalTargetDoseId, loadJournalHistory, t]
+		[
+			authFetch,
+			journalHistoryFilters,
+			journalHistoryOpen,
+			journalTargetDoseId,
+			loadJournalEvent,
+			loadJournalHistory,
+			options.onEventReversed,
+			t,
+		]
 	);
 
 	const deleteJournalNote = useCallback(async () => {
@@ -261,8 +317,13 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 			});
 
 			if (!response.ok) {
-				const message = await readErrorMessage(response, t("journal.errors.deleteFailed"));
-				setJournalEventError(message);
+				const code = await readErrorCode(response);
+				setJournalEventError(getJournalErrorMessage(code, "deleteFailed", t));
+				if (code === "EVENT_REVERSED") {
+					await loadJournalEvent(journalTargetDoseId);
+					setJournalEventError(t("journal.errors.eventReversed"));
+					options.onEventReversed?.();
+				}
 				return false;
 			}
 
@@ -279,7 +340,16 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 		} finally {
 			setJournalEventDeleting(false);
 		}
-	}, [authFetch, journalHistoryFilters, journalHistoryOpen, journalTargetDoseId, loadJournalHistory, t]);
+	}, [
+		authFetch,
+		journalHistoryFilters,
+		journalHistoryOpen,
+		journalTargetDoseId,
+		loadJournalEvent,
+		loadJournalHistory,
+		options.onEventReversed,
+		t,
+	]);
 
 	const openJournalHistory = useCallback(() => {
 		setJournalEditorOpen(false);
@@ -287,13 +357,12 @@ export function useIntakeJournal(): UseIntakeJournalReturn {
 		setJournalHistoryError(null);
 	}, []);
 
-	const closeJournalHistory = useCallback(() => {
+	const dismissJournalHistory = useCallback(() => {
 		setJournalHistoryOpen(false);
 		setJournalHistoryError(null);
 	}, []);
-
-	useModalHistory(journalEditorOpen, "intake-journal-editor", closeJournalEditor);
-	useModalHistory(journalHistoryOpen, "intake-journal-history", closeJournalHistory);
+	useModalHistory(journalHistoryOpen, "intake-journal-history", dismissJournalHistory);
+	const closeJournalHistory = dismissJournalHistory;
 
 	const updateJournalHistoryFilters = useCallback((patch: Partial<IntakeJournalHistoryFilters>) => {
 		setJournalHistoryFiltersState((previous) => ({

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -106,15 +106,21 @@
   },
   "journal": {
     "actions": {
+      "add": "Journal hinzufügen",
+      "edit": "Journal bearbeiten",
       "note": "Notiz",
       "noteTakenOnly": "Notizen funktionieren nur für genommene oder uebersprungene Dosen.",
       "history": "Journal-Verlauf",
-      "historyShort": "Journal"
+      "historyShort": "Journal",
+      "view": "Journal ansehen"
     },
     "editor": {
       "addTitle": "Journal-Notiz hinzufügen",
       "editTitle": "Journal-Notiz bearbeiten",
       "description": "Halte fest, was bei dieser Einnahme passiert ist, ohne den bestehenden Einnahme- oder Auslassen-Status zu ändern.",
+      "readOnlyTitle": "Journal-Details",
+      "readOnlyIntro": "Prüfe das mit dieser Einnahme gespeicherte Journal.",
+      "readOnlyDescription": "Diese Einnahme wurde storniert. Ihr Journal bleibt für den Prüfverlauf sichtbar, kann aber nicht mehr geändert werden.",
       "loading": "Journal-Eintrag wird geladen...",
       "noteLabel": "Notiz",
       "notePlaceholder": "Möchtest du mehr dazu notieren?",
@@ -153,6 +159,7 @@
       }
     },
     "context": {
+      "occurredAt": "Erfasst um",
       "scheduledFor": "Geplant für",
       "takenAt": "Eingenommen um",
       "markedBy": "Markiert von",
@@ -170,6 +177,9 @@
       "historyFailed": "Der Journal-Verlauf konnte nicht geladen werden.",
       "saveFailed": "Die Journal-Notiz konnte nicht gespeichert werden.",
       "deleteFailed": "Die Journal-Notiz konnte nicht gelöscht werden.",
+      "eventReversed": "Diese Einnahme wurde storniert, während das Journal geöffnet war. Der aktuelle schreibgeschützte Eintrag wird angezeigt.",
+      "readOnly": "Dieser Kontozugriff ist schreibgeschützt und kann Journal-Einträge nicht ändern.",
+      "notFound": "Diese Einnahme ist nicht mehr verfügbar. Aktualisiere den Verlauf und versuche es erneut.",
       "emptySharedNote": "Geteilte Links koennen Journal-Notizen nicht leeren. Gib eine Notiz ein oder schliesse den Dialog.",
       "noEventSelected": "Es ist kein Journal-Eintrag ausgewählt."
     }
@@ -337,7 +347,9 @@
         "correctionReadyReconciliationTitle": "Original storniert – Bestand prüfen",
         "correctionReadyReconciliationMessage": "Der Bestand übersteigt nun die konfigurierte Kapazität. Prüfe ihn und erfasse die Korrektur anschließend bei Bedarf separat.",
         "revisionChangedTitle": "Verlauf aktualisiert",
-        "revisionChangedMessage": "Die Einnahme wurde geändert, bevor die Stornierung abgeschlossen war. Prüfe den aktualisierten Eintrag."
+        "revisionChangedMessage": "Die Einnahme wurde geändert, bevor die Stornierung abgeschlossen war. Prüfe den aktualisierten Eintrag.",
+        "journalReconciledTitle": "Journal aktualisiert",
+        "journalReconciledMessage": "Die Einnahme wurde storniert, während ihr Journal geöffnet war. Der aktuelle schreibgeschützte Eintrag wird jetzt angezeigt."
       }
     }
   },

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -106,15 +106,21 @@
   },
   "journal": {
     "actions": {
+      "add": "Add journal",
+      "edit": "Edit journal",
       "note": "Note",
       "noteTakenOnly": "Notes are only available for taken or skipped doses.",
       "history": "Journal history",
-      "historyShort": "Journal"
+      "historyShort": "Journal",
+      "view": "View journal"
     },
     "editor": {
       "addTitle": "Add journal note",
       "editTitle": "Edit journal note",
       "description": "Capture what happened for this intake without changing the existing take or skip status.",
+      "readOnlyTitle": "Journal details",
+      "readOnlyIntro": "Review the journal saved with this intake.",
+      "readOnlyDescription": "This intake was reversed. Its journal remains visible for the audit history but can no longer be changed.",
       "loading": "Loading journal entry...",
       "noteLabel": "Note",
       "notePlaceholder": "Want to add a note?",
@@ -153,6 +159,7 @@
       }
     },
     "context": {
+      "occurredAt": "Recorded at",
       "scheduledFor": "Scheduled for",
       "takenAt": "Taken at",
       "markedBy": "Marked by",
@@ -170,6 +177,9 @@
       "historyFailed": "Journal history could not be loaded.",
       "saveFailed": "Journal note could not be saved.",
       "deleteFailed": "Journal note could not be deleted.",
+      "eventReversed": "This intake was reversed while the journal was open. The latest read-only entry is shown.",
+      "readOnly": "This account access is read-only and cannot change journal entries.",
+      "notFound": "This intake is no longer available. Refresh the history and try again.",
       "emptySharedNote": "Shared links cannot clear journal notes. Enter a note or close the dialog.",
       "noEventSelected": "No journal entry is selected."
     }
@@ -337,7 +347,9 @@
         "correctionReadyReconciliationTitle": "Original reversed — check stock",
         "correctionReadyReconciliationMessage": "Stock now exceeds configured capacity. Review it, then record the correction separately if appropriate.",
         "revisionChangedTitle": "History updated",
-        "revisionChangedMessage": "The intake changed before the reversal completed. Review the refreshed entry."
+        "revisionChangedMessage": "The intake changed before the reversal completed. Review the refreshed entry.",
+        "journalReconciledTitle": "Journal refreshed",
+        "journalReconciledMessage": "The intake was reversed while its journal was open. The latest read-only entry is now shown."
       }
     }
   },

--- a/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
+++ b/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
@@ -5,10 +5,28 @@ import { AsNeededIntakeRequestError } from "../../hooks/useAsNeededIntakes";
 import type { AsNeededIntakeEvent } from "../../types";
 
 const listAsNeededIntakes = vi.fn();
+const openJournalEditor = vi.fn();
+
+const intakeJournal = {
+	journalEditorOpen: false,
+	journalEvent: null,
+	journalEventLoading: false,
+	journalEventSaving: false,
+	journalEventDeleting: false,
+	journalEventError: null,
+	openJournalEditor,
+	closeJournalEditor: vi.fn(),
+	saveJournalNote: vi.fn(),
+	deleteJournalNote: vi.fn(),
+};
 
 vi.mock("../../hooks/useAsNeededIntakes", async (importActual) => ({
 	...(await importActual<typeof import("../../hooks/useAsNeededIntakes")>()),
 	useAsNeededIntakes: () => ({ listAsNeededIntakes }),
+}));
+
+vi.mock("../../hooks/useIntakeJournal", () => ({
+	useIntakeJournal: () => intakeJournal,
 }));
 
 function event(overrides: Partial<AsNeededIntakeEvent> = {}): AsNeededIntakeEvent {
@@ -230,5 +248,19 @@ describe("AsNeededIntakeHistory", () => {
 		await screen.findByText("asNeeded.reversal.notice.correctionReadyTitle");
 		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.action" }));
 		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ eventId: "event-1", status: "reversed" }));
+	});
+
+	it("opens the active journal with its opaque as-needed anchor and keeps reversed entries view-only", async () => {
+		listAsNeededIntakes.mockResolvedValueOnce({
+			events: [event(), event({ eventId: "event-old", status: "reversed", journal: null })],
+			nextCursor: null,
+		});
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
+
+		await screen.findByText("asNeeded.history.title");
+		const addButtons = screen.getAllByRole("button", { name: "journal.actions.add" });
+		expect(addButtons).toHaveLength(1);
+		fireEvent.click(addButtons[0]);
+		expect(openJournalEditor).toHaveBeenCalledWith("as-needed:event-1");
 	});
 });

--- a/frontend/src/test/components/IntakeJournalModal.test.tsx
+++ b/frontend/src/test/components/IntakeJournalModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IntakeJournalHistoryModal } from "../../components/intake-journal/IntakeJournalHistoryModal";
 import { IntakeJournalModal } from "../../components/intake-journal/IntakeJournalModal";
@@ -236,5 +236,44 @@ describe("IntakeJournalModal", () => {
 			expect(onSave).toHaveBeenCalledWith("Shared note", null);
 		});
 		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it("shows reversed as-needed entries as audit-only details without mutation actions", () => {
+		const entry = buildEntry({
+			eventType: "as_needed",
+			eventId: "event-1",
+			doseId: "as-needed:event-1",
+			scheduledFor: null,
+			occurredAt: "2026-08-15T08:00:00.000Z",
+			status: "reversed",
+			takenAt: null,
+			takenSource: "owner_as_needed",
+			note: "Retained audit note",
+		});
+		render(
+			<IntakeJournalModal
+				isOpen
+				entry={entry}
+				isLoading={false}
+				isSaving={false}
+				isDeleting={false}
+				error="journal.errors.eventReversed"
+				onClose={vi.fn()}
+				onSave={vi.fn()}
+				onDelete={vi.fn()}
+				readOnly
+			/>
+		);
+
+		expect(screen.getByText("journal.editor.readOnlyTitle")).toBeInTheDocument();
+		expect(screen.getByText("journal.context.occurredAt")).toBeInTheDocument();
+		expect(screen.queryByText("journal.context.scheduledFor")).not.toBeInTheDocument();
+		expect(screen.getByLabelText("journal.editor.noteLabel")).toHaveAttribute("readonly");
+		expect(
+			within(screen.getByTestId("app-modal-footer")).getByRole("button", { name: "common.close" })
+		).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "common.save" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "common.delete" })).not.toBeInTheDocument();
+		expect(document.activeElement).toHaveTextContent("journal.errors.eventReversed");
 	});
 });

--- a/frontend/src/test/hooks/useIntakeJournal.test.ts
+++ b/frontend/src/test/hooks/useIntakeJournal.test.ts
@@ -29,6 +29,14 @@ function buildEntry(overrides: Partial<IntakeJournalEntry> = {}): IntakeJournalE
 	};
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
 describe("useIntakeJournal", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -68,7 +76,8 @@ describe("useIntakeJournal", () => {
 
 		expect(authFetchMock).toHaveBeenNthCalledWith(
 			1,
-			`/api/intake-journal/event/${encodeURIComponent(initialEntry.doseId)}`
+			`/api/intake-journal/event/${encodeURIComponent(initialEntry.doseId)}`,
+			expect.objectContaining({ signal: expect.any(AbortSignal) })
 		);
 		expect(result.current.journalEditorOpen).toBe(true);
 		expect(result.current.journalTargetDoseId).toBe(initialEntry.doseId);
@@ -161,7 +170,8 @@ describe("useIntakeJournal", () => {
 
 		expect(authFetchMock).toHaveBeenNthCalledWith(
 			2,
-			`/api/intake-journal/event/${encodeURIComponent(historyEntry.doseId)}`
+			`/api/intake-journal/event/${encodeURIComponent(historyEntry.doseId)}`,
+			expect.objectContaining({ signal: expect.any(AbortSignal) })
 		);
 		expect(result.current.journalHistoryOpen).toBe(false);
 		expect(result.current.journalEditorOpen).toBe(true);
@@ -169,11 +179,11 @@ describe("useIntakeJournal", () => {
 		expect(result.current.journalEvent).toEqual(historyEntry);
 	});
 
-	it("surfaces owner access errors instead of swallowing them", async () => {
+	it("maps owner access errors to safe translated messages", async () => {
 		const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
 		fetchMock.mockResolvedValueOnce({
 			ok: false,
-			json: () => Promise.resolve({ error: "Tracked dose event not found for the current owner" }),
+			json: () => Promise.resolve({ code: "API_KEY_SCOPE_FORBIDDEN" }),
 		});
 
 		const { result } = renderHook(() => useIntakeJournal());
@@ -183,6 +193,95 @@ describe("useIntakeJournal", () => {
 		});
 
 		expect(result.current.journalEvent).toBeNull();
-		expect(result.current.journalEventError).toBe("Tracked dose event not found for the current owner");
+		expect(result.current.journalEventError).toBe("journal.errors.readOnly");
+	});
+
+	it("uses the as-needed anchor and keeps nullable note and mood fields end-to-end", async () => {
+		const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+		const asNeeded = buildEntry({
+			eventType: "as_needed",
+			eventId: "event-1",
+			doseId: "as-needed:event-1",
+			scheduledFor: null,
+			occurredAt: "2026-08-15T08:00:00.000Z",
+			status: "active",
+			takenAt: null,
+			takenSource: "owner_as_needed",
+			mood: null,
+			note: null,
+		});
+		fetchMock
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ entry: asNeeded }) })
+			.mockResolvedValueOnce({
+				ok: true,
+				json: () => Promise.resolve({ entry: { ...asNeeded, note: "Relief", mood: "good" } }),
+			})
+			.mockResolvedValueOnce({ ok: true });
+		const { result } = renderHook(() => useIntakeJournal());
+
+		await act(async () => {
+			await result.current.openJournalEditor(asNeeded.doseId);
+		});
+		await act(async () => {
+			await result.current.saveJournalNote("Relief", "good");
+		});
+		await act(async () => {
+			await result.current.deleteJournalNote();
+		});
+
+		expect(authFetchMock).toHaveBeenNthCalledWith(
+			1,
+			"/api/intake-journal/event/as-needed%3Aevent-1",
+			expect.objectContaining({ signal: expect.any(AbortSignal) })
+		);
+		expect(authFetchMock).toHaveBeenNthCalledWith(
+			2,
+			"/api/intake-journal/event/as-needed%3Aevent-1",
+			expect.objectContaining({ body: JSON.stringify({ note: "Relief", mood: "good" }) })
+		);
+		expect(authFetchMock).toHaveBeenNthCalledWith(
+			3,
+			"/api/intake-journal/event/as-needed%3Aevent-1",
+			expect.objectContaining({ method: "DELETE" })
+		);
+		expect(result.current.journalEvent).toEqual(expect.objectContaining({ note: null, mood: null }));
+	});
+
+	it("aborts and ignores stale event reads, then reconciles an EVENT_REVERSED save to the newest read-only event", async () => {
+		const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+		const first = deferred<{ ok: boolean; json: () => Promise<{ entry: IntakeJournalEntry }> }>();
+		const oldEntry = buildEntry({ doseId: "as-needed:old", eventType: "as_needed", status: "active" });
+		const newEntry = buildEntry({ doseId: "as-needed:new", eventType: "as_needed", status: "active" });
+		const reversedEntry = { ...newEntry, status: "reversed" as const, note: "Locked", mood: "neutral" as const };
+		fetchMock
+			.mockImplementationOnce(() => first.promise)
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ entry: newEntry }) })
+			.mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ code: "EVENT_REVERSED" }) })
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ entry: reversedEntry }) });
+		const onEventReversed = vi.fn();
+		const { result } = renderHook(() => useIntakeJournal({ onEventReversed }));
+
+		act(() => {
+			void result.current.openJournalEditor(oldEntry.doseId);
+		});
+		await waitFor(() => expect(result.current.journalEventLoading).toBe(true));
+		const firstSignal = (authFetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal;
+		if (!firstSignal) throw new Error("Expected the journal load request to have an AbortSignal");
+		act(() => {
+			void result.current.openJournalEditor(newEntry.doseId);
+		});
+		expect(firstSignal.aborted).toBe(true);
+		await waitFor(() => expect(result.current.journalEvent?.doseId).toBe(newEntry.doseId));
+		first.resolve({ ok: true, json: () => Promise.resolve({ entry: oldEntry }) });
+		await waitFor(() => expect(result.current.journalEvent?.doseId).toBe(newEntry.doseId));
+
+		let saved = true;
+		await act(async () => {
+			saved = await result.current.saveJournalNote("Race", "good");
+		});
+		expect(saved).toBe(false);
+		expect(result.current.journalEvent).toEqual(expect.objectContaining({ status: "reversed", note: "Locked" }));
+		expect(result.current.journalEventError).toBe("journal.errors.eventReversed");
+		expect(onEventReversed).toHaveBeenCalledOnce();
 	});
 });


### PR DESCRIPTION
Closes #1042

## Summary

- add nullable mood/note journal create, update, and delete for active as-needed history events using existing journal UI
- retain reversed-event journal context visibly as read-only and reconcile `EVENT_REVERSED` conflicts by refreshing history
- add latest-request guards, safe error feedback, focus/pending behavior, and desktop/mobile parity

## Scope boundary

Scheduled journal behavior is unchanged. No Slice 8 work, report, import, docs, sharing, or action changes are included.

## Validation

- focused frontend coverage: 21 tests; full frontend suite: 79 files, 1,162 tests
- authenticated Playwright: 14 tests
- root lint/check/build, i18n parity (1,047), and diff check

Security review found no critical, major, or minor findings.