### PR TITLE
fix: add safe as-needed intake undo

### DIFF
--- a/backend/src/routes/as-needed-intakes.ts
+++ b/backend/src/routes/as-needed-intakes.ts
@@ -5,6 +5,7 @@ import { env } from "../plugins/env.js";
 import {
 	AsNeededIntakeError,
 	createAsNeededIntake,
+	deleteAsNeededIntake,
 	getAsNeededMutationResponse,
 	listAsNeededIntakes,
 	reverseAsNeededIntake,
@@ -233,7 +234,7 @@ function validationError(reply: FastifyReply, code: string, message: string): Fa
 function sendServiceError(
 	request: FastifyRequest,
 	reply: FastifyReply,
-	operation: "list" | "create" | "reverse",
+	operation: "list" | "create" | "reverse" | "undo",
 	userId: number,
 	error: unknown
 ): FastifyReply {
@@ -441,6 +442,37 @@ export async function asNeededIntakeRoutes(app: FastifyInstance) {
 				return reply.status(200).send(await getAsNeededMutationResponse(userId, event.eventId));
 			} catch (error) {
 				return sendServiceError(request, reply, "reverse", userId, error);
+			}
+		}
+	);
+
+	app.delete<{ Params: Record<string, unknown> }>(
+		"/as-needed-intakes/:eventId",
+		{
+			attachValidation: true,
+			schema: {
+				params: eventParamsOpenApiSchema,
+				response: {
+					204: { type: "null" },
+					400: errorResponseSchema,
+					403: errorResponseSchema,
+					500: genericErrorSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const params = eventParamsSchema.safeParse(request.params);
+			if (!params.success) return validationError(reply, "INVALID_REQUEST", "Invalid event id");
+			const userId = await getUserId(request, reply);
+			if (userId === null) return;
+			if (isReadOnlyApiKeyRequest(request)) {
+				return reply.status(403).send({ error: "API key is read-only", code: "READ_ONLY" });
+			}
+			try {
+				await deleteAsNeededIntake(userId, params.data.eventId);
+				return reply.status(204).send();
+			} catch (error) {
+				return sendServiceError(request, reply, "undo", userId, error);
 			}
 		}
 	);

--- a/backend/src/services/as-needed-intakes-service.ts
+++ b/backend/src/services/as-needed-intakes-service.ts
@@ -585,8 +585,17 @@ export async function createAsNeededIntake(input: {
 		const profile = getAsNeededQuantityProfile(medication);
 		const quantityMilli = normalizeAsNeededQuantityMilli(input.quantity, profile);
 		if (quantityMilli === null) throw new AsNeededIntakeError("INVALID_QUANTITY", "Invalid quantity");
-		if (personName && !parseMedicationPeople(medication.takenByJson).includes(personName)) {
-			throw new AsNeededIntakeError("INVALID_PERSON", "Person is not assigned to this medication");
+		if (personName) {
+			const ownerMedications = await transactionDb
+				.select({ takenByJson: medications.takenByJson })
+				.from(medications)
+				.where(eq(medications.userId, input.userId));
+			const personIsKnown = ownerMedications.some(({ takenByJson }) =>
+				parseMedicationPeople(takenByJson).includes(personName)
+			);
+			if (!personIsKnown) {
+				throw new AsNeededIntakeError("INVALID_PERSON", "Person is not assigned to an owned medication");
+			}
 		}
 		const [settings] = await transactionDb
 			.select({ stockCalculationMode: userSettings.stockCalculationMode, timezone: userSettings.timezone })
@@ -729,5 +738,25 @@ export async function reverseAsNeededIntake(input: {
 			});
 		}
 		return reversed;
+	});
+}
+
+export async function deleteAsNeededIntake(userId: number, eventId: string): Promise<void> {
+	await withImmediateWriteTransaction(async (transactionDb) => {
+		const [event] = await transactionDb
+			.select({ doseTrackingId: asNeededIntakeEvents.doseTrackingId })
+			.from(asNeededIntakeEvents)
+			.where(
+				and(
+					eq(asNeededIntakeEvents.userId, userId),
+					eq(asNeededIntakeEvents.eventId, eventId.trim().toLowerCase()),
+					eq(asNeededIntakeEvents.status, "active")
+				)
+			);
+		if (!event) return;
+
+		await transactionDb
+			.delete(doseTracking)
+			.where(and(eq(doseTracking.id, event.doseTrackingId), eq(doseTracking.userId, userId)));
 	});
 }

--- a/backend/src/test/as-needed-intakes-routes.test.ts
+++ b/backend/src/test/as-needed-intakes-routes.test.ts
@@ -94,17 +94,76 @@ describe.sequential("as-needed owner routes", () => {
 
 	afterAll(() => rmSync(dataDir, { force: true, recursive: true }));
 
-	it("registers exactly the three owner /api-convention paths with documented strict schemas", async () => {
+	it("registers the four owner /api-convention paths with documented strict schemas", async () => {
 		const app = await buildRouteApp();
 		const routes = app.printRoutes();
 		expect(routes).toContain(":medicationId");
 		expect(routes).toContain("/as-needed-intakes (GET, HEAD, POST)");
 		expect(routes).toContain(":eventId");
 		expect(routes).toContain("/reversal (POST)");
-		expect(routes).not.toContain("DELETE");
+		expect(routes).toContain(":eventId (DELETE)");
 		expect(routes).not.toContain("share");
 		expect((await app.inject({ method: "DELETE", url: "/medications/1/as-needed-intakes" })).statusCode).toBe(404);
 		expect((await app.inject({ method: "GET", url: "/api/medications/1/as-needed-intakes" })).statusCode).toBe(404);
+		await app.close();
+	});
+
+	it("undos active intakes idempotently without disclosing unknown, other-owner, or reversed events", async () => {
+		const app = await buildRouteApp();
+		const medicationId = await seedMedication(1, 10);
+		const otherMedicationId = await seedMedication(2, 10);
+		const active = await create(app, medicationId, { quantity: 2 });
+		const activeEventId = active.json().event.eventId as string;
+		authState.userId = 2;
+		const other = await create(app, otherMedicationId, { quantity: 1 });
+		const otherEventId = other.json().event.eventId as string;
+		authState.userId = 1;
+		const reversed = await create(app, medicationId, { quantity: 1 });
+		const reversedEventId = reversed.json().event.eventId as string;
+		expect(
+			(
+				await app.inject({
+					method: "POST",
+					url: `/as-needed-intakes/${reversedEventId}/reversal`,
+					headers: { "idempotency-key": key() },
+					payload: { expectedRevision: 1 },
+				})
+			).statusCode
+		).toBe(200);
+
+		authState.readOnly = true;
+		expect((await app.inject({ method: "DELETE", url: `/as-needed-intakes/${activeEventId}` })).json()).toMatchObject({
+			code: "READ_ONLY",
+		});
+		authState.readOnly = false;
+
+		for (const eventId of [
+			"00000000-0000-4000-8000-000000000999",
+			otherEventId,
+			reversedEventId,
+			activeEventId,
+			activeEventId,
+		]) {
+			expect((await app.inject({ method: "DELETE", url: `/as-needed-intakes/${eventId}` })).statusCode).toBe(204);
+		}
+		expect((await db.select().from(asNeededIntakeEvents)).map((event) => event.eventId)).toEqual(
+			expect.arrayContaining([otherEventId, reversedEventId])
+		);
+		expect((await db.select().from(asNeededIntakeEvents)).map((event) => event.eventId)).not.toContain(activeEventId);
+		await app.close();
+	});
+
+	it("accepts a person assigned to another medication owned by the same user", async () => {
+		const app = await buildRouteApp();
+		const medicationId = await seedMedication(1, 10);
+		await seedMedication(1, 10, { people: ["Ava"] });
+		await seedMedication(2, 10, { people: ["Ben"] });
+		expect((await create(app, medicationId, { quantity: 1, person: "Ava" })).statusCode).toBe(201);
+		for (const person of ["Ben", "Unknown"]) {
+			const response = await create(app, medicationId, { quantity: 1, person });
+			expect(response.statusCode).toBe(400);
+			expect(response.json()).toMatchObject({ code: "INVALID_PERSON" });
+		}
 		await app.close();
 	});
 

--- a/backend/src/test/as-needed-intakes-service.test.ts
+++ b/backend/src/test/as-needed-intakes-service.test.ts
@@ -34,6 +34,7 @@ const {
 	getActiveAsNeededStockEffectsMilli,
 	getAsNeededMutationResponse,
 	listAsNeededIntakes,
+	deleteAsNeededIntake,
 	reverseAsNeededIntake,
 } = service;
 
@@ -172,6 +173,93 @@ describe.sequential("as-needed intake service", () => {
 			"EVENT_NOT_FOUND"
 		);
 		expect(await eventCount()).toBe(2);
+	});
+
+	it("accepts people assigned to another owned medication but rejects unknown and cross-owner-only people", async () => {
+		const targetMedicationId = await seedMedication();
+		await seedMedication({ people: ["Ava"] });
+		await seedMedication({ userId: 2, people: ["Ben"] });
+
+		await expect(
+			createAsNeededIntake({
+				userId: 1,
+				medicationId: targetMedicationId,
+				quantity: 1,
+				personName: "Ava",
+				idempotencyKey: intentKey(),
+			})
+		).resolves.toMatchObject({ personName: "Ava" });
+		await expectCode(
+			createAsNeededIntake({
+				userId: 1,
+				medicationId: targetMedicationId,
+				quantity: 1,
+				personName: "Ben",
+				idempotencyKey: intentKey(),
+			}),
+			"INVALID_PERSON"
+		);
+		await expectCode(
+			createAsNeededIntake({
+				userId: 1,
+				medicationId: targetMedicationId,
+				quantity: 1,
+				personName: "Unknown",
+				idempotencyKey: intentKey(),
+			}),
+			"INVALID_PERSON"
+		);
+	});
+
+	it("deletes an active owner intake with its anchor and journal while restoring the stock effect", async () => {
+		const medicationId = await seedMedication({ stock: 10 });
+		const event = await createAsNeededIntake({ userId: 1, medicationId, quantity: 2, idempotencyKey: intentKey() });
+		await db.insert(intakeJournal).values({
+			userId: 1,
+			doseTrackingId: event.doseTrackingId,
+			medicationId,
+			scheduledFor: event.occurredAt,
+			note: "Undo me",
+			createdAt: event.occurredAt,
+			updatedAt: event.occurredAt,
+		});
+
+		expect((await getAsNeededMutationResponse(1, event.eventId)).inventory.currentStock).toBe(8);
+		await deleteAsNeededIntake(1, event.eventId);
+		expect(await getActiveAsNeededStockEffectMilli(db, 1, medicationId)).toBe(0);
+		expect(await db.select().from(asNeededIntakeEvents)).toEqual([]);
+		expect(await db.select().from(doseTracking)).toEqual([]);
+		expect(await db.select().from(intakeJournal)).toEqual([]);
+	});
+
+	it("makes owner undo idempotent and non-disclosing for unknown, other-owner, and reversed events", async () => {
+		const medicationId = await seedMedication({ stock: 10 });
+		const otherMedicationId = await seedMedication({ userId: 2, stock: 10 });
+		const active = await createAsNeededIntake({ userId: 1, medicationId, quantity: 1, idempotencyKey: intentKey() });
+		const other = await createAsNeededIntake({
+			userId: 2,
+			medicationId: otherMedicationId,
+			quantity: 1,
+			idempotencyKey: intentKey(),
+		});
+		const reversed = await createAsNeededIntake({ userId: 1, medicationId, quantity: 1, idempotencyKey: intentKey() });
+		await reverseAsNeededIntake({
+			userId: 1,
+			eventId: reversed.eventId,
+			expectedRevision: 1,
+			idempotencyKey: intentKey(),
+		});
+
+		await deleteAsNeededIntake(1, "00000000-0000-4000-8000-000000000999");
+		await deleteAsNeededIntake(1, other.eventId);
+		await deleteAsNeededIntake(1, reversed.eventId);
+		expect(await eventCount()).toBe(3);
+		expect(await getActiveAsNeededStockEffectMilli(db, 1, medicationId)).toBe(active.stockEffectMilli);
+
+		await deleteAsNeededIntake(1, active.eventId);
+		await deleteAsNeededIntake(1, active.eventId);
+		expect(await eventCount()).toBe(2);
+		expect(await getActiveAsNeededStockEffectMilli(db, 1, medicationId)).toBe(0);
 	});
 
 	it("replays an imported semantic intent after medication IDs have been remapped", async () => {


### PR DESCRIPTION
Closes #1050

Adds a backward-compatible Undo endpoint for active as-needed intakes. Undo removes the intake and restores stock safely, while selected people are validated server-side against the authenticated owner's existing intake users.

Legacy reversal handling remains available temporarily for compatibility.