### PR TITLE
fix: simplify as-needed take and undo history

### DIFF
--- a/frontend/e2e/as-needed-record-now.spec.ts
+++ b/frontend/e2e/as-needed-record-now.spec.ts
@@ -1,15 +1,15 @@
 import { authFile, createMedicationViaAPI, deleteAllMedicationsViaAPI, expect, navigateTo, test } from "./fixtures";
 
-const MEDICATION_NAME = "As-needed record now";
+const medicationName = "As-needed Take and Undo";
 
-test.describe("As-needed Record now", () => {
+test.describe("As-needed Take and Undo history", () => {
 	test.use({ storageState: authFile });
 	test.describe.configure({ timeout: 90000 });
 
 	test.beforeEach(async () => {
 		await deleteAllMedicationsViaAPI();
 		await createMedicationViaAPI({
-			name: MEDICATION_NAME,
+			name: medicationName,
 			packageType: "blister",
 			medicationForm: "tablet",
 			packCount: 1,
@@ -28,245 +28,65 @@ test.describe("As-needed Record now", () => {
 		{ name: "desktop", size: { width: 1280, height: 720 } },
 		{ name: "mobile", size: { width: 390, height: 844 } },
 	]) {
-		test(`${viewport.name} includes a recorded as-needed intake in its owner report`, async ({ page }) => {
-			await page.setViewportSize(viewport.size);
-			await navigateTo(page, "/medications");
-			const medication = page.getByTestId("medication-row").filter({ hasText: MEDICATION_NAME });
-			await medication.getByRole("button", { name: /Take|Einnehmen/i }).click();
-			await page
-				.getByRole("dialog")
-				.last()
-				.getByRole("button", { name: /Take|Einnehmen/i })
-				.click();
-			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
-			const recordModal = page.getByRole("dialog").last();
-			await recordModal.getByLabel(/Close|Schließen/i).click();
-			await expect(recordModal).toBeHidden();
-
-			await page
-				.getByRole("button", { name: /Report|Bericht/i })
-				.first()
-				.click();
-			const reportModal = page.getByRole("dialog").filter({ hasText: /Medication Report|Medikamentenbericht/i });
-			await expect(reportModal).toBeVisible();
-			const future = new Date(Date.now() + 60_000);
-			const localFuture = new Date(future.getTime() - future.getTimezoneOffset() * 60_000).toISOString().slice(0, 16);
-			await reportModal.locator('input[type="datetime-local"]').last().fill(localFuture);
-			await reportModal.locator('label:has(input[name="format"][value="txt"])').click();
-			await reportModal.getByRole("button", { name: /Generate|Erstellen/i }).click();
-			const preview = reportModal.getByTestId("report-preview");
-			await expect(preview).toBeVisible();
-			await expect(preview).toContainText(/As-needed intakes|Einnahmen bei Bedarf/i);
-			await expect(preview).toContainText(/Active intake count|Aktive Einnahmen/i);
-		});
-
-		test(`${viewport.name} safely replays a lost response and reloads stock`, async ({ page }) => {
-			await page.setViewportSize(viewport.size);
-			await navigateTo(page, "/medications");
-			const medication = page.getByTestId("medication-row").filter({ hasText: MEDICATION_NAME });
-			await expect(medication).toBeVisible();
-			await medication.getByRole("button", { name: /Take|Einnehmen/i }).click();
-
-			let firstServerStatus: number | null = null;
-			let firstKey: string | null = null;
-			let lostResponse = true;
-			await page.route("**/api/medications/*/as-needed-intakes", async (route) => {
-				if (!lostResponse) return route.continue();
-				lostResponse = false;
-				firstKey = await route.request().headerValue("idempotency-key");
-				const response = await route.fetch();
-				firstServerStatus = response.status();
-				await route.abort("connectionreset");
-			});
-
-			await page
-				.getByRole("dialog")
-				.last()
-				.getByRole("button", { name: /Take|Einnehmen/i })
-				.click();
-			await expect(page.getByText(/result is uncertain|Ergebnis.*unklar/i)).toBeVisible();
-
-			const replay = page.waitForResponse((response) => response.url().includes("/as-needed-intakes"));
-			const reload = page.waitForResponse((response) =>
-				response.url().includes("/api/medications?includeObsolete=true")
-			);
-			await page.getByRole("button", { name: /Retry|Erneut/i }).click();
-			const replayResponse = await replay;
-			const reloadResponse = await reload;
-			expect(firstServerStatus).toBe(201);
-			expect(replayResponse.status()).toBe(200);
-			expect(await replayResponse.request().headerValue("idempotency-key")).toBe(firstKey);
-			expect((await reloadResponse.json()) as Array<{ asNeededStockEffect?: number }>).toEqual(
-				expect.arrayContaining([expect.objectContaining({ asNeededStockEffect: 1 })])
-			);
-			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
-			await expect(medication).toContainText(/9\s*\/\s*10/);
-		});
-	}
-
-	for (const viewport of [
-		{ name: "desktop detail", size: { width: 1280, height: 720 } },
-		{ name: "mobile detail", size: { width: 390, height: 844 } },
-	]) {
-		test(`${viewport.name} records from medication detail and refreshes its history`, async ({ page }) => {
+		test(`${viewport.name} takes and undoes a bounded active-only intake history without a global reload`, async ({
+			page,
+		}) => {
 			await page.setViewportSize(viewport.size);
 			await navigateTo(page, "/dashboard");
 			const overview = page.getByTestId("dashboard-overview-table");
-			await expect(overview).toBeVisible();
 			await overview
 				.getByTestId("dashboard-overview-row")
-				.filter({ hasText: MEDICATION_NAME })
-				.getByRole("button", { name: MEDICATION_NAME })
+				.filter({ hasText: medicationName })
+				.getByRole("button", { name: medicationName })
 				.click();
 
 			const detail = page
 				.getByRole("dialog")
-				.filter({ has: page.getByRole("heading", { name: MEDICATION_NAME }) })
+				.filter({ has: page.getByRole("heading", { name: medicationName }) })
 				.last();
-			await expect(detail).toBeVisible();
-			await expect(detail.getByRole("region", { name: /As-needed history|Bei-Bedarf-Verlauf/i })).toBeVisible();
-			await detail.getByRole("button", { name: /^(Take|Nehmen)$/ }).click();
+			const history = detail.getByRole("button", { name: "As-needed intake history" });
+			await expect(history).toHaveAttribute("aria-expanded", "false");
 
-			const create = page.waitForResponse(
+			await detail.getByRole("button", { name: "Take", exact: true }).click();
+			const takeModal = page.getByRole("dialog", { name: "Take as-needed medication" });
+			const takeResponse = page.waitForResponse(
 				(response) => response.url().includes("/as-needed-intakes") && response.request().method() === "POST"
 			);
-			await page
-				.getByRole("dialog", { name: /Take as-needed medication|Medikament bei Bedarf nehmen/i })
-				.getByRole("button", { name: /^(Take|Nehmen)$/ })
-				.click();
-			expect((await create).status()).toBe(201);
-			await expect(page.getByText(/Medication taken|Medikament eingenommen/i)).toBeVisible();
-			await page.goBack();
-			await expect(detail).toBeVisible();
-			await expect(detail.locator("article").first()).toContainText(/^1 pill|^1 Tablette/);
-			await detail
-				.getByLabel(/Close|Schließen/i)
-				.first()
-				.click();
-			await expect(detail).toBeHidden();
+			await takeModal.getByRole("button", { name: "Take", exact: true }).click();
+			expect((await takeResponse).status()).toBe(201);
+			await expect(takeModal.getByText("Medication taken")).toBeVisible();
+			await takeModal.getByLabel("Close").click();
+
+			const historyResponse = page.waitForResponse(
+				(response) => response.url().includes("/as-needed-intakes") && response.request().method() === "GET"
+			);
+			await history.click();
+			const requestUrl = new URL((await historyResponse).url());
+			expect(requestUrl.searchParams.get("includeReversed")).toBe("false");
+			expect(requestUrl.searchParams.get("limit")).toBe("10");
+			await expect(detail.getByText("1 pill")).toBeVisible();
+			await expect(detail.getByText(/Reverse|Correct|Correction|Reversed/)).toHaveCount(0);
+
+			let releaseRefresh: (() => void) | undefined;
+			let refreshStarted = false;
+			await page.route("**/api/medications?includeObsolete=true", async (route) => {
+				refreshStarted = true;
+				await new Promise<void>((resolve) => {
+					releaseRefresh = resolve;
+				});
+				await route.continue();
+			});
+			const undoResponse = page.waitForResponse(
+				(response) => response.url().includes("/api/as-needed-intakes/") && response.request().method() === "DELETE"
+			);
+			await detail.getByRole("button", { name: "Undo" }).click();
+			expect((await undoResponse).status()).toBe(204);
+			await expect.poll(() => refreshStarted).toBe(true);
+			await expect(page.locator(".dashboard-card-skeleton")).toHaveCount(0);
+			await expect(detail.getByText("1 pill")).toHaveCount(0);
+
+			releaseRefresh?.();
+			await expect(detail).toContainText("10 / 10");
 		});
 	}
-
-	test("records a named fractional tablet from the list, audits its correction, and locks the reversed journal", async ({
-		page,
-	}) => {
-		const name = "As-needed correction tablet";
-		await deleteAllMedicationsViaAPI();
-		await createMedicationViaAPI({
-			name,
-			takenBy: ["Alice"],
-			packageType: "blister",
-			medicationForm: "tablet",
-			packCount: 1,
-			blistersPerPack: 1,
-			pillsPerBlister: 10,
-			looseTablets: 0,
-			intakes: [],
-		});
-
-		await page.setViewportSize({ width: 1280, height: 720 });
-		await navigateTo(page, "/medications");
-		const medication = page.getByTestId("medication-row").filter({ hasText: name });
-		await medication.getByRole("button", { name: /Take|Einnehmen/i }).click();
-		const recordModal = page.getByRole("dialog").last();
-		await recordModal.getByLabel(/Person|Person/i).selectOption("Alice");
-		await recordModal.getByRole("button", { name: /Take|Einnehmen/i }).click();
-		await expect(recordModal.getByText(/Current stock:\s*9|Aktueller Bestand:\s*9/i)).toBeVisible();
-		await recordModal.getByLabel(/Close|Schließen/i).click();
-
-		await navigateTo(page, "/dashboard");
-		const overview = page.getByTestId("dashboard-overview-table");
-		await overview
-			.getByTestId("dashboard-overview-row")
-			.filter({ hasText: name })
-			.getByRole("button", { name })
-			.click();
-		const detail = page
-			.getByRole("dialog")
-			.filter({ has: page.getByRole("heading", { name }) })
-			.last();
-		const history = detail.getByRole("region", { name: /As-needed history|Bei-Bedarf-Verlauf/i });
-		await expect(history.getByText("Alice", { exact: true })).toBeVisible();
-
-		await history.getByRole("button", { name: /Add journal|Journal hinzufügen/i }).click();
-		let journal = page.locator(".journal-modal");
-		await journal.getByRole("textbox").fill("Initial correction journal");
-		await journal.getByRole("button", { name: /Save|Speichern/i }).click();
-		await expect(journal).toBeHidden();
-
-		await history.getByRole("button", { name: /Edit journal|Journal bearbeiten/i }).click();
-		journal = page.locator(".journal-modal");
-		await journal.getByRole("textbox").fill("Updated correction journal");
-		await journal.getByRole("button", { name: /Save|Speichern/i }).click();
-		await expect(journal).toBeHidden();
-		await expect(history.getByText("Updated correction journal")).toBeVisible();
-
-		await history.getByRole("button", { name: /Edit journal|Journal bearbeiten/i }).click();
-		journal = page.locator(".journal-modal");
-		await journal.getByRole("button", { name: /Delete|Löschen/i }).click();
-		await expect(journal).toBeHidden();
-
-		await history.getByRole("button", { name: /Add journal|Journal hinzufügen/i }).click();
-		journal = page.locator(".journal-modal");
-		await journal.getByRole("textbox").fill("Retained reversed journal");
-		await journal.getByRole("button", { name: /Save|Speichern/i }).click();
-		await expect(journal).toBeHidden();
-
-		await history.getByRole("button", { name: /Reverse|Stornieren/i }).click();
-		const reversal = page.getByRole("dialog").last();
-		await reversal.getByRole("button", { name: /Reverse intake|Einnahme stornieren/i }).click();
-		await expect(history.getByText(/Reversed|Storniert/i)).toBeVisible();
-
-		await history.getByRole("button", { name: /View journal|Journal ansehen/i }).click();
-		journal = page.locator(".journal-modal");
-		await expect(journal.getByRole("textbox")).toHaveValue("Retained reversed journal");
-		await expect(journal.getByRole("textbox")).toHaveAttribute("readonly", "");
-		await expect(journal.getByRole("button", { name: /Save|Speichern/i })).toHaveCount(0);
-		await expect(journal.getByRole("button", { name: /Delete|Löschen/i })).toHaveCount(0);
-		await journal.getByLabel(/Close|Schließen/i).click();
-
-		await history.getByRole("button", { name: /Record correction|Korrektur erfassen/i }).click();
-		const replacement = page.getByRole("dialog", { name: /Record corrected intake|Korrigierte Einnahme erfassen/i });
-		await replacement.getByRole("button", { name: /Record correction|Korrektur erfassen/i }).click();
-		await expect(replacement.getByText(/Correction recorded|Korrektur erfasst/i)).toBeVisible({ timeout: 15_000 });
-		await replacement.getByLabel(/Close|Schließen/i).click();
-		await expect(history.getByText(/Correction of event|Korrektur von Ereignis/i)).toBeVisible();
-		await expect(history.getByText(/^(Active|Aktiv)$/i)).toBeVisible();
-	});
-
-	test("records a topical None/self application from mobile detail without reducing measured stock", async ({
-		page,
-	}) => {
-		const name = "As-needed topical self";
-		await deleteAllMedicationsViaAPI();
-		await createMedicationViaAPI({
-			name,
-			packageType: "tube",
-			medicationForm: "topical",
-			packageAmountValue: 30,
-			looseTablets: 30,
-			intakes: [],
-		});
-
-		await page.setViewportSize({ width: 390, height: 844 });
-		await navigateTo(page, "/dashboard");
-		const overview = page.getByTestId("dashboard-overview-table");
-		await overview
-			.getByTestId("dashboard-overview-row")
-			.filter({ hasText: name })
-			.getByRole("button", { name })
-			.click();
-		const detail = page
-			.getByRole("dialog")
-			.filter({ has: page.getByRole("heading", { name }) })
-			.last();
-		await detail.getByRole("button", { name: /Take|Einnehmen/i }).click();
-		const recordModal = page.getByRole("dialog").last();
-		await recordModal.getByLabel(/Person|Person/i).selectOption("");
-		await expect(recordModal.getByText(/without changing the measured stock|ohne.*Bestand/i)).toBeVisible();
-		await recordModal.getByRole("button", { name: /Take|Einnehmen/i }).click();
-		await expect(recordModal.getByText(/Current stock:\s*30|Aktueller Bestand:\s*30/i)).toBeVisible();
-		await recordModal.getByLabel(/Close|Schließen/i).click();
-		await expect(detail.getByText(/No measurable stock effect|Kein messbarer Bestandseffekt/i)).toBeVisible();
-	});
 });

--- a/frontend/e2e/as-needed-take-polish.spec.ts
+++ b/frontend/e2e/as-needed-take-polish.spec.ts
@@ -55,7 +55,7 @@ test.describe("As-needed Take polish", () => {
 				.filter({ has: page.getByRole("heading", { name: MEDICATION_NAME }) })
 				.last();
 			await expect(detail).toBeVisible();
-			await detail.getByRole("button", { name: "Take" }).click();
+			await detail.getByRole("button", { name: "Take", exact: true }).click();
 			const modal = page.getByRole("dialog", { name: "Take as-needed medication" });
 			await expect(modal).toBeVisible();
 			await expect(modal.locator("#record-now-quantity")).toHaveValue("1");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,6 @@ import {
 } from "./context";
 import { useModalHistory } from "./hooks/useModalHistory";
 import { useScrollLock } from "./hooks/useScrollLock";
-import type { AsNeededIntakeEvent } from "./types";
 import { AppButton } from "./ui/primitives/AppButton";
 import { getMedicationIntakes } from "./utils/intake-schedule";
 
@@ -245,7 +244,7 @@ function AppContent() {
 		meds,
 		loadMeds,
 		recordAsNeededIntake,
-		reverseAsNeededIntake,
+		undoAsNeededIntake,
 		// Refill
 		showRefillModal,
 		setShowRefillModal,
@@ -326,7 +325,6 @@ function AppContent() {
 	const [showProfile, setShowProfile] = useState(false);
 	const [showAbout, setShowAbout] = useState(false);
 	const [detailRecordNowMedication, setDetailRecordNowMedication] = useState<(typeof meds)[number] | null>(null);
-	const [detailReplacementEvent, setDetailReplacementEvent] = useState<AsNeededIntakeEvent | null>(null);
 	const [asNeededHistoryRefreshVersion, setAsNeededHistoryRefreshVersion] = useState(0);
 	const [routeTransitionMaskActive, setRouteTransitionMaskActive] = useState(false);
 	const [showMainSwipeHint, setShowMainSwipeHint] = useState(shouldShowInitialMainSwipeHint);
@@ -348,7 +346,6 @@ function AppContent() {
 	}, []);
 	const dismissDetailRecordNow = useCallback(() => {
 		setDetailRecordNowMedication(null);
-		setDetailReplacementEvent(null);
 	}, []);
 	// History integration via the shared modal stack: pushes one entry on open,
 	// browser back (or closeModal) dismisses only the topmost modal.
@@ -359,9 +356,7 @@ function AppContent() {
 		"detail-record-now",
 		dismissDetailRecordNow,
 		{
-			state: detailRecordNowMedication
-				? { medicationId: detailRecordNowMedication.id, replacementEventId: detailReplacementEvent?.eventId }
-				: undefined,
+			state: detailRecordNowMedication ? { medicationId: detailRecordNowMedication.id } : undefined,
 		}
 	);
 
@@ -767,15 +762,9 @@ function AppContent() {
 						onOpenEditStockModal={handleOpenEditStockFromDetail}
 						onOpenRecordNow={() => {
 							if (!selectedMed) return;
-							setDetailReplacementEvent(null);
 							setDetailRecordNowMedication(selectedMed);
 						}}
-						onReplaceAsNeeded={(event) => {
-							if (!selectedMed) return;
-							setDetailReplacementEvent(event);
-							setDetailRecordNowMedication(selectedMed);
-						}}
-						onReverseAsNeeded={reverseAsNeededIntake}
+						onUndoAsNeeded={undoAsNeededIntake}
 						onCloseEditStockModal={closeEditStockModal}
 						onOpenUserFilter={openUserFilter}
 						refillPacks={refillPacks}
@@ -806,7 +795,6 @@ function AppContent() {
 					<RecordNowModal
 						existingPeople={ctx.existingPeople}
 						medication={detailRecordNowMedication}
-						replacementEvent={detailReplacementEvent}
 						onClose={closeDetailRecordNow}
 						onRecord={async (input) => {
 							const result = await recordAsNeededIntake(input);

--- a/frontend/src/components/AsNeededIntakeHistory.module.css
+++ b/frontend/src/components/AsNeededIntakeHistory.module.css
@@ -5,39 +5,41 @@
 }
 
 .headingRow,
-.headingBlock,
-.entryHeading {
+.entryHeading,
+.journal,
+.undoRow {
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 	gap: 0.65rem;
 }
 
-.headingRow {
-	justify-content: space-between;
-}
-
-.headingBlock {
-	flex-wrap: wrap;
-}
-
-.headingBlock h3 {
-	margin: 0;
+.disclosure {
+	padding-inline: 0;
 	color: var(--text-secondary);
 	font-size: 0.85rem;
+	font-weight: 700;
 	letter-spacing: 0.05em;
 	text-transform: uppercase;
 }
 
-.description,
+.chevron {
+	transition: transform 150ms ease;
+}
+
+.disclosure[aria-expanded="true"] .chevron {
+	transform: rotate(180deg);
+}
+
+.content {
+	margin-top: 0.75rem;
+}
+
 .state,
 .entry time,
 .entry p {
 	color: var(--text-secondary);
 	font-size: 0.875rem;
-}
-
-.description {
-	margin: 0.55rem 0 0.9rem;
 }
 
 .state {
@@ -60,7 +62,6 @@
 }
 
 .entryHeading {
-	justify-content: space-between;
 	flex-wrap: wrap;
 }
 
@@ -68,66 +69,38 @@
 	margin: 0;
 }
 
-.meta {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 0.65rem;
-	margin: 0;
+.person {
+	overflow-wrap: anywhere;
 }
 
-.meta div,
 .journal {
 	min-width: 0;
-	padding: 0.6rem;
+	padding: 0.35rem 0.5rem;
 	border-radius: 8px;
 	background: var(--bg-primary);
 }
 
-.meta dt {
-	color: var(--text-secondary);
-	font-size: 0.75rem;
-	font-weight: 700;
-	text-transform: uppercase;
-}
-
-.meta dd {
-	margin: 0.2rem 0 0;
-	overflow-wrap: anywhere;
-}
-
-.meta dd span {
-	display: block;
-	color: var(--text-secondary);
-	font-size: 0.75rem;
-}
-
 .journal p {
-	margin-top: 0.25rem;
+	min-width: 0;
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
 }
 
-.journalHeading {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 0.5rem;
+.undoRow {
+	justify-content: flex-end;
 }
 
-.entryActions {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-end;
-	gap: 0.5rem;
+.undoError {
+	color: var(--danger);
 }
 
 @media (max-width: 600px) {
 	.headingRow {
 		align-items: flex-start;
-		flex-direction: column;
 	}
 
-	.meta {
-		grid-template-columns: 1fr;
+	.journal {
+		align-items: flex-start;
+		flex-direction: column;
 	}
 }

--- a/frontend/src/components/AsNeededIntakeHistory.tsx
+++ b/frontend/src/components/AsNeededIntakeHistory.tsx
@@ -1,35 +1,22 @@
-import { Alert, Stack, Text } from "@mantine/core";
+import { Alert } from "@mantine/core";
 import { normalizeIntakeMood } from "@medassist/shared";
+import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AsNeededIntakeRequestError, useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
+import { useAsNeededIntakes } from "../hooks/useAsNeededIntakes";
 import { useIntakeJournal } from "../hooks/useIntakeJournal";
-import { useModalHistory } from "../hooks/useModalHistory";
-import type { AsNeededIntakeEvent, AsNeededIntakeMutationResponse } from "../types";
+import type { AsNeededIntakeEvent } from "../types";
 import { AppButton } from "../ui/primitives/AppButton";
-import { StatusBadge } from "../ui/primitives/StatusBadge";
 import { getNumericLocale, withFormattingTimezone } from "../utils/formatters";
 import { getIntakeMoodLabel } from "../utils/intake-mood";
 import classes from "./AsNeededIntakeHistory.module.css";
-import { ConfirmModal } from "./ConfirmModal";
 import { IntakeJournalModal } from "./intake-journal/IntakeJournalModal";
 
 type AsNeededIntakeHistoryProps = {
 	medicationId: number;
 	canRecordNow: boolean;
-	onRecordNow: () => void;
-	onReplace?: (event: AsNeededIntakeEvent) => void;
-	onReverse?: (input: {
-		eventId: string;
-		expectedRevision: number;
-		idempotencyKey: string;
-	}) => Promise<AsNeededIntakeMutationResponse>;
-};
-
-type ReversalIntent = {
-	event: AsNeededIntakeEvent;
-	idempotencyKey: string;
-	replaceAfter: boolean;
+	onTake: () => void;
+	onUndo?: (eventId: string) => Promise<void>;
 };
 
 function formatQuantity(value: number): string {
@@ -43,62 +30,21 @@ function formatTrustedDateTime(value: string): string {
 	);
 }
 
-function getReversalErrorKey(code: string): string {
-	if (code === "NETWORK_ERROR") return "asNeeded.reversal.errors.network";
-	if (code === "EVENT_VERSION_CONFLICT") return "asNeeded.reversal.errors.revision";
-	if (code === "IDEMPOTENCY_KEY_REUSED") return "asNeeded.reversal.errors.intentConflict";
-	if (code === "READ_ONLY" || code === "API_KEY_SCOPE_FORBIDDEN") return "asNeeded.errors.readOnly";
-	return "asNeeded.reversal.errors.generic";
-}
-
-function getJournalActionKey(event: AsNeededIntakeEvent): string {
-	if (event.status === "reversed") return "journal.actions.view";
-	if (event.journal) return "journal.actions.edit";
-	return "journal.actions.add";
-}
-
-export function AsNeededIntakeHistory({
-	medicationId,
-	canRecordNow,
-	onRecordNow,
-	onReplace,
-	onReverse,
-}: AsNeededIntakeHistoryProps) {
+export function AsNeededIntakeHistory({ medicationId, canRecordNow, onTake, onUndo }: AsNeededIntakeHistoryProps) {
 	const { t } = useTranslation();
 	const { listAsNeededIntakes } = useAsNeededIntakes();
+	const [expanded, setExpanded] = useState(false);
 	const [events, setEvents] = useState<AsNeededIntakeEvent[]>([]);
 	const [nextCursor, setNextCursor] = useState<string | null>(null);
-	const [loading, setLoading] = useState(true);
+	const [loading, setLoading] = useState(false);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const [error, setError] = useState(false);
-	const [reversalIntent, setReversalIntent] = useState<ReversalIntent | null>(null);
-	const [reversalPending, setReversalPending] = useState(false);
-	const [reversalError, setReversalError] = useState<string | null>(null);
-	const [actionNotice, setActionNotice] = useState<{ tone: "green" | "yellow" | "red"; key: string } | null>(null);
-	const [replacementReady, setReplacementReady] = useState<AsNeededIntakeEvent | null>(null);
-	const [journalTargetStatus, setJournalTargetStatus] = useState<AsNeededIntakeEvent["status"] | null>(null);
+	const [undoPendingIds, setUndoPendingIds] = useState<Set<string>>(() => new Set());
+	const [undoErrorIds, setUndoErrorIds] = useState<Set<string>>(() => new Set());
+	const requestedRef = useRef(false);
 	const requestVersionRef = useRef(0);
 	const firstPageAbortRef = useRef<AbortController | null>(null);
-	const actionFeedbackRef = useRef<HTMLDivElement>(null);
-	const refreshHistoryRef = useRef<() => Promise<void>>(async () => undefined);
-	const handleJournalEventReversed = useCallback(() => {
-		setActionNotice({ tone: "yellow", key: "journalReconciled" });
-		void refreshHistoryRef.current();
-	}, []);
-	const intakeJournal = useIntakeJournal({
-		manageProgrammaticClose: true,
-		onEventReversed: handleJournalEventReversed,
-	});
-	const dismissReversal = useCallback(() => {
-		setReversalIntent(null);
-		setReversalError(null);
-	}, []);
-	const { closeModal: closeReversal } = useModalHistory(
-		Boolean(reversalIntent),
-		"as-needed-reversal-confirm",
-		dismissReversal,
-		{ state: reversalIntent ? { eventId: reversalIntent.event.eventId } : undefined }
-	);
+	const intakeJournal = useIntakeJournal({ manageProgrammaticClose: true });
 
 	const loadFirstPage = useCallback(async () => {
 		firstPageAbortRef.current?.abort();
@@ -114,24 +60,25 @@ export function AsNeededIntakeHistory({
 			setEvents(result.events);
 			setNextCursor(result.nextCursor);
 		} catch {
-			if (requestVersion === requestVersionRef.current) setError(true);
+			if (!controller.signal.aborted && requestVersion === requestVersionRef.current) setError(true);
 		} finally {
 			if (requestVersion === requestVersionRef.current) setLoading(false);
 		}
 	}, [listAsNeededIntakes, medicationId]);
-	refreshHistoryRef.current = loadFirstPage;
 
 	useEffect(() => {
+		if (!expanded || requestedRef.current) return;
+		requestedRef.current = true;
 		void loadFirstPage();
-		return () => {
+	}, [expanded, loadFirstPage]);
+
+	useEffect(
+		() => () => {
 			firstPageAbortRef.current?.abort();
 			requestVersionRef.current += 1;
-		};
-	}, [loadFirstPage]);
-
-	useEffect(() => {
-		if (actionNotice || reversalError) actionFeedbackRef.current?.focus();
-	}, [actionNotice, reversalError]);
+		},
+		[]
+	);
 
 	const loadMore = async () => {
 		if (!nextCursor || loadingMore) return;
@@ -153,62 +100,30 @@ export function AsNeededIntakeHistory({
 		}
 	};
 
-	const beginReversal = (event: AsNeededIntakeEvent, replaceAfter: boolean) => {
-		setReversalIntent({ event, idempotencyKey: crypto.randomUUID(), replaceAfter });
-		setReversalError(null);
-		setActionNotice(null);
-		setReplacementReady(null);
-	};
-
-	const submitReversal = async () => {
-		if (!reversalIntent || !onReverse || reversalPending) return;
-		setReversalPending(true);
-		setReversalError(null);
+	const undo = async (eventId: string) => {
+		if (!onUndo || undoPendingIds.has(eventId)) return;
+		setUndoPendingIds((current) => new Set(current).add(eventId));
+		setUndoErrorIds((current) => {
+			const next = new Set(current);
+			next.delete(eventId);
+			return next;
+		});
 		try {
-			const result = await onReverse({
-				eventId: reversalIntent.event.eventId,
-				expectedRevision: reversalIntent.event.revision,
-				idempotencyKey: reversalIntent.idempotencyKey,
-			});
-			setEvents((current) => current.map((event) => (event.eventId === result.event.eventId ? result.event : event)));
-			if (reversalIntent.replaceAfter) {
-				setReplacementReady(result.event);
-				setActionNotice({
-					tone: result.inventory.reconciliationRequired ? "yellow" : "green",
-					key: result.inventory.reconciliationRequired ? "correctionReadyReconciliation" : "correctionReady",
-				});
-			} else {
-				setActionNotice({
-					tone: result.inventory.reconciliationRequired ? "yellow" : "green",
-					key: result.inventory.reconciliationRequired ? "reconciliation" : "reversed",
-				});
-			}
-			closeReversal();
-		} catch (requestError) {
-			if (requestError instanceof AsNeededIntakeRequestError) {
-				if (requestError.code === "EVENT_VERSION_CONFLICT") {
-					closeReversal();
-					setActionNotice({ tone: "red", key: "revisionChanged" });
-					await loadFirstPage();
-				} else {
-					setReversalError(getReversalErrorKey(requestError.code));
-				}
-			} else {
-				setReversalError("asNeeded.reversal.errors.generic");
-			}
+			await onUndo(eventId);
+			setEvents((current) => current.filter((event) => event.eventId !== eventId));
+		} catch {
+			setUndoErrorIds((current) => new Set(current).add(eventId));
 		} finally {
-			setReversalPending(false);
+			setUndoPendingIds((current) => {
+				const next = new Set(current);
+				next.delete(eventId);
+				return next;
+			});
 		}
 	};
 
 	const openJournal = (event: AsNeededIntakeEvent) => {
-		setJournalTargetStatus(event.status);
 		void intakeJournal.openJournalEditor(event.journal?.doseId ?? `as-needed:${event.eventId}`);
-	};
-
-	const closeJournal = () => {
-		setJournalTargetStatus(null);
-		intakeJournal.closeJournalEditor();
 	};
 
 	const saveJournal = async (
@@ -224,194 +139,108 @@ export function AsNeededIntakeHistory({
 		const deleted = await intakeJournal.deleteJournalNote();
 		if (!deleted) return;
 		await loadFirstPage();
-		closeJournal();
+		intakeJournal.closeJournalEditor();
 	};
-
-	if (!canRecordNow && !loading && !error && events.length === 0) return null;
-	const lifecycle = events[0]?.medication.lifecycle ?? (canRecordNow ? "active_no_schedule" : null);
-	let reversalConfirmLabel = t("asNeeded.reversal.confirm");
-	if (reversalPending) reversalConfirmLabel = t("asNeeded.reversal.saving");
-	else if (reversalError) reversalConfirmLabel = t("common.retry");
-	const replacedEventIds = new Set(
-		events.map((event) => event.replacementForEventId).filter((eventId): eventId is string => eventId !== null)
-	);
 
 	return (
 		<section className={classes.section} aria-labelledby="as-needed-history-title">
 			<div className={classes.headingRow}>
-				<div className={classes.headingBlock}>
-					<h3 id="as-needed-history-title">{t("asNeeded.history.title")}</h3>
-					{lifecycle ? <StatusBadge tone="info">{t(`asNeeded.lifecycle.${lifecycle}`)}</StatusBadge> : null}
-				</div>
+				<AppButton
+					type="button"
+					tone="ghost"
+					size="compact-sm"
+					className={classes.disclosure}
+					aria-controls="as-needed-history-content"
+					aria-expanded={expanded}
+					rightSection={<ChevronDown aria-hidden="true" className={classes.chevron} size={16} />}
+					onClick={() => setExpanded((current) => !current)}
+				>
+					<span id="as-needed-history-title">{t("asNeeded.history.title")}</span>
+				</AppButton>
 				{canRecordNow ? (
-					<AppButton type="button" tone="primary" size="xs" onClick={onRecordNow}>
-						{t("asNeeded.record.action")}
+					<AppButton type="button" tone="primary" size="xs" onClick={onTake}>
+						{t("dose.take")}
 					</AppButton>
 				) : null}
 			</div>
-			<p className={classes.description}>{t("asNeeded.history.description")}</p>
 
-			{loading ? <p className={classes.state}>{t("asNeeded.history.loading")}</p> : null}
-			{error ? (
-				<Alert color="red" title={t("asNeeded.history.errorTitle")}>
-					{t("asNeeded.history.errorMessage")}
-					<AppButton type="button" tone="secondary" size="xs" onClick={() => void loadFirstPage()}>
-						{t("asNeeded.history.retry")}
-					</AppButton>
-				</Alert>
-			) : null}
-			{actionNotice ? (
-				<Alert
-					ref={actionFeedbackRef}
-					tabIndex={-1}
-					color={actionNotice.tone}
-					title={t(`asNeeded.reversal.notice.${actionNotice.key}Title`)}
-				>
-					{t(`asNeeded.reversal.notice.${actionNotice.key}Message`)}
-					{replacementReady && onReplace ? (
-						<AppButton
-							type="button"
-							tone="primary"
-							size="xs"
-							onClick={() => {
-								onReplace(replacementReady);
-								setReplacementReady(null);
-								setActionNotice(null);
-							}}
-						>
-							{t("asNeeded.replacement.action")}
-						</AppButton>
-					) : null}
-				</Alert>
-			) : null}
-			{!loading && events.length === 0 ? <p className={classes.state}>{t("asNeeded.history.empty")}</p> : null}
+			<div id="as-needed-history-content" className={classes.content} hidden={!expanded}>
+				{expanded ? (
+					<>
+						{loading ? <p className={classes.state}>{t("asNeeded.history.loading")}</p> : null}
+						{error ? (
+							<Alert color="red" title={t("asNeeded.history.errorTitle")}>
+								{t("asNeeded.history.errorMessage")}
+								<AppButton type="button" tone="secondary" size="xs" onClick={() => void loadFirstPage()}>
+									{t("asNeeded.history.retry")}
+								</AppButton>
+							</Alert>
+						) : null}
+						{!loading && !error && events.length === 0 ? (
+							<p className={classes.state}>{t("asNeeded.history.empty")}</p>
+						) : null}
 
-			<div className={classes.list}>
-				{events.map((event) => {
-					const mood = normalizeIntakeMood(event.journal?.mood);
-					const canOpenJournal = event.status === "active" || event.journal !== null;
-					return (
-						<article className={classes.entry} key={event.eventId}>
-							<div className={classes.entryHeading}>
-								<strong>
-									{formatQuantity(event.quantity)}{" "}
-									{t(`asNeeded.units.${event.quantityUnit}`, { count: event.quantity })}
-								</strong>
-								<StatusBadge tone={event.status === "active" ? "success" : "danger"}>
-									{t(`asNeeded.history.status.${event.status}`)}
-								</StatusBadge>
-							</div>
-							<time dateTime={event.occurredAt}>{formatTrustedDateTime(event.occurredAt)}</time>
-							<dl className={classes.meta}>
-								<div>
-									<dt>{t("asNeeded.history.person")}</dt>
-									<dd>{event.person ?? t("asNeeded.record.noPerson")}</dd>
-								</div>
-								<div>
-									<dt>{t("asNeeded.history.stockEffect")}</dt>
-									<dd>
-										{event.stockEffect > 0 ? "−" : ""}
-										{formatQuantity(event.stockEffect)}{" "}
-										{t(`asNeeded.units.${event.quantityUnit}`, { count: event.stockEffect })}
-										<span>{t(`asNeeded.history.stockReason.${event.stockEffectReason}`)}</span>
-									</dd>
-								</div>
-							</dl>
-							{event.reversedAt ? (
-								<p>{t("asNeeded.history.reversedAt", { time: formatTrustedDateTime(event.reversedAt) })}</p>
-							) : null}
-							{event.replacementForEventId ? (
-								<p>{t("asNeeded.history.replacementFor", { eventId: event.replacementForEventId })}</p>
-							) : null}
-							<div className={classes.journal}>
-								<div className={classes.journalHeading}>
-									<strong>{t("asNeeded.history.journal")}</strong>
-									{canOpenJournal ? (
-										<AppButton type="button" tone="ghost" size="xs" onClick={() => openJournal(event)}>
-											{t(getJournalActionKey(event))}
-										</AppButton>
-									) : null}
-								</div>
-								{event.journal ? (
-									<p>
-										{[mood ? getIntakeMoodLabel(mood, t) : null, event.journal.note].filter(Boolean).join(" · ") ||
-											t("journal.history.noNote")}
-									</p>
-								) : (
-									<p>{t("asNeeded.history.noJournal")}</p>
-								)}
-							</div>
-							{event.status === "active" && onReverse ? (
-								<div className={classes.entryActions}>
-									<AppButton type="button" tone="danger" size="xs" onClick={() => beginReversal(event, false)}>
-										{t("asNeeded.reversal.action")}
-									</AppButton>
-									{event.medication.recordEligibility.eligible && onReplace ? (
-										<AppButton type="button" tone="secondary" size="xs" onClick={() => beginReversal(event, true)}>
-											{t("asNeeded.replacement.correctAction")}
-										</AppButton>
-									) : null}
-								</div>
-							) : null}
-							{event.status === "reversed" &&
-							!replacedEventIds.has(event.eventId) &&
-							replacementReady?.eventId !== event.eventId &&
-							event.medication.recordEligibility.eligible &&
-							onReplace ? (
-								<div className={classes.entryActions}>
-									<AppButton type="button" tone="secondary" size="xs" onClick={() => onReplace(event)}>
-										{t("asNeeded.replacement.action")}
-									</AppButton>
-								</div>
-							) : null}
-						</article>
-					);
-				})}
+						<div className={classes.list}>
+							{events.map((event) => {
+								const mood = normalizeIntakeMood(event.journal?.mood);
+								const undoPending = undoPendingIds.has(event.eventId);
+								return (
+									<article className={classes.entry} key={event.eventId}>
+										<div className={classes.entryHeading}>
+											<strong>
+												{formatQuantity(event.quantity)}{" "}
+												{t(`asNeeded.units.${event.quantityUnit}`, { count: event.quantity })}
+											</strong>
+											<time dateTime={event.occurredAt}>{formatTrustedDateTime(event.occurredAt)}</time>
+										</div>
+										{event.person ? (
+											<p className={classes.person}>
+												{t("asNeeded.history.person")}: {event.person}
+											</p>
+										) : null}
+										<div className={classes.journal}>
+											<p>
+												{event.journal
+													? [mood ? getIntakeMoodLabel(mood, t) : null, event.journal.note]
+															.filter(Boolean)
+															.join(" · ") || t("journal.history.noNote")
+													: t("asNeeded.history.noJournal")}
+											</p>
+											<AppButton type="button" tone="ghost" size="xs" onClick={() => openJournal(event)}>
+												{t(event.journal ? "journal.actions.edit" : "journal.actions.add")}
+											</AppButton>
+										</div>
+										<div className={classes.undoRow}>
+											{undoErrorIds.has(event.eventId) ? (
+												<p role="alert" className={classes.undoError}>
+													{t("asNeeded.undo.error")}
+												</p>
+											) : null}
+											{onUndo ? (
+												<AppButton
+													type="button"
+													tone="ghost"
+													size="xs"
+													loading={undoPending}
+													onClick={() => void undo(event.eventId)}
+												>
+													{t("dose.undoAction")}
+												</AppButton>
+											) : null}
+										</div>
+									</article>
+								);
+							})}
+						</div>
+						{nextCursor ? (
+							<AppButton type="button" tone="secondary" onClick={() => void loadMore()} disabled={loadingMore}>
+								{loadingMore ? t("asNeeded.history.loadingMore") : t("asNeeded.history.loadMore")}
+							</AppButton>
+						) : null}
+					</>
+				) : null}
 			</div>
-			{nextCursor ? (
-				<AppButton type="button" tone="secondary" onClick={() => void loadMore()} disabled={loadingMore}>
-					{loadingMore ? t("asNeeded.history.loadingMore") : t("asNeeded.history.loadMore")}
-				</AppButton>
-			) : null}
-			{reversalIntent ? (
-				<ConfirmModal
-					title={t(
-						reversalIntent.replaceAfter ? "asNeeded.replacement.reverseTitle" : "asNeeded.reversal.confirmTitle"
-					)}
-					message={
-						<Stack gap="sm">
-							<Text>
-								{t(
-									reversalIntent.replaceAfter
-										? "asNeeded.replacement.reverseMessage"
-										: "asNeeded.reversal.confirmMessage",
-									{
-										quantity: formatQuantity(reversalIntent.event.quantity),
-										unit: t(`asNeeded.units.${reversalIntent.event.quantityUnit}`, {
-											count: reversalIntent.event.quantity,
-										}),
-									}
-								)}
-							</Text>
-							{reversalError ? (
-								<Alert ref={actionFeedbackRef} tabIndex={-1} color="red">
-									{t(reversalError)}
-								</Alert>
-							) : null}
-						</Stack>
-					}
-					confirmLabel={reversalConfirmLabel}
-					cancelLabel={t("common.cancel")}
-					onConfirm={() => void submitReversal()}
-					onCancel={() => {
-						if (!reversalPending) closeReversal();
-					}}
-					isLoading={reversalPending}
-					confirmVariant="danger"
-					overlayClassName="nested-confirm"
-					captureEscape
-				/>
-			) : null}
+
 			<IntakeJournalModal
 				isOpen={intakeJournal.journalEditorOpen}
 				entry={intakeJournal.journalEvent}
@@ -419,13 +248,10 @@ export function AsNeededIntakeHistory({
 				isSaving={intakeJournal.journalEventSaving}
 				isDeleting={intakeJournal.journalEventDeleting}
 				error={intakeJournal.journalEventError}
-				onClose={closeJournal}
+				onClose={intakeJournal.closeJournalEditor}
 				onSave={saveJournal}
 				onDelete={deleteJournal}
-				readOnly={
-					journalTargetStatus === "reversed" ||
-					(intakeJournal.journalEvent?.eventType === "as_needed" && intakeJournal.journalEvent.status === "reversed")
-				}
+				readOnly={false}
 			/>
 		</section>
 	);

--- a/frontend/src/components/MedDetailModal.tsx
+++ b/frontend/src/components/MedDetailModal.tsx
@@ -25,14 +25,7 @@ import {
 import { Fragment, type MouseEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import type {
-	AsNeededIntakeEvent,
-	AsNeededIntakeMutationResponse,
-	Coverage,
-	Medication,
-	RefillEntry,
-	StockThresholds,
-} from "../types";
+import type { Coverage, Medication, RefillEntry, StockThresholds } from "../types";
 import {
 	allowsPillFormSelection,
 	getMedDisplayName,
@@ -141,12 +134,7 @@ export interface MedDetailModalProps {
 	onOpenMedicationEdit?: () => void;
 	onOpenEditStockModal?: () => void;
 	onOpenRecordNow?: () => void;
-	onReplaceAsNeeded?: (event: AsNeededIntakeEvent) => void;
-	onReverseAsNeeded?: (input: {
-		eventId: string;
-		expectedRevision: number;
-		idempotencyKey: string;
-	}) => Promise<AsNeededIntakeMutationResponse>;
+	onUndoAsNeeded?: (eventId: string) => Promise<void>;
 	onCloseEditStockModal: () => void;
 	onOpenUserFilter?: (person: string) => void;
 	showAsNeededHistory?: boolean;
@@ -191,8 +179,7 @@ export function MedDetailModal({
 	onOpenMedicationEdit,
 	onOpenEditStockModal,
 	onOpenRecordNow,
-	onReplaceAsNeeded,
-	onReverseAsNeeded,
+	onUndoAsNeeded,
 	onCloseEditStockModal,
 	onOpenUserFilter,
 	showAsNeededHistory = false,
@@ -943,9 +930,8 @@ export function MedDetailModal({
 							key={`${selectedMed.id}:${asNeededHistoryRefreshVersion}`}
 							medicationId={selectedMed.id}
 							canRecordNow={canRecordAsNeeded}
-							onRecordNow={() => onOpenRecordNow?.()}
-							onReplace={onReplaceAsNeeded}
-							onReverse={onReverseAsNeeded}
+							onTake={() => onOpenRecordNow?.()}
+							onUndo={onUndoAsNeeded}
 						/>
 					) : null}
 

--- a/frontend/src/components/RecordNowModal.tsx
+++ b/frontend/src/components/RecordNowModal.tsx
@@ -3,7 +3,7 @@ import { getAsNeededQuantityProfile, normalizeAsNeededQuantityMilli } from "@med
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AsNeededIntakeRequestError } from "../hooks/useAsNeededIntakes";
-import type { AsNeededIntakeEvent, AsNeededIntakeMutationResponse, Medication } from "../types";
+import type { AsNeededIntakeMutationResponse, Medication } from "../types";
 import { getMedDisplayName } from "../types";
 import { AppModal, AppModalFooter } from "../ui/modal/AppModal";
 import { AppButton } from "../ui/primitives/AppButton";
@@ -15,15 +15,13 @@ import { MedicationAvatar } from "./MedicationAvatar";
 
 type RecordNowModalProps = {
 	medication: Medication | null;
-	replacementEvent?: AsNeededIntakeEvent | null;
-	existingPeople?: string[];
+	existingPeople: string[];
 	onClose: () => void;
 	onRecord: (input: {
 		medicationId: number;
 		quantity: number;
 		person: string | null;
 		idempotencyKey: string;
-		replacementForEventId?: string | null;
 	}) => Promise<AsNeededIntakeMutationResponse>;
 };
 
@@ -36,7 +34,6 @@ function getErrorKey(code: string): string {
 	if (code === "INVALID_QUANTITY") return "asNeeded.errors.invalidQuantity";
 	if (code === "TOO_MANY_NEW_INTAKES") return "asNeeded.errors.rateLimited";
 	if (code === "IDEMPOTENCY_KEY_REUSED") return "asNeeded.errors.intentConflict";
-	if (code === "REPLACEMENT_NOT_ALLOWED" || code === "EVENT_NOT_FOUND") return "asNeeded.errors.replacementUnavailable";
 	if (code === "READ_ONLY" || code === "API_KEY_SCOPE_FORBIDDEN") return "asNeeded.errors.readOnly";
 	return "asNeeded.errors.generic";
 }
@@ -52,19 +49,10 @@ function formatTrustedDateTime(value: string): string {
 	);
 }
 
-export function RecordNowModal({
-	medication,
-	replacementEvent = null,
-	existingPeople = [],
-	onClose,
-	onRecord,
-}: RecordNowModalProps) {
+export function RecordNowModal({ medication, existingPeople, onClose, onRecord }: RecordNowModalProps) {
 	const { t } = useTranslation();
 	const profile = useMemo(() => getAsNeededQuantityProfile(medication ?? {}), [medication]);
-	const personOptions = useMemo(
-		() => mergePersonTags([...existingPeople, ...(medication?.takenBy ?? []), replacementEvent?.person]),
-		[existingPeople, medication?.takenBy, replacementEvent?.person]
-	);
+	const personOptions = useMemo(() => mergePersonTags(existingPeople), [existingPeople]);
 	const [quantity, setQuantity] = useState(String(profile.defaultQuantity));
 	const [person, setPerson] = useState("");
 	const [idempotencyKey, setIdempotencyKey] = useState("");
@@ -77,16 +65,14 @@ export function RecordNowModal({
 	useEffect(() => {
 		if (!medication) return;
 		const nextProfile = getAsNeededQuantityProfile(medication);
-		setQuantity(String(replacementEvent?.quantity ?? nextProfile.defaultQuantity));
-		setPerson(
-			replacementEvent?.person && medication.takenBy.includes(replacementEvent.person) ? replacementEvent.person : ""
-		);
+		setQuantity(String(nextProfile.defaultQuantity));
+		setPerson("");
 		setIdempotencyKey(crypto.randomUUID());
 		setPending(false);
 		setAttempted(false);
 		setError(null);
 		setResult(null);
-	}, [medication, replacementEvent]);
+	}, [medication]);
 
 	useEffect(() => {
 		if (error || result) feedbackRef.current?.focus();
@@ -98,7 +84,7 @@ export function RecordNowModal({
 	const quantityIsValid = normalizeAsNeededQuantityMilli(numericQuantity, profile) !== null;
 	const unitLabel = t(`asNeeded.units.${profile.unit}`, { count: numericQuantity });
 	const locked = pending || attempted;
-	let submitLabel = t(replacementEvent ? "asNeeded.replacement.confirm" : "dose.take");
+	let submitLabel = t("dose.take");
 	if (pending) {
 		submitLabel = t("asNeeded.record.saving");
 	} else if (error) {
@@ -121,7 +107,6 @@ export function RecordNowModal({
 					quantity: numericQuantity,
 					person: person || null,
 					idempotencyKey,
-					...(replacementEvent ? { replacementForEventId: replacementEvent.eventId } : {}),
 				})
 			);
 		} catch (requestError) {
@@ -141,7 +126,7 @@ export function RecordNowModal({
 			onClose={close}
 			opened
 			size={480}
-			title={t(replacementEvent ? "asNeeded.replacement.title" : "asNeeded.record.title")}
+			title={t("asNeeded.record.title")}
 			withCloseButton
 		>
 			<Stack gap="md">
@@ -156,13 +141,7 @@ export function RecordNowModal({
 				</Group>
 
 				{result ? (
-					<Alert
-						mb="md"
-						ref={feedbackRef}
-						tabIndex={-1}
-						color="green"
-						title={t(replacementEvent ? "asNeeded.replacement.successTitle" : "asNeeded.record.successTitle")}
-					>
+					<Alert mb="md" ref={feedbackRef} tabIndex={-1} color="green" title={t("asNeeded.record.successTitle")}>
 						{t("asNeeded.record.successMessage", {
 							quantity: formatQuantity(result.event.quantity),
 							unit: t(`asNeeded.units.${result.event.quantityUnit}`, { count: result.event.quantity }),
@@ -173,11 +152,6 @@ export function RecordNowModal({
 					</Alert>
 				) : (
 					<>
-						{replacementEvent ? (
-							<Text size="sm">
-								{t("asNeeded.replacement.description", { time: formatTrustedDateTime(replacementEvent.occurredAt) })}
-							</Text>
-						) : null}
 						<Text size="sm">{t("asNeeded.record.trustedTime")}</Text>
 						<fieldset disabled={locked} style={{ border: 0, margin: 0, padding: 0 }}>
 							<Stack gap="md">

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -64,12 +64,12 @@ export interface AppContextValue {
 	saving: boolean;
 	setSaving: React.Dispatch<React.SetStateAction<boolean>>;
 	uploadingImage: boolean;
-	loadMeds: () => void;
+	loadMeds: (options?: { silent?: boolean }) => Promise<void>;
 	deleteMed: (id: number, editingId: number | null, resetForm: () => void) => Promise<void>;
 	uploadMedImage: (medId: number, file: File) => Promise<void>;
 	deleteMedImage: (medId: number) => Promise<void>;
 	recordAsNeededIntake: ReturnType<typeof useAsNeededIntakes>["recordAsNeededIntake"];
-	reverseAsNeededIntake: ReturnType<typeof useAsNeededIntakes>["reverseAsNeededIntake"];
+	undoAsNeededIntake: ReturnType<typeof useAsNeededIntakes>["undoAsNeededIntake"];
 
 	// From useSettings (selected fields)
 	settings: ReturnType<typeof useSettings>["settings"];
@@ -308,13 +308,12 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		},
 		[asNeededIntakes.recordAsNeededIntake, medications.loadMeds]
 	);
-	const reverseAsNeededIntake = useCallback(
-		async (input: Parameters<typeof asNeededIntakes.reverseAsNeededIntake>[0]) => {
-			const result = await asNeededIntakes.reverseAsNeededIntake(input);
+	const undoAsNeededIntake = useCallback(
+		async (eventId: string) => {
+			await asNeededIntakes.undoAsNeededIntake(eventId);
 			void medications.loadMeds({ silent: true });
-			return result;
 		},
-		[asNeededIntakes.reverseAsNeededIntake, medications.loadMeds]
+		[asNeededIntakes.undoAsNeededIntake, medications.loadMeds]
 	);
 
 	// Schedule UI state
@@ -668,7 +667,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 			// From useMedications
 			...medications,
 			recordAsNeededIntake,
-			reverseAsNeededIntake,
+			undoAsNeededIntake,
 
 			// From useSettings
 			settings: settingsHook.settings,
@@ -851,7 +850,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 		[
 			medications,
 			recordAsNeededIntake,
-			reverseAsNeededIntake,
+			undoAsNeededIntake,
 			settingsHook,
 			doses,
 			intakeJournal,

--- a/frontend/src/hooks/useAsNeededIntakes.ts
+++ b/frontend/src/hooks/useAsNeededIntakes.ts
@@ -5,8 +5,7 @@ import type { AsNeededIntakeListResponse, AsNeededIntakeMutationResponse } from 
 export class AsNeededIntakeRequestError extends Error {
 	constructor(
 		public readonly code: string,
-		public readonly retryAfterSeconds: number | null = null,
-		public readonly currentRevision: number | null = null
+		public readonly retryAfterSeconds: number | null = null
 	) {
 		super(code);
 		this.name = "AsNeededIntakeRequestError";
@@ -16,24 +15,20 @@ export class AsNeededIntakeRequestError extends Error {
 async function getMutationError(response: Response): Promise<AsNeededIntakeRequestError> {
 	const retryAfter = Number.parseInt(response.headers.get("Retry-After") ?? "", 10);
 	let code = "UNKNOWN_ERROR";
-	let currentRevision: number | null = null;
 	try {
-		const body = (await response.json()) as { code?: unknown; currentRevision?: unknown };
+		const body = (await response.json()) as { code?: unknown };
 		if (typeof body.code === "string") code = body.code;
-		if (typeof body.currentRevision === "number" && Number.isSafeInteger(body.currentRevision)) {
-			currentRevision = body.currentRevision;
-		}
 	} catch {
 		// The translated UI uses stable fallbacks for malformed error responses.
 	}
-	return new AsNeededIntakeRequestError(code, Number.isFinite(retryAfter) ? retryAfter : null, currentRevision);
+	return new AsNeededIntakeRequestError(code, Number.isFinite(retryAfter) ? retryAfter : null);
 }
 
 export function useAsNeededIntakes() {
 	const { authFetch } = useAuth();
 	const listAsNeededIntakes = useCallback(
 		async (medicationId: number, cursor?: string, signal?: AbortSignal): Promise<AsNeededIntakeListResponse> => {
-			const query = new URLSearchParams({ includeReversed: "true", limit: "10" });
+			const query = new URLSearchParams({ includeReversed: "false", limit: "10" });
 			if (cursor) query.set("cursor", cursor);
 
 			let response: Response;
@@ -54,7 +49,6 @@ export function useAsNeededIntakes() {
 			quantity: number;
 			person: string | null;
 			idempotencyKey: string;
-			replacementForEventId?: string | null;
 		}): Promise<AsNeededIntakeMutationResponse> => {
 			let response: Response;
 			try {
@@ -64,7 +58,6 @@ export function useAsNeededIntakes() {
 					body: JSON.stringify({
 						quantity: input.quantity,
 						person: input.person,
-						...(input.replacementForEventId ? { replacementForEventId: input.replacementForEventId } : {}),
 					}),
 				});
 			} catch {
@@ -78,27 +71,20 @@ export function useAsNeededIntakes() {
 		[authFetch]
 	);
 
-	const reverseAsNeededIntake = useCallback(
-		async (input: {
-			eventId: string;
-			expectedRevision: number;
-			idempotencyKey: string;
-		}): Promise<AsNeededIntakeMutationResponse> => {
+	const undoAsNeededIntake = useCallback(
+		async (eventId: string): Promise<void> => {
 			let response: Response;
 			try {
-				response = await authFetch(`/api/as-needed-intakes/${input.eventId}/reversal`, {
-					method: "POST",
-					headers: { "Content-Type": "application/json", "Idempotency-Key": input.idempotencyKey },
-					body: JSON.stringify({ expectedRevision: input.expectedRevision }),
+				response = await authFetch(`/api/as-needed-intakes/${eventId}`, {
+					method: "DELETE",
 				});
 			} catch {
 				throw new AsNeededIntakeRequestError("NETWORK_ERROR");
 			}
 			if (!response.ok) throw await getMutationError(response);
-			return (await response.json()) as AsNeededIntakeMutationResponse;
 		},
 		[authFetch]
 	);
 
-	return { listAsNeededIntakes, recordAsNeededIntake, reverseAsNeededIntake };
+	return { listAsNeededIntakes, recordAsNeededIntake, undoAsNeededIntake };
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -239,44 +239,31 @@
   },
   "asNeeded": {
     "record": {
-      "action": "Nehmen",
-      "title": "Medikament bei Bedarf nehmen",
-      "trustedTime": "Die aktuelle Uhrzeit wird beim Einnehmen gespeichert.",
+      "title": "Bedarfsmedikament nehmen",
+      "trustedTime": "Beim Nehmen wird die aktuelle Uhrzeit gespeichert.",
       "quantity": "Menge ({{unit}})",
       "person": "Person",
       "noPerson": "Keine Person / selbst",
       "decreaseQuantity": "Menge verringern",
       "increaseQuantity": "Menge erhöhen",
       "stockEffect": "Der Bestand wird um {{quantity}} {{unit}} verringert.",
-      "noStockEffect": "Eine Anwendung wird erfasst, ohne den messbaren Bestand zu verändern.",
-      "confirm": "Nehmen",
+      "noStockEffect": "Eine Anwendung wird gespeichert, ohne den messbaren Bestand zu verändern.",
       "saving": "Einnahme wird gespeichert...",
-      "failedTitle": "Medikament wurde nicht eingenommen",
-      "successTitle": "Medikament eingenommen",
-      "successMessage": "{{quantity}} {{unit}} um {{time}} eingenommen. Aktueller Bestand: {{stock}}.",
+      "failedTitle": "Medikament wurde nicht genommen",
+      "successTitle": "Medikament genommen",
+      "successMessage": "{{quantity}} {{unit}} um {{time}} genommen. Aktueller Bestand: {{stock}}.",
       "reconciliationRequired": "Packungskonfiguration und aktueller Bestand sollten geprüft werden."
-    },
-    "lifecycle": {
-      "active_no_schedule": "Aktiv ohne Einnahmeplan",
-      "active_scheduled": "Aktiv mit Einnahmeplan",
-      "ended": "Beendet",
-      "obsolete": "Obsolet"
     },
     "history": {
       "title": "Bedarfseinnahmen",
-      "description": "Erfasste Bedarfseinnahmen einschließlich Korrekturen und Tagebuchkontext.",
       "loading": "Bedarfseinnahmen werden geladen...",
       "loadingMore": "Weitere Einträge werden geladen...",
-      "empty": "Noch keine Bedarfseinnahmen erfasst.",
+      "empty": "Noch kein Bedarfsmedikament genommen.",
       "loadMore": "Mehr laden",
       "retry": "Erneut versuchen",
       "errorTitle": "Verlauf nicht verfügbar",
       "errorMessage": "Der Verlauf der Bedarfseinnahmen konnte nicht geladen werden. Versuche es erneut.",
       "person": "Person",
-      "stockEffect": "Bestandswirkung",
-      "reversedAt": "Storniert am {{time}}",
-      "replacementFor": "Korrektur des Ereignisses {{eventId}}",
-      "journal": "Tagebuch",
       "noJournal": "Kein Tagebucheintrag.",
       "status": {
         "active": "Aktiv",
@@ -305,52 +292,17 @@
     "errors": {
       "network": "Das Ergebnis ist wegen einer unterbrochenen Verbindung unklar. Erneut versuchen prüft sicher dieselbe Einnahme.",
       "insufficientStock": "Für diese Menge ist nicht genug Bestand vorhanden. Prüfe den echten Bestand vor dem nächsten Versuch.",
-      "stockUnresolvable": "Der aktuelle Bestand kann nicht sicher bestimmt werden. Korrigiere ihn, bevor du eine Einnahme erfasst.",
-      "notEligible": "Dieses Medikament kann nicht mehr ohne Einnahmeplan erfasst werden. Aktualisiere die Medikamentenliste.",
-      "invalidPerson": "Die ausgewählte Person ist diesem Medikament nicht mehr zugeordnet.",
+      "stockUnresolvable": "Der aktuelle Bestand kann nicht sicher bestimmt werden. Korrigiere ihn, bevor du das Medikament nimmst.",
+      "notEligible": "Dieses Medikament kann hier nicht mehr ohne Einnahmeplan genommen werden. Aktualisiere die Medikamentenliste.",
+      "invalidPerson": "Die ausgewählte Person ist für dieses Konto nicht mehr verfügbar.",
       "invalidQuantity": "Gib eine für diesen Packungstyp gültige Menge ein.",
       "rateLimited": "Es wurden zu viele neue Einnahmen angefordert. Versuche dieselbe Einnahme nach {{seconds}} Sekunden erneut.",
       "intentConflict": "Diese Anfrage kollidiert mit einer früheren Anfrage. Schließe den Dialog und beginne erneut.",
-      "replacementUnavailable": "Diese Korrektur kann nicht mehr mit der ausgewählten Einnahme verknüpft werden. Aktualisiere den Verlauf und versuche es erneut.",
-      "readOnly": "Mit diesem schreibgeschützten Zugriff kann keine Einnahme erfasst werden.",
-      "generic": "Die Einnahme konnte nicht erfasst werden. Versuche dieselbe Einnahme erneut oder brich ab."
+      "readOnly": "Mit diesem schreibgeschützten Zugriff kann kein Medikament genommen werden.",
+      "generic": "Das Medikament konnte nicht als genommen gespeichert werden. Versuche dieselbe Einnahme erneut oder brich ab."
     },
-    "replacement": {
-      "action": "Korrektur erfassen",
-      "correctAction": "Korrigieren",
-      "title": "Korrigierte Einnahme erfassen",
-      "description": "Dies erstellt eine separate Einnahme, die mit dem stornierten Ereignis vom {{time}} verknüpft ist.",
-      "confirm": "Korrektur erfassen",
-      "successTitle": "Korrektur erfasst",
-      "reverseTitle": "Einnahme korrigieren",
-      "reverseMessage": "Die ursprüngliche Einnahme von {{quantity}} {{unit}} muss zuerst storniert werden. Ihr Prüfverlauf bleibt erhalten, auch wenn du abbrichst oder die Ersetzung fehlschlägt."
-    },
-    "reversal": {
-      "action": "Stornieren",
-      "confirmTitle": "Einnahme stornieren",
-      "confirmMessage": "Die erfasste Einnahme von {{quantity}} {{unit}} stornieren? Nur ihre gespeicherte Bestandswirkung wird wiederhergestellt und der Prüfverlauf bleibt erhalten.",
-      "confirm": "Einnahme stornieren",
-      "saving": "Wird storniert...",
-      "errors": {
-        "network": "Das Ergebnis ist wegen einer unterbrochenen Verbindung unklar. Erneut versuchen verwendet sicher dieselbe Stornierung.",
-        "revision": "Diese Einnahme wurde geändert. Der Verlauf wurde aktualisiert; prüfe ihn vor einem neuen Versuch.",
-        "intentConflict": "Diese Stornierung kollidiert mit einer anderen Einnahme. Schließe die Bestätigung und beginne erneut.",
-        "generic": "Die Einnahme konnte nicht storniert werden. Versuche dieselbe Stornierung erneut oder brich ab."
-      },
-      "notice": {
-        "reversedTitle": "Einnahme storniert",
-        "reversedMessage": "Die gespeicherte Bestandswirkung wurde wiederhergestellt und das Original bleibt im Verlauf.",
-        "reconciliationTitle": "Einnahme storniert – Bestand prüfen",
-        "reconciliationMessage": "Die gespeicherte Bestandswirkung wurde wiederhergestellt, aber der aktuelle Bestand übersteigt nun die konfigurierte Packungskapazität.",
-        "correctionReadyTitle": "Ursprüngliche Einnahme storniert",
-        "correctionReadyMessage": "Erfasse die Korrektur jetzt als separate Einnahme oder kehre später zu diesem stornierten Ereignis zurück.",
-        "correctionReadyReconciliationTitle": "Original storniert – Bestand prüfen",
-        "correctionReadyReconciliationMessage": "Der Bestand übersteigt nun die konfigurierte Kapazität. Prüfe ihn und erfasse die Korrektur anschließend bei Bedarf separat.",
-        "revisionChangedTitle": "Verlauf aktualisiert",
-        "revisionChangedMessage": "Die Einnahme wurde geändert, bevor die Stornierung abgeschlossen war. Prüfe den aktualisierten Eintrag.",
-        "journalReconciledTitle": "Journal aktualisiert",
-        "journalReconciledMessage": "Die Einnahme wurde storniert, während ihr Journal geöffnet war. Der aktuelle schreibgeschützte Eintrag wird jetzt angezeigt."
-      }
+    "undo": {
+      "error": "Die Einnahme konnte nicht rückgängig gemacht werden. Versuche es erneut."
     }
   },
   "form": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -239,7 +239,6 @@
   },
   "asNeeded": {
     "record": {
-      "action": "Take",
       "title": "Take as-needed medication",
       "trustedTime": "The current time is saved when you take it.",
       "quantity": "Quantity ({{unit}})",
@@ -248,35 +247,23 @@
       "decreaseQuantity": "Decrease quantity",
       "increaseQuantity": "Increase quantity",
       "stockEffect": "This will reduce stock by {{quantity}} {{unit}}.",
-      "noStockEffect": "This records one application without changing the measured stock.",
-      "confirm": "Take",
+      "noStockEffect": "One application will be saved without changing the measured stock.",
       "saving": "Saving intake...",
       "failedTitle": "Medication was not taken",
       "successTitle": "Medication taken",
       "successMessage": "Took {{quantity}} {{unit}} at {{time}}. Current stock: {{stock}}.",
       "reconciliationRequired": "The package configuration and current stock should be checked."
     },
-    "lifecycle": {
-      "active_no_schedule": "Active without schedule",
-      "active_scheduled": "Active with schedule",
-      "ended": "Ended",
-      "obsolete": "Obsolete"
-    },
     "history": {
-      "title": "As-needed history",
-      "description": "Recorded as-needed intakes, including corrections and journal context.",
+      "title": "As-needed intake history",
       "loading": "Loading as-needed history...",
       "loadingMore": "Loading more...",
-      "empty": "No as-needed intakes recorded yet.",
+      "empty": "No as-needed medication taken yet.",
       "loadMore": "Load more",
       "retry": "Retry",
       "errorTitle": "History unavailable",
       "errorMessage": "The as-needed history could not be loaded. Try again.",
       "person": "Person",
-      "stockEffect": "Stock effect",
-      "reversedAt": "Reversed {{time}}",
-      "replacementFor": "Correction of event {{eventId}}",
-      "journal": "Journal",
       "noJournal": "No journal entry.",
       "status": {
         "active": "Active",
@@ -305,52 +292,17 @@
     "errors": {
       "network": "The result is uncertain because the connection was interrupted. Retry to safely check the same intake.",
       "insufficientStock": "There is not enough stock for this quantity. Check the real stock before trying again.",
-      "stockUnresolvable": "The current stock cannot be determined safely. Correct the stock before recording an intake.",
-      "notEligible": "This medication can no longer be recorded without a schedule. Refresh the medication list.",
-      "invalidPerson": "The selected person is no longer assigned to this medication.",
+      "stockUnresolvable": "The current stock cannot be determined safely. Correct the stock before taking the medication.",
+      "notEligible": "This medication can no longer be taken here without a schedule. Refresh the medication list.",
+      "invalidPerson": "The selected person is no longer available for this account.",
       "invalidQuantity": "Enter a valid quantity for this package type.",
       "rateLimited": "Too many new intakes were requested. Retry the same intake after {{seconds}} seconds.",
       "intentConflict": "This intake request conflicts with an earlier request. Close the dialog and start again.",
-      "replacementUnavailable": "This correction can no longer be linked to the selected intake. Refresh the history and try again.",
-      "readOnly": "This account access is read-only and cannot record an intake.",
-      "generic": "The intake could not be recorded. Retry the same intake or cancel."
+      "readOnly": "This account access is read-only and cannot take medication.",
+      "generic": "The medication could not be saved as taken. Retry the same intake or cancel."
     },
-    "replacement": {
-      "action": "Record correction",
-      "correctAction": "Correct",
-      "title": "Record corrected intake",
-      "description": "This creates a separate intake linked to the reversed event from {{time}}.",
-      "confirm": "Record correction",
-      "successTitle": "Correction recorded",
-      "reverseTitle": "Correct intake",
-      "reverseMessage": "The original {{quantity}} {{unit}} intake must first be reversed. Its audit record remains even if you cancel or the replacement fails."
-    },
-    "reversal": {
-      "action": "Reverse",
-      "confirmTitle": "Reverse intake",
-      "confirmMessage": "Reverse the recorded {{quantity}} {{unit}} intake? This restores only its stored stock effect and keeps the audit record.",
-      "confirm": "Reverse intake",
-      "saving": "Reversing...",
-      "errors": {
-        "network": "The result is uncertain because the connection was interrupted. Retry safely uses the same reversal request.",
-        "revision": "This intake changed. The history has been refreshed; review it before trying again.",
-        "intentConflict": "This reversal request conflicts with another intake. Close the confirmation and start again.",
-        "generic": "The intake could not be reversed. Retry the same reversal or cancel."
-      },
-      "notice": {
-        "reversedTitle": "Intake reversed",
-        "reversedMessage": "The stored stock effect was restored and the original remains in history.",
-        "reconciliationTitle": "Intake reversed — check stock",
-        "reconciliationMessage": "The stored stock effect was restored, but current stock now exceeds the configured package capacity.",
-        "correctionReadyTitle": "Original intake reversed",
-        "correctionReadyMessage": "Record the correction as a separate intake now, or return to this reversed event later.",
-        "correctionReadyReconciliationTitle": "Original reversed — check stock",
-        "correctionReadyReconciliationMessage": "Stock now exceeds configured capacity. Review it, then record the correction separately if appropriate.",
-        "revisionChangedTitle": "History updated",
-        "revisionChangedMessage": "The intake changed before the reversal completed. Review the refreshed entry.",
-        "journalReconciledTitle": "Journal refreshed",
-        "journalReconciledMessage": "The intake was reversed while its journal was open. The latest read-only entry is now shown."
-      }
+    "undo": {
+      "error": "The intake could not be undone. Try again."
     }
   },
   "form": {

--- a/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
+++ b/frontend/src/test/components/AsNeededIntakeHistory.test.tsx
@@ -1,32 +1,24 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AsNeededIntakeHistory } from "../../components/AsNeededIntakeHistory";
-import { AsNeededIntakeRequestError } from "../../hooks/useAsNeededIntakes";
 import type { AsNeededIntakeEvent } from "../../types";
 
 const listAsNeededIntakes = vi.fn();
 const openJournalEditor = vi.fn();
-
-const intakeJournal = {
-	journalEditorOpen: false,
-	journalEvent: null,
-	journalEventLoading: false,
-	journalEventSaving: false,
-	journalEventDeleting: false,
-	journalEventError: null,
-	openJournalEditor,
-	closeJournalEditor: vi.fn(),
-	saveJournalNote: vi.fn(),
-	deleteJournalNote: vi.fn(),
-};
-
-vi.mock("../../hooks/useAsNeededIntakes", async (importActual) => ({
-	...(await importActual<typeof import("../../hooks/useAsNeededIntakes")>()),
-	useAsNeededIntakes: () => ({ listAsNeededIntakes }),
-}));
-
+vi.mock("../../hooks/useAsNeededIntakes", () => ({ useAsNeededIntakes: () => ({ listAsNeededIntakes }) }));
 vi.mock("../../hooks/useIntakeJournal", () => ({
-	useIntakeJournal: () => intakeJournal,
+	useIntakeJournal: () => ({
+		journalEditorOpen: false,
+		journalEvent: null,
+		journalEventLoading: false,
+		journalEventSaving: false,
+		journalEventDeleting: false,
+		journalEventError: null,
+		openJournalEditor,
+		closeJournalEditor: vi.fn(),
+		saveJournalNote: vi.fn(),
+		deleteJournalNote: vi.fn(),
+	}),
 }));
 
 function event(overrides: Partial<AsNeededIntakeEvent> = {}): AsNeededIntakeEvent {
@@ -46,13 +38,13 @@ function event(overrides: Partial<AsNeededIntakeEvent> = {}): AsNeededIntakeEven
 		},
 		occurredAt: "2026-08-15T12:30:00.000Z",
 		recordedAt: "2026-08-15T12:30:01.000Z",
-		quantity: 0.5,
+		quantity: 1,
 		quantityUnit: "pills",
 		person: "Alex",
 		source: "owner_as_needed",
 		status: "active",
 		revision: 1,
-		stockEffect: 0.5,
+		stockEffect: 1,
 		stockEffectReason: "applied",
 		stockCutoffAt: null,
 		replacementForEventId: null,
@@ -62,205 +54,36 @@ function event(overrides: Partial<AsNeededIntakeEvent> = {}): AsNeededIntakeEven
 	};
 }
 
-function deferred<T>() {
-	let resolve!: (value: T) => void;
-	const promise = new Promise<T>((resolvePromise) => {
-		resolve = resolvePromise;
-	});
-	return { promise, resolve };
-}
-
-function reversalResponse(source: AsNeededIntakeEvent): {
-	event: AsNeededIntakeEvent;
-	inventory: { reconciliationRequired: boolean };
-} {
-	return {
-		event: {
-			...source,
-			status: "reversed",
-			revision: source.revision + 1,
-			stockEffect: 0,
-			reversedAt: "2026-08-15T13:00:00.000Z",
-		},
-		inventory: { reconciliationRequired: false },
-	};
-}
-
 describe("AsNeededIntakeHistory", () => {
-	afterEach(() => {
-		vi.clearAllMocks();
+	afterEach(() => vi.clearAllMocks());
+
+	it("stays collapsed and lazy until opened, requesting active-only bounded history", async () => {
+		listAsNeededIntakes.mockResolvedValue({ events: [event()], nextCursor: null });
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onTake={vi.fn()} />);
+		expect(listAsNeededIntakes).not.toHaveBeenCalled();
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.title" }));
+		await screen.findByText("asNeeded.history.person: Alex");
+		expect(listAsNeededIntakes).toHaveBeenCalledWith(9, undefined, expect.any(AbortSignal));
+		expect(screen.queryByText(/Reverse|Correct|Correction|reversed/i)).not.toBeInTheDocument();
 	});
 
-	it("renders active and reversed corrections with trusted times, journal context, person and stock reason", async () => {
-		listAsNeededIntakes.mockResolvedValueOnce({
-			events: [
-				event({
-					journal: {
-						doseId: "as-needed:event-1",
-						mood: "better",
-						note: "Helped quickly",
-						createdAt: "x",
-						updatedAt: "x",
-					},
-				}),
-				event({
-					eventId: "event-0",
-					status: "reversed",
-					person: null,
-					stockEffect: 0,
-					stockEffectReason: "superseded_by_correction",
-					reversedAt: "2026-08-15T13:00:00.000Z",
-					replacementForEventId: "event-1",
-					journal: null,
-				}),
-			],
-			nextCursor: null,
-		});
-		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
-
-		await screen.findByText("asNeeded.history.title");
-		expect(screen.getByText("asNeeded.lifecycle.active_no_schedule")).toBeInTheDocument();
-		expect(screen.getByText("Alex")).toBeInTheDocument();
-		expect(screen.getByText("asNeeded.record.noPerson")).toBeInTheDocument();
-		expect(screen.getByText("asNeeded.history.stockReason.applied")).toBeInTheDocument();
-		expect(screen.getByText("asNeeded.history.stockReason.superseded_by_correction")).toBeInTheDocument();
-		expect(screen.getByText("asNeeded.history.replacementFor")).toBeInTheDocument();
-		expect(screen.getByText("asNeeded.history.noJournal")).toBeInTheDocument();
-		expect(screen.getByText(/Helped quickly/)).toBeInTheDocument();
-		const times = document.querySelectorAll("time");
-		expect(times).toHaveLength(2);
-		expect(times[0]).toHaveAttribute("dateTime", "2026-08-15T12:30:00.000Z");
-	});
-
-	it("hides empty history when intake is ineligible, but keeps the eligible empty state and Record now action", async () => {
-		listAsNeededIntakes.mockResolvedValue({ events: [], nextCursor: null });
-		const { rerender } = render(<AsNeededIntakeHistory medicationId={9} canRecordNow={false} onRecordNow={vi.fn()} />);
-		await waitFor(() => expect(screen.queryByText("asNeeded.history.title")).not.toBeInTheDocument());
-
-		const onRecordNow = vi.fn();
-		rerender(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={onRecordNow} />);
-		await screen.findByText("asNeeded.history.empty");
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.action" }));
-		expect(onRecordNow).toHaveBeenCalledOnce();
-	});
-
-	it("retries safe failures and deduplicates cursor pages", async () => {
+	it("takes through the ordinary action, pages compact entries, keeps journal active, and removes Undo immediately", async () => {
+		const onTake = vi.fn();
+		const onUndo = vi.fn().mockResolvedValue(undefined);
 		listAsNeededIntakes
-			.mockRejectedValueOnce(new Error("offline"))
-			.mockResolvedValueOnce({ events: [event()], nextCursor: "cursor-2" })
-			.mockResolvedValueOnce({ events: [event(), event({ eventId: "event-2", person: "Bea" })], nextCursor: null });
-		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
-
-		await screen.findByText("asNeeded.history.errorMessage");
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.retry" }));
-		await screen.findByText("Alex");
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.loadMore" }));
-		await screen.findByText("Bea");
-		expect(screen.getAllByText("Alex")).toHaveLength(1);
-		expect(screen.getAllByText("Bea")).toHaveLength(1);
-		expect(listAsNeededIntakes).toHaveBeenLastCalledWith(9, "cursor-2");
-	});
-
-	it("aborts stale first-page work and ignores its late response after medication changes", async () => {
-		const first = deferred<{ events: AsNeededIntakeEvent[]; nextCursor: string | null }>();
-		listAsNeededIntakes.mockImplementationOnce((_id: number, _cursor: string | undefined, signal: AbortSignal) => {
-			expect(signal.aborted).toBe(false);
-			return first.promise;
-		});
-		listAsNeededIntakes.mockResolvedValueOnce({
-			events: [event({ medicationId: 10, person: "New" })],
-			nextCursor: null,
-		});
-		const { rerender } = render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
-		rerender(<AsNeededIntakeHistory medicationId={10} canRecordNow onRecordNow={vi.fn()} />);
-
-		await screen.findByText("New");
-		first.resolve({ events: [event({ person: "Stale" })], nextCursor: null });
-		await waitFor(() => expect(screen.queryByText("Stale")).not.toBeInTheDocument());
-		expect(listAsNeededIntakes.mock.calls[0][2].aborted).toBe(true);
-	});
-
-	it("reverses only active events, retries with the same key, and retains the reversed audit entry", async () => {
-		const active = event();
-		const reversed = event({
-			eventId: "event-old",
-			status: "reversed",
-			stockEffect: 0,
-			reversedAt: "2026-08-15T13:00:00.000Z",
-		});
-		const onReverse = vi
-			.fn()
-			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
-			.mockResolvedValueOnce(reversalResponse(active));
-		listAsNeededIntakes.mockResolvedValueOnce({ events: [active, reversed], nextCursor: null });
-		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} onReverse={onReverse} />);
-
-		await screen.findByText("asNeeded.reversal.action");
-		expect(screen.getAllByText("asNeeded.reversal.action")).toHaveLength(1);
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.action" }));
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.confirm" }));
-		await screen.findByText("asNeeded.reversal.errors.network");
-		fireEvent.click(screen.getByRole("button", { name: "common.retry" }));
-		await screen.findByText("asNeeded.reversal.notice.reversedTitle");
-		expect(onReverse).toHaveBeenCalledTimes(2);
-		expect(onReverse.mock.calls[0][0]).toEqual(onReverse.mock.calls[1][0]);
-		expect(onReverse.mock.calls[0][0]).toMatchObject({ eventId: "event-1", expectedRevision: 1 });
-		expect(screen.getAllByText("asNeeded.history.status.reversed")).toHaveLength(2);
-	});
-
-	it("closes the stale confirmation, refreshes, and never applies a 409 reversal locally", async () => {
-		const active = event();
-		const onReverse = vi.fn().mockRejectedValue(new AsNeededIntakeRequestError("EVENT_VERSION_CONFLICT", null, 2));
-		listAsNeededIntakes.mockResolvedValueOnce({ events: [active], nextCursor: null }).mockResolvedValueOnce({
-			events: [event({ eventId: "event-new", revision: 2, person: "Refreshed" })],
-			nextCursor: null,
-		});
-		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} onReverse={onReverse} />);
-
-		await screen.findByText("asNeeded.reversal.action");
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.action" }));
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.confirm" }));
-		await screen.findByText("asNeeded.reversal.notice.revisionChangedTitle");
-		await screen.findByText("Refreshed");
-		expect(screen.queryByText("asNeeded.reversal.confirmTitle")).not.toBeInTheDocument();
-		expect(listAsNeededIntakes).toHaveBeenCalledTimes(2);
-	});
-
-	it("offers correction only after a successful reversal and passes the reversed event to Record now", async () => {
-		const active = event();
-		const onReverse = vi.fn().mockResolvedValue(reversalResponse(active));
-		const onReplace = vi.fn();
-		listAsNeededIntakes.mockResolvedValueOnce({ events: [active], nextCursor: null });
-		render(
-			<AsNeededIntakeHistory
-				medicationId={9}
-				canRecordNow
-				onRecordNow={vi.fn()}
-				onReverse={onReverse}
-				onReplace={onReplace}
-			/>
-		);
-
-		await screen.findByText("asNeeded.replacement.correctAction");
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.correctAction" }));
-		expect(onReplace).not.toHaveBeenCalled();
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.reversal.confirm" }));
-		await screen.findByText("asNeeded.reversal.notice.correctionReadyTitle");
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.action" }));
-		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ eventId: "event-1", status: "reversed" }));
-	});
-
-	it("opens the active journal with its opaque as-needed anchor and keeps reversed entries view-only", async () => {
-		listAsNeededIntakes.mockResolvedValueOnce({
-			events: [event(), event({ eventId: "event-old", status: "reversed", journal: null })],
-			nextCursor: null,
-		});
-		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onRecordNow={vi.fn()} />);
-
-		await screen.findByText("asNeeded.history.title");
-		const addButtons = screen.getAllByRole("button", { name: "journal.actions.add" });
-		expect(addButtons).toHaveLength(1);
-		fireEvent.click(addButtons[0]);
+			.mockResolvedValueOnce({ events: [event()], nextCursor: "next" })
+			.mockResolvedValueOnce({ events: [event({ eventId: "event-2", person: null })], nextCursor: null });
+		render(<AsNeededIntakeHistory medicationId={9} canRecordNow onTake={onTake} onUndo={onUndo} />);
+		fireEvent.click(screen.getByRole("button", { name: "dose.take" }));
+		expect(onTake).toHaveBeenCalledOnce();
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.title" }));
+		await screen.findByText("asNeeded.history.person: Alex");
+		fireEvent.click(screen.getByRole("button", { name: "journal.actions.add" }));
 		expect(openJournalEditor).toHaveBeenCalledWith("as-needed:event-1");
+		fireEvent.click(screen.getByRole("button", { name: "asNeeded.history.loadMore" }));
+		await waitFor(() => expect(listAsNeededIntakes).toHaveBeenLastCalledWith(9, "next"));
+		fireEvent.click(screen.getAllByRole("button", { name: "dose.undoAction" })[0]);
+		await waitFor(() => expect(screen.queryByText("Alex")).not.toBeInTheDocument());
+		expect(onUndo).toHaveBeenCalledWith("event-1");
 	});
 });

--- a/frontend/src/test/components/RecordNowModal.test.tsx
+++ b/frontend/src/test/components/RecordNowModal.test.tsx
@@ -79,7 +79,9 @@ describe("RecordNowModal", () => {
 			.fn()
 			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
 			.mockResolvedValueOnce(response());
-		render(<RecordNowModal medication={medication()} onClose={vi.fn()} onRecord={onRecord} />);
+		render(
+			<RecordNowModal existingPeople={["Alex"]} medication={medication()} onClose={vi.fn()} onRecord={onRecord} />
+		);
 
 		expect(screen.getByRole("textbox")).toHaveValue("1");
 		expect(screen.getByText("asNeeded.record.stockEffect")).toBeInTheDocument();
@@ -105,6 +107,7 @@ describe("RecordNowModal", () => {
 	it("enforces topical one-application semantics and leaves no measured stock effect", () => {
 		render(
 			<RecordNowModal
+				existingPeople={["Alex"]}
 				medication={medication({ packageType: "tube", medicationForm: "topical" })}
 				onClose={vi.fn()}
 				onRecord={vi.fn()}
@@ -127,7 +130,9 @@ describe("RecordNowModal", () => {
 					resolveRequest = resolve;
 				})
 		);
-		render(<RecordNowModal medication={medication()} onClose={vi.fn()} onRecord={onRecord} />);
+		render(
+			<RecordNowModal existingPeople={["Alex"]} medication={medication()} onClose={vi.fn()} onRecord={onRecord} />
+		);
 
 		const confirm = screen.getByRole("button", { name: "dose.take" });
 		fireEvent.click(confirm);
@@ -140,51 +145,14 @@ describe("RecordNowModal", () => {
 		await screen.findByText("asNeeded.record.successTitle");
 	});
 
-	it("offers all existing people while retaining legacy replacement preselection", () => {
-		const replacementEvent = { ...response().event, person: "Alex", status: "reversed" as const, revision: 2 };
+	it("offers all existing people for an ordinary Take without a replacement mode", () => {
 		render(
-			<RecordNowModal
-				existingPeople={["Sam", "Alex"]}
-				medication={medication()}
-				replacementEvent={replacementEvent}
-				onClose={vi.fn()}
-				onRecord={vi.fn()}
-			/>
+			<RecordNowModal existingPeople={["Sam", "Alex"]} medication={medication()} onClose={vi.fn()} onRecord={vi.fn()} />
 		);
 
 		const person = screen.getByLabelText("asNeeded.record.person");
-		expect(person).toHaveValue("Alex");
+		expect(person).toHaveValue("");
 		expect(screen.getByRole("option", { name: "Sam" })).toBeInTheDocument();
-	});
-
-	it("creates a replacement only with the durable reversed event and replays the exact request", async () => {
-		const replacementEvent = response().event;
-		const onRecord = vi
-			.fn()
-			.mockRejectedValueOnce(new AsNeededIntakeRequestError("NETWORK_ERROR"))
-			.mockResolvedValueOnce({
-				...response(),
-				event: { ...response().event, replacementForEventId: replacementEvent.eventId },
-			});
-		render(
-			<RecordNowModal
-				medication={medication()}
-				replacementEvent={{ ...replacementEvent, status: "reversed", revision: 2, stockEffect: 0 }}
-				onClose={vi.fn()}
-				onRecord={onRecord}
-			/>
-		);
-
-		expect(screen.getByText("asNeeded.replacement.description")).toBeInTheDocument();
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.replacement.confirm" }));
-		await screen.findByText("asNeeded.errors.network");
-		fireEvent.click(screen.getByRole("button", { name: "common.retry" }));
-		await screen.findByText("asNeeded.replacement.successTitle");
-		expect(onRecord).toHaveBeenCalledTimes(2);
-		expect(onRecord.mock.calls[0][0]).toEqual(onRecord.mock.calls[1][0]);
-		expect(onRecord.mock.calls[0][0]).toMatchObject({
-			replacementForEventId: "event-8",
-			idempotencyKey: "modal-intent-key",
-		});
+		expect(screen.queryByText(/replacement|correction/i)).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/test/context/AppContext.test.tsx
+++ b/frontend/src/test/context/AppContext.test.tsx
@@ -158,7 +158,7 @@ describe("useAppContext", () => {
 		mockUseAuth.mockReturnValue({ user: { id: 7, username: "owner" }, authFetch: authFetchMock });
 		mockUseAsNeededIntakes.mockReturnValue({
 			recordAsNeededIntake: vi.fn(async () => ({ event: {}, inventory: {} })),
-			reverseAsNeededIntake: vi.fn(async () => ({ event: {}, inventory: {} })),
+			undoAsNeededIntake: vi.fn(async () => undefined),
 		});
 
 		mockUseMedications.mockReturnValue({
@@ -339,10 +339,10 @@ describe("useAppContext", () => {
 		expect(result.current.settingsChanged).toBe(false);
 	});
 
-	it("silently refreshes medications after recording or reversing an as-needed intake", async () => {
+	it("silently refreshes medications after taking or undoing an as-needed intake", async () => {
 		const recordAsNeededIntake = vi.fn(async () => ({ event: {}, inventory: {} }));
-		const reverseAsNeededIntake = vi.fn(async () => ({ event: {}, inventory: {} }));
-		mockUseAsNeededIntakes.mockReturnValue({ recordAsNeededIntake, reverseAsNeededIntake });
+		const undoAsNeededIntake = vi.fn(async () => undefined);
+		mockUseAsNeededIntakes.mockReturnValue({ recordAsNeededIntake, undoAsNeededIntake });
 		const { result } = renderHook(() => useAppContext(), { wrapper });
 
 		await act(async () => {
@@ -352,11 +352,7 @@ describe("useAppContext", () => {
 				person: null,
 				idempotencyKey: "intent-key",
 			});
-			await result.current.reverseAsNeededIntake({
-				eventId: "event-11",
-				expectedRevision: 1,
-				idempotencyKey: "undo-key",
-			});
+			await result.current.undoAsNeededIntake("event-11");
 		});
 
 		expect(mockUseMedications().loadMeds).toHaveBeenCalledWith({ silent: true });

--- a/frontend/src/test/hooks/useAsNeededIntakes.test.ts
+++ b/frontend/src/test/hooks/useAsNeededIntakes.test.ts
@@ -52,44 +52,24 @@ describe("useAsNeededIntakes", () => {
 		).rejects.toEqual(expect.objectContaining({ code: "TOO_MANY_NEW_INTAKES", retryAfterSeconds: 17 }));
 	});
 
-	it("posts a reversal with its stable intent key and exposes the current revision from a conflict", async () => {
-		authFetchMock.mockResolvedValue({
-			ok: false,
-			headers: new Headers(),
-			json: async () => ({ code: "EVENT_VERSION_CONFLICT", currentRevision: 3 }),
-		});
+	it("deletes an owner intake through the Undo endpoint", async () => {
+		authFetchMock.mockResolvedValue({ ok: true });
 		const { result } = renderHook(() => useAsNeededIntakes());
 
-		await expect(
-			result.current.reverseAsNeededIntake({ eventId: "event-42", expectedRevision: 2, idempotencyKey: "reverse-key" })
-		).rejects.toEqual(expect.objectContaining({ code: "EVENT_VERSION_CONFLICT", currentRevision: 3 }));
-		expect(authFetchMock).toHaveBeenCalledWith(
-			"/api/as-needed-intakes/event-42/reversal",
-			expect.objectContaining({
-				method: "POST",
-				headers: { "Content-Type": "application/json", "Idempotency-Key": "reverse-key" },
-				body: JSON.stringify({ expectedRevision: 2 }),
-			})
-		);
+		await expect(result.current.undoAsNeededIntake("event-42")).resolves.toBeUndefined();
+		expect(authFetchMock).toHaveBeenCalledWith("/api/as-needed-intakes/event-42", { method: "DELETE" });
 	});
 
-	it("includes a replacement link only when the caller supplies one", async () => {
-		authFetchMock.mockResolvedValue({ ok: true, json: async () => ({ event: {}, inventory: {} }) });
+	it("lists active-only bounded history with cursors", async () => {
+		const response = { events: [], nextCursor: "next-page" };
+		const controller = new AbortController();
+		authFetchMock.mockResolvedValue({ ok: true, json: async () => response });
 		const { result } = renderHook(() => useAsNeededIntakes());
 
-		await result.current.recordAsNeededIntake({
-			medicationId: 42,
-			quantity: 1,
-			person: null,
-			idempotencyKey: "replacement-key",
-			replacementForEventId: "reversed-event",
-		});
-
+		await expect(result.current.listAsNeededIntakes(42, "cursor-1", controller.signal)).resolves.toBe(response);
 		expect(authFetchMock).toHaveBeenCalledWith(
-			"/api/medications/42/as-needed-intakes",
-			expect.objectContaining({
-				body: JSON.stringify({ quantity: 1, person: null, replacementForEventId: "reversed-event" }),
-			})
+			"/api/medications/42/as-needed-intakes?includeReversed=false&limit=10&cursor=cursor-1",
+			{ signal: controller.signal }
 		);
 	});
 
@@ -103,19 +83,6 @@ describe("useAsNeededIntakes", () => {
 		await expect(
 			result.current.recordAsNeededIntake({ medicationId: 1, quantity: 1, person: null, idempotencyKey: "network-key" })
 		).rejects.toEqual(expect.objectContaining({ code: "NETWORK_ERROR" }));
-	});
-
-	it("lists corrected history with a bounded cursor request and forwards cancellation", async () => {
-		const response = { events: [], nextCursor: "next-page" };
-		const controller = new AbortController();
-		authFetchMock.mockResolvedValue({ ok: true, json: async () => response });
-		const { result } = renderHook(() => useAsNeededIntakes());
-
-		await expect(result.current.listAsNeededIntakes(42, "cursor-1", controller.signal)).resolves.toBe(response);
-		expect(authFetchMock).toHaveBeenCalledWith(
-			"/api/medications/42/as-needed-intakes?includeReversed=true&limit=10&cursor=cursor-1",
-			{ signal: controller.signal }
-		);
 	});
 
 	it("maps unavailable history responses and transport failures to safe errors", async () => {


### PR DESCRIPTION
Closes #1052

Simplifies as-needed intake history to the familiar **Take** and **Undo** flow. Undo removes the intake and restores stock; history stays collapsed and loads only its compact active entries.