### PR TITLE
test: stabilize collapsed today E2E fixtures

### DIFF
--- a/frontend/e2e/button-height-contract.spec.ts
+++ b/frontend/e2e/button-height-contract.spec.ts
@@ -749,12 +749,12 @@ test.describe("Button height contract", () => {
 						await page.reload();
 						await page.waitForLoadState("networkidle");
 						const todayBlock = page.locator(".day-block.today");
-						await expect(todayBlock).toContainText(takeMedName, { timeout: 10000 });
-						await expect(todayBlock).toContainText(skipMedName, { timeout: 10000 });
 						if (await todayBlock.evaluate((element) => element.classList.contains("collapsed"))) {
 							await todayBlock.locator(".day-divider.clickable").click();
 							await expect(todayBlock).not.toHaveClass(/collapsed/, { timeout: 10000 });
 						}
+						await expect(todayBlock).toContainText(takeMedName, { timeout: 10000 });
+						await expect(todayBlock).toContainText(skipMedName, { timeout: 10000 });
 
 						const takeRow = page.locator(".time-row", { hasText: takeMedName }).first();
 						await expect(takeRow).toBeVisible({ timeout: 10000 });

--- a/frontend/e2e/mobile-modal-history.spec.ts
+++ b/frontend/e2e/mobile-modal-history.spec.ts
@@ -108,14 +108,13 @@ test.describe("Mobile modal browser back", () => {
 			timeout: 15000,
 		});
 
-		const doseItem = page.locator(".dose-item").first();
-		await expect(doseItem).toBeVisible({ timeout: 15000 });
-		await doseItem.getByRole("button", { name: /Take|Nehmen/i }).click();
-
 		const collapsedTodayDivider = page.locator(".day-block.today.collapsed .day-divider.clickable").first();
 		if (await collapsedTodayDivider.isVisible().catch(() => false)) {
 			await collapsedTodayDivider.click();
 		}
+		const doseItem = page.locator(".dose-item").first();
+		await expect(doseItem).toBeVisible({ timeout: 15000 });
+		await doseItem.getByRole("button", { name: /Take|Nehmen/i }).click();
 
 		const noteButton = page
 			.locator(".dose-item")


### PR DESCRIPTION
Closes #1091

Expands an intentionally collapsed today block before mobile dose-action and history E2E assertions. This carries the minimal combined, already-validated test correction only.