### PR TITLE
test: wait for seeded dashboard medications

### DIFF
--- a/frontend/e2e/button-height-contract.spec.ts
+++ b/frontend/e2e/button-height-contract.spec.ts
@@ -746,6 +746,9 @@ test.describe("Button height contract", () => {
 							],
 						});
 						await navigateTo(page, "/dashboard");
+						const todayBlock = page.locator(".day-block.today");
+						await expect(todayBlock).toContainText(takeMedName, { timeout: 10000 });
+						await expect(todayBlock).toContainText(skipMedName, { timeout: 10000 });
 
 						const takeRow = page.locator(".time-row", { hasText: takeMedName }).first();
 						await expect(takeRow).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
Closes #1075

Wait for both API-seeded German medication names in today's dashboard block before locating dose action rows. This removes the render race without changing application behavior.