### PR TITLE
docs: document unscheduled medication workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Share your medication schedule with others via a public link.
 - Track exact stock with package profiles (blister, bottle, tube, liquid container, inhaler, injection)
 - Display remaining days of supply
 - Automatic calculation based on intake schedule
+- Record package-aware as-needed consumption for active medications without a regular schedule
 - Manual stock corrections
 
 ### Medication Refill
@@ -139,7 +140,17 @@ Share your medication schedule with others via a public link.
 ### Flexible Schedules
 - Daily, weekly, or custom intervals per medication
 - Independent schedules for each medication
+- Create or edit a medication without a regular schedule on desktop and mobile, then add or remove schedules later
 - Optional timeline filters for dashboard and shared schedule views
+
+### Unscheduled Medications & As-Needed Intakes
+- **Record now** is available for active medications with no regular schedule; scheduled, ended, and obsolete medications keep their existing behavior
+- Quantity, unit, and stock effect follow the medication's package profile. Topical use records one application without guessing a measurable stock reduction
+- Attribute an intake to one of the medication's current people or choose **None / self**
+- Keep an auditable active and reversed history, with corrections recorded as a reversal followed by a separate replacement
+- Include as-needed history and journals in reports and export/import backups without exposing event details or mutation actions on public shares
+
+See [Unscheduled medications and Record now](docs/CONFIGURATION.md#unscheduled-medications-and-record-now) for the inventory, retry, correction, sharing, and backup rules.
 
 ### Stock Alerts & Reminders
 - Notifications before stock runs out
@@ -152,7 +163,7 @@ Share your medication schedule with others via a public link.
 
 ### Reports
 - Generate medication reports as PDF, Markdown, or plain text
-- Include intake history with mood summaries, refill history, and prescription details
+- Include scheduled history plus separate active as-needed totals and active/reversed audit entries with journal context
 
 ### Multi-Person Support
 - Manage medications for multiple people
@@ -161,7 +172,7 @@ Share your medication schedule with others via a public link.
 - Optionally embed the medication overview directly on shared links via a settings toggle
 
 ### Data Export & Import
-- Export all your data (medications, dose history, intake journal notes and moods, settings) as JSON
+- Export all your data (medications, scheduled dose history, as-needed intake events, intake journal notes and moods, settings) as JSON
 - Review validated import contents before replacing current data
 - Optionally download a fresh backup before confirming import
 - Import previously exported data with automatic ID remapping

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -80,6 +80,49 @@ Medication rows still retain legacy schedule columns (`usage_json`, `every_json`
 
 Backend code should consume medication schedules through the canonical normalization helpers in `backend/src/utils/scheduler-utils.ts` (`normalizeMedicationSchedule()` or `normalizeMedicationIntakes()`). Direct legacy parsing should stay inside that utility boundary until a reviewed migration policy can remove the old columns safely.
 
+## Unscheduled Medications and Record Now
+
+### Schedule state and eligibility
+
+The desktop and mobile medication editors both support **No regular schedule**. This stores an explicit empty schedule rather than a placeholder or zero-dose entry. Removing the last schedule requires confirmation. A schedule-only transition to or from this state preserves the medication, its existing history, and the full current stock; it does not create past or future doses.
+
+**Record now** is available only to the authenticated owner for a medication that is active and currently has no regular schedule. It is unavailable when the medication has a schedule, has ended, or is obsolete. A no-schedule medication creates no scheduled dose rows or intake reminders.
+
+The dialog accepts one of the medication's current people or **None / self**. The selected value is stored with the event. The service, not the browser, supplies the acceptance time for both the occurrence and recording time; the UI displays that absolute instant in the user's saved app timezone.
+
+### Quantity and stock behavior
+
+The app derives the quantity unit and valid step from the current medication package profile:
+
+| Medication/package profile | Record now quantity | Current-stock effect |
+|---|---|---|
+| Tablet in a blister or bottle | Pills in half-pill steps | Subtract the accepted quantity |
+| Capsule in a blister or bottle | Whole pills | Subtract the accepted quantity |
+| Liquid container | Millilitres, with a 0.1 ml UI step | Subtract the accepted quantity |
+| Inhaler | Whole puffs | Subtract the accepted quantity |
+| Injection | Whole injections | Subtract the accepted quantity |
+| Tube or topical medication | Exactly one application | No measurable reduction; package stock remains unchanged |
+
+Measurable events are rejected atomically when current stock is zero, insufficient, or cannot be resolved safely. No event or partial stock change is retained. Check the real supply, use a stock correction to set the physical count, or add a refill before starting a new intent.
+
+A stock correction treats the submitted stock as the new physical baseline. A refill first adds its quantity to the complete transaction-visible current stock and then establishes that result as the baseline. Active as-needed effects already included in either physical count remain factual history but receive a durable zero stock effect, so they are not subtracted twice. A topical application remains zero-effect throughout these operations.
+
+### Retries, reversal, and journals
+
+Each opened Record now intent uses one idempotency key. A double tap, a same-intent concurrent submission, or a retry after an interrupted response resolves to the same event and stock effect. Retry the still-open intent when the result is uncertain; closing it and deliberately starting another Record now action creates a new intent. There is no persistent offline submission queue.
+
+Reversing an event restores only its stored stock effect and leaves a durable reversed audit entry. Retrying the same reversal cannot restore stock again. A correction is deliberately two operations: reverse the original event, then confirm a separate replacement. If the replacement is cancelled or fails, the original remains reversed and no replacement is invented.
+
+An active event's journal supports add, edit, and delete actions. After reversal, an existing journal remains visible in history, reports, and backups but becomes read-only.
+
+### Reports, sharing, and backups
+
+Reports keep scheduled intake results separate from as-needed data. Active as-needed events contribute to active counts and quantity totals grouped by unit. Both active and reversed events remain in the audit section with their stored quantity, person, source, stock effect, correction relationship, and journal context; reversed events do not contribute to active consumption or mood totals.
+
+Public share links do not expose as-needed event history, journals, Record now, reversal, or correction actions. When the medication overview is enabled for a share, its aggregate current-stock value includes active as-needed stock effects for medications already visible under the existing share rules. Existing shared scheduled-dose permissions do not grant as-needed mutation access.
+
+JSON exports use format version `1.9` and store as-needed events, active/reversed state, replacement links, exact stock effects, and linked journals separately from scheduled dose history. Import preview validates and counts these events before the existing all-or-nothing replacement. Backups from versions `1.0` through `1.8` remain importable and are treated as containing no as-needed events; restoring one therefore replaces any current as-needed history along with the other current account data.
+
 ## Docker Image Pinning
 
 The default `docker-compose.yml` uses readable versioned image tags. Each GitHub release also attaches `docker-compose.pinned.yml` with the same release tags plus immutable image digests for deployments that need stricter reproducibility.

--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -135,4 +135,127 @@ test.describe("As-needed Record now", () => {
 			await expect(detail).toBeHidden();
 		});
 	}
+
+	test("records a named fractional tablet from the list, audits its correction, and locks the reversed journal", async ({
+		page,
+	}) => {
+		const name = "As-needed correction tablet";
+		await deleteAllMedicationsViaAPI();
+		await createMedicationViaAPI({
+			name,
+			takenBy: ["Alice"],
+			packageType: "blister",
+			medicationForm: "tablet",
+			packCount: 1,
+			blistersPerPack: 1,
+			pillsPerBlister: 10,
+			looseTablets: 0,
+			intakes: [],
+		});
+
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await navigateTo(page, "/medications");
+		const medication = page.getByTestId("medication-row").filter({ hasText: name });
+		await medication.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+		const recordModal = page.getByRole("dialog").last();
+		await recordModal.getByLabel(/Person|Person/i).selectOption("Alice");
+		await recordModal.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+		await expect(recordModal.getByText(/Current stock:\s*9\.5|Aktueller Bestand:\s*9,5/i)).toBeVisible();
+		await recordModal.getByLabel(/Close|Schließen/i).click();
+
+		await navigateTo(page, "/dashboard");
+		const overview = page.getByTestId("dashboard-overview-table");
+		await overview
+			.getByTestId("dashboard-overview-row")
+			.filter({ hasText: name })
+			.getByRole("button", { name })
+			.click();
+		const detail = page
+			.getByRole("dialog")
+			.filter({ has: page.getByRole("heading", { name }) })
+			.last();
+		const history = detail.getByRole("region", { name: /As-needed history|Bei-Bedarf-Verlauf/i });
+		await expect(history.getByText("Alice", { exact: true })).toBeVisible();
+
+		await history.getByRole("button", { name: /Add journal|Journal hinzufügen/i }).click();
+		let journal = page.locator(".journal-modal");
+		await journal.getByRole("textbox").fill("Initial correction journal");
+		await journal.getByRole("button", { name: /Save|Speichern/i }).click();
+		await expect(journal).toBeHidden();
+
+		await history.getByRole("button", { name: /Edit journal|Journal bearbeiten/i }).click();
+		journal = page.locator(".journal-modal");
+		await journal.getByRole("textbox").fill("Updated correction journal");
+		await journal.getByRole("button", { name: /Save|Speichern/i }).click();
+		await expect(journal).toBeHidden();
+		await expect(history.getByText("Updated correction journal")).toBeVisible();
+
+		await history.getByRole("button", { name: /Edit journal|Journal bearbeiten/i }).click();
+		journal = page.locator(".journal-modal");
+		await journal.getByRole("button", { name: /Delete|Löschen/i }).click();
+		await expect(journal).toBeHidden();
+
+		await history.getByRole("button", { name: /Add journal|Journal hinzufügen/i }).click();
+		journal = page.locator(".journal-modal");
+		await journal.getByRole("textbox").fill("Retained reversed journal");
+		await journal.getByRole("button", { name: /Save|Speichern/i }).click();
+		await expect(journal).toBeHidden();
+
+		await history.getByRole("button", { name: /Reverse|Stornieren/i }).click();
+		const reversal = page.getByRole("dialog").last();
+		await reversal.getByRole("button", { name: /Reverse intake|Einnahme stornieren/i }).click();
+		await expect(history.getByText(/Reversed|Storniert/i)).toBeVisible();
+
+		await history.getByRole("button", { name: /View journal|Journal ansehen/i }).click();
+		journal = page.locator(".journal-modal");
+		await expect(journal.getByRole("textbox")).toHaveValue("Retained reversed journal");
+		await expect(journal.getByRole("textbox")).toHaveAttribute("readonly", "");
+		await expect(journal.getByRole("button", { name: /Save|Speichern/i })).toHaveCount(0);
+		await expect(journal.getByRole("button", { name: /Delete|Löschen/i })).toHaveCount(0);
+		await journal.getByLabel(/Close|Schließen/i).click();
+
+		await history.getByRole("button", { name: /Record correction|Korrektur erfassen/i }).click();
+		const replacement = page.getByRole("dialog", { name: /Record corrected intake|Korrigierte Einnahme erfassen/i });
+		await replacement.getByRole("button", { name: /Record correction|Korrektur erfassen/i }).click();
+		await expect(replacement.getByText(/Correction recorded|Korrektur erfasst/i)).toBeVisible({ timeout: 15_000 });
+		await replacement.getByLabel(/Close|Schließen/i).click();
+		await expect(history.getByText(/Correction of event|Korrektur von Ereignis/i)).toBeVisible();
+		await expect(history.getByText(/^(Active|Aktiv)$/i)).toBeVisible();
+	});
+
+	test("records a topical None/self application from mobile detail without reducing measured stock", async ({
+		page,
+	}) => {
+		const name = "As-needed topical self";
+		await deleteAllMedicationsViaAPI();
+		await createMedicationViaAPI({
+			name,
+			packageType: "tube",
+			medicationForm: "topical",
+			packageAmountValue: 30,
+			looseTablets: 30,
+			intakes: [],
+		});
+
+		await page.setViewportSize({ width: 390, height: 844 });
+		await navigateTo(page, "/dashboard");
+		const overview = page.getByTestId("dashboard-overview-table");
+		await overview
+			.getByTestId("dashboard-overview-row")
+			.filter({ hasText: name })
+			.getByRole("button", { name })
+			.click();
+		const detail = page
+			.getByRole("dialog")
+			.filter({ has: page.getByRole("heading", { name }) })
+			.last();
+		await detail.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+		const recordModal = page.getByRole("dialog").last();
+		await recordModal.getByLabel(/Person|Person/i).selectOption("");
+		await expect(recordModal.getByText(/without changing the measured stock|ohne.*Bestand/i)).toBeVisible();
+		await recordModal.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+		await expect(recordModal.getByText(/Current stock:\s*30|Aktueller Bestand:\s*30/i)).toBeVisible();
+		await recordModal.getByLabel(/Close|Schließen/i).click();
+		await expect(detail.getByText(/No measurable stock effect|Kein messbarer Bestandseffekt/i)).toBeVisible();
+	});
 });


### PR DESCRIPTION
Closes #1045

## Summary

- document the complete no-schedule and Record now workflow, package-aware quantity/stock behavior, idempotent retries, corrections, journals, reports, sharing, and v1.9 backup compatibility
- update README feature descriptions for separate as-needed history, reports, and exports
- add authenticated desktop/mobile final workflow coverage for fractional/named, topical/None, journal, reversal, replacement, stock, and read-only history behavior

## Validation

- shared: 12 tests; backend: 943 tests; frontend: 1,169 tests
- stable E2E: 211 passed, 3 expected OIDC skips
- root lint, check, build, and diff check

## Residual

Expected AbortError logging is tracked separately by project-bot and is non-blocking. No About/GitHub link was added.