### PR TITLE
fix: polish as-needed take flow

### DIFF
--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -124,8 +124,8 @@ test.describe("As-needed Record now", () => {
 				.filter({ has: page.getByRole("heading", { name: MEDICATION_NAME }) })
 				.last();
 			await expect(detail).toBeVisible();
-			await expect(detail.getByText(/As-needed history|Bei-Bedarf-Verlauf/i)).toBeVisible();
-			await detail.getByRole("button", { name: /Take|Einnehmen/i }).click();
+			await expect(detail.getByRole("region", { name: /As-needed history|Bei-Bedarf-Verlauf/i })).toBeVisible();
+			await detail.getByRole("button", { name: /^(Take|Nehmen)$/ }).click();
 
 			const create = page.waitForResponse(
 				(response) => response.url().includes("/as-needed-intakes") && response.request().method() === "POST"
@@ -133,13 +133,13 @@ test.describe("As-needed Record now", () => {
 			await page
 				.getByRole("dialog")
 				.last()
-				.getByRole("button", { name: /Take|Einnehmen/i })
+				.getByRole("button", { name: /^(Take|Nehmen)$/ })
 				.click();
 			expect((await create).status()).toBe(201);
 			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
 			await page.goBack();
 			await expect(detail).toBeVisible();
-			await expect(detail.locator("article").first()).toContainText(/0\.5/);
+			await expect(detail.locator("article").first()).toContainText(/^1 pill|^1 Tablette/);
 			await detail
 				.getByLabel(/Close|Schließen/i)
 				.first()

--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -131,8 +131,7 @@ test.describe("As-needed Record now", () => {
 				(response) => response.url().includes("/as-needed-intakes") && response.request().method() === "POST"
 			);
 			await page
-				.getByRole("dialog")
-				.last()
+				.getByRole("dialog", { name: /Take as-needed medication|Medikament bei Bedarf nehmen/i })
 				.getByRole("button", { name: /^(Take|Nehmen)$/ })
 				.click();
 			expect((await create).status()).toBe(201);

--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -32,9 +32,13 @@ test.describe("As-needed Record now", () => {
 			await page.setViewportSize(viewport.size);
 			await navigateTo(page, "/medications");
 			const medication = page.getByTestId("medication-row").filter({ hasText: MEDICATION_NAME });
-			await medication.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
-			await page.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
-			await expect(page.getByText(/Intake recorded|Einnahme erfasst/i)).toBeVisible();
+			await medication.getByRole("button", { name: /Take|Einnehmen/i }).click();
+			await page
+				.getByRole("dialog")
+				.last()
+				.getByRole("button", { name: /Take|Einnehmen/i })
+				.click();
+			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
 			const recordModal = page.getByRole("dialog").last();
 			await recordModal.getByLabel(/Close|Schließen/i).click();
 			await expect(recordModal).toBeHidden();
@@ -61,7 +65,7 @@ test.describe("As-needed Record now", () => {
 			await navigateTo(page, "/medications");
 			const medication = page.getByTestId("medication-row").filter({ hasText: MEDICATION_NAME });
 			await expect(medication).toBeVisible();
-			await medication.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+			await medication.getByRole("button", { name: /Take|Einnehmen/i }).click();
 
 			let firstServerStatus: number | null = null;
 			let firstKey: string | null = null;
@@ -75,7 +79,11 @@ test.describe("As-needed Record now", () => {
 				await route.abort("connectionreset");
 			});
 
-			await page.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+			await page
+				.getByRole("dialog")
+				.last()
+				.getByRole("button", { name: /Take|Einnehmen/i })
+				.click();
 			await expect(page.getByText(/result is uncertain|Ergebnis.*unklar/i)).toBeVisible();
 
 			const replay = page.waitForResponse((response) => response.url().includes("/as-needed-intakes"));
@@ -89,10 +97,10 @@ test.describe("As-needed Record now", () => {
 			expect(replayResponse.status()).toBe(200);
 			expect(await replayResponse.request().headerValue("idempotency-key")).toBe(firstKey);
 			expect((await reloadResponse.json()) as Array<{ asNeededStockEffect?: number }>).toEqual(
-				expect.arrayContaining([expect.objectContaining({ asNeededStockEffect: 0.5 })])
+				expect.arrayContaining([expect.objectContaining({ asNeededStockEffect: 1 })])
 			);
-			await expect(page.getByText(/Intake recorded|Einnahme erfasst/i)).toBeVisible();
-			await expect(medication).toContainText(/9\.5\s*\/\s*10/);
+			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
+			await expect(medication).toContainText(/9\s*\/\s*10/);
 		});
 	}
 
@@ -117,14 +125,18 @@ test.describe("As-needed Record now", () => {
 				.last();
 			await expect(detail).toBeVisible();
 			await expect(detail.getByText(/As-needed history|Bei-Bedarf-Verlauf/i)).toBeVisible();
-			await detail.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+			await detail.getByRole("button", { name: /Take|Einnehmen/i }).click();
 
 			const create = page.waitForResponse(
 				(response) => response.url().includes("/as-needed-intakes") && response.request().method() === "POST"
 			);
-			await page.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+			await page
+				.getByRole("dialog")
+				.last()
+				.getByRole("button", { name: /Take|Einnehmen/i })
+				.click();
 			expect((await create).status()).toBe(201);
-			await expect(page.getByText(/Intake recorded|Einnahme erfasst/i)).toBeVisible();
+			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
 			await page.goBack();
 			await expect(detail).toBeVisible();
 			await expect(detail.locator("article").first()).toContainText(/0\.5/);
@@ -156,11 +168,11 @@ test.describe("As-needed Record now", () => {
 		await page.setViewportSize({ width: 1280, height: 720 });
 		await navigateTo(page, "/medications");
 		const medication = page.getByTestId("medication-row").filter({ hasText: name });
-		await medication.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+		await medication.getByRole("button", { name: /Take|Einnehmen/i }).click();
 		const recordModal = page.getByRole("dialog").last();
 		await recordModal.getByLabel(/Person|Person/i).selectOption("Alice");
-		await recordModal.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
-		await expect(recordModal.getByText(/Current stock:\s*9\.5|Aktueller Bestand:\s*9,5/i)).toBeVisible();
+		await recordModal.getByRole("button", { name: /Take|Einnehmen/i }).click();
+		await expect(recordModal.getByText(/Current stock:\s*9|Aktueller Bestand:\s*9/i)).toBeVisible();
 		await recordModal.getByLabel(/Close|Schließen/i).click();
 
 		await navigateTo(page, "/dashboard");
@@ -249,11 +261,11 @@ test.describe("As-needed Record now", () => {
 			.getByRole("dialog")
 			.filter({ has: page.getByRole("heading", { name }) })
 			.last();
-		await detail.getByRole("button", { name: /Record now|Jetzt erfassen/i }).click();
+		await detail.getByRole("button", { name: /Take|Einnehmen/i }).click();
 		const recordModal = page.getByRole("dialog").last();
 		await recordModal.getByLabel(/Person|Person/i).selectOption("");
 		await expect(recordModal.getByText(/without changing the measured stock|ohne.*Bestand/i)).toBeVisible();
-		await recordModal.getByRole("button", { name: /Record intake|Einnahme erfassen/i }).click();
+		await recordModal.getByRole("button", { name: /Take|Einnehmen/i }).click();
 		await expect(recordModal.getByText(/Current stock:\s*30|Aktueller Bestand:\s*30/i)).toBeVisible();
 		await recordModal.getByLabel(/Close|Schließen/i).click();
 		await expect(detail.getByText(/No measurable stock effect|Kein messbarer Bestandseffekt/i)).toBeVisible();

--- a/frontend/e2e/as-needed-take-polish.spec.ts
+++ b/frontend/e2e/as-needed-take-polish.spec.ts
@@ -1,0 +1,92 @@
+import { authFile, createMedicationViaAPI, deleteAllMedicationsViaAPI, expect, navigateTo, test } from "./fixtures";
+
+const MEDICATION_NAME = "As-needed take polish";
+
+test.describe("As-needed Take polish", () => {
+	test.use({ storageState: authFile });
+	test.describe.configure({ timeout: 90000 });
+
+	test.beforeEach(async () => {
+		await deleteAllMedicationsViaAPI();
+		await createMedicationViaAPI({
+			name: MEDICATION_NAME,
+			packageType: "blister",
+			medicationForm: "tablet",
+			packCount: 1,
+			blistersPerPack: 1,
+			pillsPerBlister: 10,
+			looseTablets: 0,
+			intakes: [],
+		});
+		await createMedicationViaAPI({
+			name: "Existing person source",
+			takenBy: ["Ava"],
+			packageType: "blister",
+			medicationForm: "tablet",
+			packCount: 1,
+			blistersPerPack: 1,
+			pillsPerBlister: 10,
+			looseTablets: 0,
+			intakes: [],
+		});
+	});
+
+	test.afterAll(async () => {
+		await deleteAllMedicationsViaAPI();
+	});
+
+	for (const viewport of [
+		{ name: "desktop", size: { width: 1280, height: 720 } },
+		{ name: "mobile", size: { width: 390, height: 844 } },
+	]) {
+		test(`${viewport.name} keeps the dashboard stable while Take refreshes silently`, async ({ page }) => {
+			await page.setViewportSize(viewport.size);
+			await navigateTo(page, "/dashboard");
+			const overview = page.getByTestId("dashboard-overview-table");
+			await expect(overview).toBeVisible();
+			await overview
+				.getByTestId("dashboard-overview-row")
+				.filter({ hasText: MEDICATION_NAME })
+				.getByRole("button", { name: MEDICATION_NAME })
+				.click();
+
+			const detail = page
+				.getByRole("dialog")
+				.filter({ has: page.getByRole("heading", { name: MEDICATION_NAME }) })
+				.last();
+			await expect(detail).toBeVisible();
+			await detail.getByRole("button", { name: "Take" }).click();
+			const modal = page.getByRole("dialog", { name: "Take as-needed medication" });
+			await expect(modal).toBeVisible();
+			await expect(modal.locator("#record-now-quantity")).toHaveValue("1");
+			await expect(modal.getByLabel("Person")).toHaveText(/Ava/);
+
+			let releaseRefresh: (() => void) | undefined;
+			let refreshStarted = false;
+			await page.route("**/api/medications?includeObsolete=true", async (route) => {
+				refreshStarted = true;
+				await new Promise<void>((resolve) => {
+					releaseRefresh = resolve;
+				});
+				await route.continue();
+			});
+
+			await modal.getByRole("button", { name: "Take", exact: true }).click();
+			await expect(modal.getByText("Medication taken")).toBeVisible();
+			await expect.poll(() => refreshStarted).toBe(true);
+			await expect(page.locator(".dashboard-card-skeleton")).toHaveCount(0);
+
+			const gap = await modal.evaluate((dialog) => {
+				const alert = dialog.querySelector<HTMLElement>("[role='alert']");
+				const footer = dialog.querySelector<HTMLElement>("[data-testid='app-modal-footer']");
+				if (!alert || !footer) throw new Error("Take modal success alert or footer is missing");
+				return footer.getBoundingClientRect().top - alert.getBoundingClientRect().bottom;
+			});
+			expect(gap).toBeGreaterThanOrEqual(12);
+
+			releaseRefresh?.();
+			await expect.poll(() => refreshStarted).toBe(true);
+			await expect(detail).toContainText("9 / 10");
+		});
+	}
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -804,6 +804,7 @@ function AppContent() {
 			{detailRecordNowMedication && (
 				<Suspense fallback={null}>
 					<RecordNowModal
+						existingPeople={ctx.existingPeople}
 						medication={detailRecordNowMedication}
 						replacementEvent={detailReplacementEvent}
 						onClose={closeDetailRecordNow}

--- a/frontend/src/components/RecordNowModal.tsx
+++ b/frontend/src/components/RecordNowModal.tsx
@@ -9,12 +9,14 @@ import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
 import { AppButton } from "../ui/primitives/AppButton";
 import { AppSelect } from "../ui/primitives/AppSelect";
 import { getNumericLocale, withFormattingTimezone } from "../utils/formatters";
+import { mergePersonTags } from "../utils/person-tags";
 import { FormNumberStepper } from "./FormNumberStepper";
 import { MedicationAvatar } from "./MedicationAvatar";
 
 type RecordNowModalProps = {
 	medication: Medication | null;
 	replacementEvent?: AsNeededIntakeEvent | null;
+	existingPeople?: string[];
 	onClose: () => void;
 	onRecord: (input: {
 		medicationId: number;
@@ -50,9 +52,19 @@ function formatTrustedDateTime(value: string): string {
 	);
 }
 
-export function RecordNowModal({ medication, replacementEvent = null, onClose, onRecord }: RecordNowModalProps) {
+export function RecordNowModal({
+	medication,
+	replacementEvent = null,
+	existingPeople = [],
+	onClose,
+	onRecord,
+}: RecordNowModalProps) {
 	const { t } = useTranslation();
 	const profile = useMemo(() => getAsNeededQuantityProfile(medication ?? {}), [medication]);
+	const personOptions = useMemo(
+		() => mergePersonTags([...existingPeople, ...(medication?.takenBy ?? []), replacementEvent?.person]),
+		[existingPeople, medication?.takenBy, replacementEvent?.person]
+	);
 	const [quantity, setQuantity] = useState(String(profile.defaultQuantity));
 	const [person, setPerson] = useState("");
 	const [idempotencyKey, setIdempotencyKey] = useState("");
@@ -86,7 +98,7 @@ export function RecordNowModal({ medication, replacementEvent = null, onClose, o
 	const quantityIsValid = normalizeAsNeededQuantityMilli(numericQuantity, profile) !== null;
 	const unitLabel = t(`asNeeded.units.${profile.unit}`, { count: numericQuantity });
 	const locked = pending || attempted;
-	let submitLabel = t(replacementEvent ? "asNeeded.replacement.confirm" : "asNeeded.record.confirm");
+	let submitLabel = t(replacementEvent ? "asNeeded.replacement.confirm" : "dose.take");
 	if (pending) {
 		submitLabel = t("asNeeded.record.saving");
 	} else if (error) {
@@ -145,6 +157,7 @@ export function RecordNowModal({ medication, replacementEvent = null, onClose, o
 
 				{result ? (
 					<Alert
+						mb="md"
 						ref={feedbackRef}
 						tabIndex={-1}
 						color="green"
@@ -187,7 +200,7 @@ export function RecordNowModal({ medication, replacementEvent = null, onClose, o
 								<AppSelect
 									data={[
 										{ value: "", label: t("asNeeded.record.noPerson") },
-										...medication.takenBy.map((name) => ({ value: name, label: name })),
+										...personOptions.map((name) => ({ value: name, label: name })),
 									]}
 									label={t("asNeeded.record.person")}
 									onChange={(event) => setPerson(event.currentTarget.value)}

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -303,7 +303,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 	const recordAsNeededIntake = useCallback(
 		async (input: Parameters<typeof asNeededIntakes.recordAsNeededIntake>[0]) => {
 			const result = await asNeededIntakes.recordAsNeededIntake(input);
-			medications.loadMeds();
+			void medications.loadMeds({ silent: true });
 			return result;
 		},
 		[asNeededIntakes.recordAsNeededIntake, medications.loadMeds]
@@ -311,7 +311,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 	const reverseAsNeededIntake = useCallback(
 		async (input: Parameters<typeof asNeededIntakes.reverseAsNeededIntake>[0]) => {
 			const result = await asNeededIntakes.reverseAsNeededIntake(input);
-			medications.loadMeds();
+			void medications.loadMeds({ silent: true });
 			return result;
 		},
 		[asNeededIntakes.reverseAsNeededIntake, medications.loadMeds]

--- a/frontend/src/hooks/useMedications.ts
+++ b/frontend/src/hooks/useMedications.ts
@@ -11,7 +11,7 @@ export interface UseMedicationsReturn {
 	setSaving: React.Dispatch<React.SetStateAction<boolean>>;
 	uploadingImage: boolean;
 	clearMedicationsState: () => void;
-	loadMeds: () => void;
+	loadMeds: (options?: { silent?: boolean }) => Promise<void>;
 	deleteMed: (id: number, editingId: number | null, resetForm: () => void) => Promise<void>;
 	uploadMedImage: (medId: number, file: File) => Promise<void>;
 	deleteMedImage: (medId: number) => Promise<void>;
@@ -35,22 +35,27 @@ export function useMedications(): UseMedicationsReturn {
 		setUploadingImage(false);
 	}, []);
 
-	const loadMeds = useCallback(() => {
-		setLoading(true);
-		authFetch("/api/medications?includeObsolete=true")
-			.then((res) => {
+	const loadMeds = useCallback(
+		async ({ silent = false }: { silent?: boolean } = {}) => {
+			if (!silent) setLoading(true);
+
+			try {
+				const res = await authFetch("/api/medications?includeObsolete=true");
 				if (!res.ok) {
 					throw new Error(`HTTP ${res.status}`);
 				}
-				return res.json();
-			})
-			.then((data) => setMeds(Array.isArray(data) ? data : []))
-			.catch((error: unknown) => {
+
+				const data = await res.json();
+				setMeds(Array.isArray(data) ? data : []);
+			} catch (error: unknown) {
 				log.warn("[useMedications] load medications failed", { error: getErrorMessage(error) });
-				setMeds([]);
-			})
-			.finally(() => setLoading(false));
-	}, [authFetch]);
+				if (!silent) setMeds([]);
+			} finally {
+				if (!silent) setLoading(false);
+			}
+		},
+		[authFetch]
+	);
 
 	const deleteMed = useCallback(
 		async (id: number, editingId: number | null, resetForm: () => void) => {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -239,9 +239,9 @@
   },
   "asNeeded": {
     "record": {
-      "action": "Jetzt erfassen",
-      "title": "Bedarfseinnahme erfassen",
-      "trustedTime": "Der Dienst erfasst beim Bestätigen die aktuelle Uhrzeit.",
+      "action": "Nehmen",
+      "title": "Medikament bei Bedarf nehmen",
+      "trustedTime": "Die aktuelle Uhrzeit wird beim Einnehmen gespeichert.",
       "quantity": "Menge ({{unit}})",
       "person": "Person",
       "noPerson": "Keine Person / selbst",
@@ -249,11 +249,11 @@
       "increaseQuantity": "Menge erhöhen",
       "stockEffect": "Der Bestand wird um {{quantity}} {{unit}} verringert.",
       "noStockEffect": "Eine Anwendung wird erfasst, ohne den messbaren Bestand zu verändern.",
-      "confirm": "Einnahme erfassen",
-      "saving": "Einnahme wird erfasst...",
-      "failedTitle": "Einnahme wurde nicht erfasst",
-      "successTitle": "Einnahme erfasst",
-      "successMessage": "{{quantity}} {{unit}} um {{time}} erfasst. Aktueller Bestand: {{stock}}.",
+      "confirm": "Nehmen",
+      "saving": "Einnahme wird gespeichert...",
+      "failedTitle": "Medikament wurde nicht eingenommen",
+      "successTitle": "Medikament eingenommen",
+      "successMessage": "{{quantity}} {{unit}} um {{time}} eingenommen. Aktueller Bestand: {{stock}}.",
       "reconciliationRequired": "Packungskonfiguration und aktueller Bestand sollten geprüft werden."
     },
     "lifecycle": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -239,9 +239,9 @@
   },
   "asNeeded": {
     "record": {
-      "action": "Record now",
-      "title": "Record as-needed intake",
-      "trustedTime": "The service records the current time when you confirm.",
+      "action": "Take",
+      "title": "Take as-needed medication",
+      "trustedTime": "The current time is saved when you take it.",
       "quantity": "Quantity ({{unit}})",
       "person": "Person",
       "noPerson": "None / self",
@@ -249,11 +249,11 @@
       "increaseQuantity": "Increase quantity",
       "stockEffect": "This will reduce stock by {{quantity}} {{unit}}.",
       "noStockEffect": "This records one application without changing the measured stock.",
-      "confirm": "Record intake",
-      "saving": "Recording intake...",
-      "failedTitle": "Intake was not recorded",
-      "successTitle": "Intake recorded",
-      "successMessage": "Recorded {{quantity}} {{unit}} at {{time}}. Current stock: {{stock}}.",
+      "confirm": "Take",
+      "saving": "Saving intake...",
+      "failedTitle": "Medication was not taken",
+      "successTitle": "Medication taken",
+      "successMessage": "Took {{quantity}} {{unit}} at {{time}}. Current stock: {{stock}}.",
       "reconciliationRequired": "The package configuration and current stock should be checked."
     },
     "lifecycle": {

--- a/frontend/src/pages/DashboardPage.module.css
+++ b/frontend/src/pages/DashboardPage.module.css
@@ -31,7 +31,7 @@
 	--overview-name-stack-height: calc(1rem * 1.55 + 0.4rem + 0.78rem * 1.2);
 }
 
-.overviewNameLine:has(.overviewTakenByLine) :global(.med-avatar-sm) {
+.overviewNameLine :global(.med-avatar-sm) {
 	width: var(--overview-name-stack-height);
 	height: var(--overview-name-stack-height);
 }

--- a/frontend/src/pages/MedicationsPage.tsx
+++ b/frontend/src/pages/MedicationsPage.tsx
@@ -2397,6 +2397,7 @@ export function MedicationsPage() {
 			</MedicationEditCoordinator>
 
 			<RecordNowModal
+				existingPeople={existingPeople}
 				medication={recordNowMedication}
 				onClose={() => setRecordNowMedication(null)}
 				onRecord={recordAsNeededIntake}

--- a/frontend/src/test/components/RecordNowModal.test.tsx
+++ b/frontend/src/test/components/RecordNowModal.test.tsx
@@ -74,16 +74,18 @@ describe("RecordNowModal", () => {
 		setDefaultFormattingTimezone(null);
 	});
 
-	it("uses package defaults, supports None/self, and sends the stable key on retry", async () => {
+	it("uses the tablet default of 1, supports 0.5 steps and None/self, and sends the stable key on retry", async () => {
 		const onRecord = vi
 			.fn()
 			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
 			.mockResolvedValueOnce(response());
 		render(<RecordNowModal medication={medication()} onClose={vi.fn()} onRecord={onRecord} />);
 
-		expect(screen.getByRole("textbox")).toHaveValue("0.5");
+		expect(screen.getByRole("textbox")).toHaveValue("1");
 		expect(screen.getByText("asNeeded.record.stockEffect")).toBeInTheDocument();
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.confirm" }));
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.decreaseQuantity" }));
+		expect(screen.getByRole("textbox")).toHaveValue("0.5");
+		fireEvent.click(screen.getByRole("button", { name: "dose.take" }));
 		await screen.findByText("asNeeded.errors.network");
 		fireEvent.click(screen.getByRole("button", { name: "common.retry" }));
 
@@ -114,7 +116,7 @@ describe("RecordNowModal", () => {
 		expect(screen.getByRole("button", { name: "asNeeded.record.increaseQuantity" })).toBeDisabled();
 		fireEvent.change(screen.getByRole("textbox"), { target: { value: "2" } });
 		expect(screen.getByText("asNeeded.errors.invalidQuantity")).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "asNeeded.record.confirm" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "dose.take" })).toBeDisabled();
 	});
 
 	it("keeps the dialog pending and blocks duplicate submits until the latest response arrives", async () => {
@@ -127,7 +129,7 @@ describe("RecordNowModal", () => {
 		);
 		render(<RecordNowModal medication={medication()} onClose={vi.fn()} onRecord={onRecord} />);
 
-		const confirm = screen.getByRole("button", { name: "asNeeded.record.confirm" });
+		const confirm = screen.getByRole("button", { name: "dose.take" });
 		fireEvent.click(confirm);
 		fireEvent.click(confirm);
 		expect(onRecord).toHaveBeenCalledTimes(1);
@@ -136,6 +138,23 @@ describe("RecordNowModal", () => {
 
 		resolveRequest?.(response());
 		await screen.findByText("asNeeded.record.successTitle");
+	});
+
+	it("offers all existing people while retaining legacy replacement preselection", () => {
+		const replacementEvent = { ...response().event, person: "Alex", status: "reversed" as const, revision: 2 };
+		render(
+			<RecordNowModal
+				existingPeople={["Sam", "Alex"]}
+				medication={medication()}
+				replacementEvent={replacementEvent}
+				onClose={vi.fn()}
+				onRecord={vi.fn()}
+			/>
+		);
+
+		const person = screen.getByLabelText("asNeeded.record.person");
+		expect(person).toHaveValue("Alex");
+		expect(screen.getByRole("option", { name: "Sam" })).toBeInTheDocument();
 	});
 
 	it("creates a replacement only with the durable reversed event and replays the exact request", async () => {

--- a/frontend/src/test/context/AppContext.test.tsx
+++ b/frontend/src/test/context/AppContext.test.tsx
@@ -7,6 +7,7 @@ import type { Medication } from "../../types";
 const feedbackMock = vi.hoisted(() => ({ showFeedback: vi.fn() }));
 const authFetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init));
 const mockUseAuth = vi.fn();
+const mockUseAsNeededIntakes = vi.fn();
 const mockUseMedications = vi.fn();
 const mockUseSettings = vi.fn();
 const mockUseDoses = vi.fn();
@@ -27,6 +28,10 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("../../components/Auth", () => ({
 	useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("../../hooks/useAsNeededIntakes", () => ({
+	useAsNeededIntakes: () => mockUseAsNeededIntakes(),
 }));
 
 vi.mock("../../context/FeedbackContext", () => ({
@@ -151,6 +156,10 @@ describe("useAppContext", () => {
 
 		authFetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => fetch(input, init));
 		mockUseAuth.mockReturnValue({ user: { id: 7, username: "owner" }, authFetch: authFetchMock });
+		mockUseAsNeededIntakes.mockReturnValue({
+			recordAsNeededIntake: vi.fn(async () => ({ event: {}, inventory: {} })),
+			reverseAsNeededIntake: vi.fn(async () => ({ event: {}, inventory: {} })),
+		});
 
 		mockUseMedications.mockReturnValue({
 			meds,
@@ -328,6 +337,30 @@ describe("useAppContext", () => {
 		expect(result.current.existingPeople).toEqual(["Anna", "Max"]);
 		expect(result.current.stockThresholds.lowStockDays).toBe(10);
 		expect(result.current.settingsChanged).toBe(false);
+	});
+
+	it("silently refreshes medications after recording or reversing an as-needed intake", async () => {
+		const recordAsNeededIntake = vi.fn(async () => ({ event: {}, inventory: {} }));
+		const reverseAsNeededIntake = vi.fn(async () => ({ event: {}, inventory: {} }));
+		mockUseAsNeededIntakes.mockReturnValue({ recordAsNeededIntake, reverseAsNeededIntake });
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		await act(async () => {
+			await result.current.recordAsNeededIntake({
+				medicationId: 11,
+				quantity: 1,
+				person: null,
+				idempotencyKey: "intent-key",
+			});
+			await result.current.reverseAsNeededIntake({
+				eventId: "event-11",
+				expectedRevision: 1,
+				idempotencyKey: "undo-key",
+			});
+		});
+
+		expect(mockUseMedications().loadMeds).toHaveBeenCalledWith({ silent: true });
+		expect(mockUseMedications().loadMeds).toHaveBeenCalledTimes(3);
 	});
 
 	it("marks settings as changed when shareMedicationOverview differs", async () => {

--- a/frontend/src/test/hooks/useMedications.test.ts
+++ b/frontend/src/test/hooks/useMedications.test.ts
@@ -78,6 +78,47 @@ describe("useMedications", () => {
 		expect(authFetchMock).toHaveBeenCalledWith("/api/medications?includeObsolete=true");
 	});
 
+	it("silently refreshes medication data without toggling global loading", async () => {
+		let resolveRefresh: ((response: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined;
+		const refreshedMeds = [{ id: 2, name: "Refreshed" }];
+		(global.fetch as ReturnType<typeof vi.fn>).mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveRefresh = resolve;
+				})
+		);
+
+		const { result } = renderHook(() => useMedications());
+		let refresh: Promise<void> | undefined;
+		act(() => {
+			refresh = result.current.loadMeds({ silent: true });
+		});
+
+		expect(result.current.loading).toBe(false);
+		resolveRefresh?.({ ok: true, json: () => Promise.resolve(refreshedMeds) });
+		await act(async () => {
+			await refresh;
+		});
+		expect(result.current.loading).toBe(false);
+		expect(result.current.meds).toEqual(refreshedMeds);
+	});
+
+	it("keeps visible medication data when a silent refresh fails", async () => {
+		const initialMeds = [{ id: 1, name: "Visible" }];
+		(global.fetch as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(initialMeds) })
+			.mockRejectedValueOnce(new Error("Refresh failed"));
+		const { result } = renderHook(() => useMedications());
+
+		await act(async () => {
+			await result.current.loadMeds();
+			await result.current.loadMeds({ silent: true });
+		});
+
+		expect(result.current.loading).toBe(false);
+		expect(result.current.meds).toEqual(initialMeds);
+	});
+
 	it("handles API error gracefully", async () => {
 		(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Network error"));
 

--- a/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
+++ b/frontend/src/test/ui/dashboard-nowrap-spacing-contract.test.ts
@@ -95,10 +95,7 @@ describe("dashboard table and spacing contract", () => {
 		const scheduleName = blockFor(surfacesCss, ".time-main .med-name");
 		const scheduleAvatar = blockFor(surfacesCss, ".time-main .med-name:has(.med-generic-inline) .med-avatar-sm");
 		const overviewNameLine = blockFor(dashboardCss, ".overviewNameLine");
-		const overviewAvatar = blockFor(
-			dashboardCss,
-			".overviewNameLine:has(.overviewTakenByLine) :global(.med-avatar-sm)"
-		);
+		const overviewAvatar = blockFor(dashboardCss, ".overviewNameLine :global(.med-avatar-sm)");
 
 		expect(scheduleName).toMatch(
 			/--schedule-med-name-stack-height\s*:\s*calc\(1rem \* 1\.55 \+ 0\.1rem \+ 0\.875rem \* 1\.2\)/

--- a/shared/src/as-needed-intakes.test.ts
+++ b/shared/src/as-needed-intakes.test.ts
@@ -3,7 +3,7 @@ import { getAsNeededQuantityProfile, normalizeAsNeededQuantityMilli } from "./as
 
 describe("as-needed quantity profiles", () => {
 	it.each([
-		[{ packageType: "blister", medicationForm: "tablet", pillForm: "tablet" }, "pills", 0.5, 0.5, false, true],
+		[{ packageType: "blister", medicationForm: "tablet", pillForm: "tablet" }, "pills", 1, 0.5, false, true],
 		[{ packageType: "blister", medicationForm: "capsule", pillForm: "capsule" }, "pills", 1, 1, true, true],
 		[{ packageType: "liquid_container", medicationForm: "liquid" }, "ml", 1, 0.1, false, true],
 		[{ packageType: "inhaler", medicationForm: "tablet" }, "puffs", 1, 1, true, true],

--- a/shared/src/as-needed-intakes.ts
+++ b/shared/src/as-needed-intakes.ts
@@ -22,7 +22,7 @@ const WHOLE_PILL_PROFILE: AsNeededQuantityProfile = {
 
 const TABLET_PROFILE: AsNeededQuantityProfile = {
 	unit: "pills",
-	defaultQuantity: 0.5,
+	defaultQuantity: 1,
 	uiStep: 0.5,
 	wholeUnitsOnly: false,
 	measurable: true,


### PR DESCRIPTION
Closes #1051

Polishes the as-needed Take flow with a default quantity of one tablet, existing intake-user selection, uniform medication avatars, and comfortable success-state spacing. Medication data refreshes silently after Take or Undo so the visible page remains stable.