### PR TITLE
fix: use Take label for as-needed actions

### DIFF
--- a/frontend/src/components/medications/MedicationListSection.tsx
+++ b/frontend/src/components/medications/MedicationListSection.tsx
@@ -243,7 +243,7 @@ export function MedicationListSection({
 														leftSection={<Plus size={14} aria-hidden="true" />}
 														onClick={() => onRecordNow?.(med)}
 													>
-														{t("asNeeded.record.action")}
+														{t("dose.take")}
 													</AppButton>
 												) : null}
 											</div>

--- a/frontend/src/test/components/MedicationListSection.test.tsx
+++ b/frontend/src/test/components/MedicationListSection.test.tsx
@@ -68,7 +68,7 @@ describe("MedicationListSection", () => {
 		expect(screen.getByText("form.blisters.noRegularSchedule")).toBeInTheDocument();
 	});
 
-	it("offers Record now only when the page has confirmed an active zero-schedule medication", () => {
+	it("offers Take only when the page has confirmed an active zero-schedule medication", () => {
 		const onRecordNow = vi.fn();
 		const eligible = createMedication({ intakes: [] });
 		const scheduled = createMedication({
@@ -81,7 +81,7 @@ describe("MedicationListSection", () => {
 			onRecordNow,
 		});
 
-		fireEvent.click(screen.getByRole("button", { name: "asNeeded.record.action" }));
+		fireEvent.click(screen.getByRole("button", { name: "dose.take" }));
 		expect(onRecordNow).toHaveBeenCalledWith(eligible);
 		expect(screen.getAllByText("form.blisters.noRegularSchedule")).toHaveLength(1);
 	});


### PR DESCRIPTION
Closes #1058

Replaces the removed `asNeeded.record.action` key in `MedicationListSection` with the existing `dose.take` label and updates the focused regression test.

Local validation:
- `CI=true npm run test:run -- src/test/components/MedicationListSection.test.tsx` (4 passed)
- `npm run check` (frontend Biome and TypeScript passed)