### PR TITLE
test: stabilize E2E reliability fixtures

### DIFF
--- a/frontend/e2e/app-shell.spec.ts
+++ b/frontend/e2e/app-shell.spec.ts
@@ -5,6 +5,7 @@ import {
 	deleteAllMedicationsViaAPI,
 	expect,
 	navigateTo,
+	relativeLocalDateTime,
 	test,
 } from "./fixtures";
 
@@ -111,7 +112,7 @@ test.describe("Public Share Routes", () => {
 				{
 					usage: 1,
 					every: 1,
-					start: new Date().toISOString().slice(0, 16),
+					start: relativeLocalDateTime(0, 8),
 					intakeRemindersEnabled: false,
 					takenBy: "Alice",
 				},

--- a/frontend/e2e/button-height-contract.spec.ts
+++ b/frontend/e2e/button-height-contract.spec.ts
@@ -3,8 +3,10 @@ import {
 	authFile,
 	createMedicationViaAPI,
 	deleteAllMedicationsViaAPI,
+	expandDayBlock,
 	expect,
 	navigateTo,
+	relativeLocalDateTime,
 	test,
 	updateSettingsViaAPI,
 } from "./fixtures";
@@ -12,9 +14,7 @@ import {
 const MED_NAME = "Button Height Guard Med";
 
 function dueIntakeStart(): string {
-	const startDate = new Date();
-	startDate.setDate(startDate.getDate() - 1);
-	return startDate.toISOString().slice(0, 16);
+	return relativeLocalDateTime(-1, 8);
 }
 
 function actionGroupSelector() {
@@ -503,6 +503,7 @@ test.describe("Button height contract", () => {
 	test.describe.configure({ mode: "serial", timeout: 90000 });
 
 	test.beforeAll(async () => {
+		await updateSettingsViaAPI({ stockCalculationMode: "manual" });
 		await deleteAllMedicationsViaAPI();
 		await createMedicationViaAPI({
 			name: MED_NAME,
@@ -525,6 +526,7 @@ test.describe("Button height contract", () => {
 
 	test.afterAll(async () => {
 		await deleteAllMedicationsViaAPI();
+		await updateSettingsViaAPI({ stockCalculationMode: "automatic" });
 	});
 
 	for (const viewport of [
@@ -677,11 +679,7 @@ test.describe("Button height contract", () => {
 					await navigateTo(page, "/dashboard");
 
 					const todayBlock = page.locator(".day-block.today");
-					await expect(todayBlock).toBeVisible({ timeout: 10000 });
-					if (await todayBlock.evaluate((element) => element.classList.contains("collapsed"))) {
-						await todayBlock.locator(".day-divider.clickable").click();
-						await expect(todayBlock).not.toHaveClass(/collapsed/, { timeout: 10000 });
-					}
+					await expandDayBlock(todayBlock);
 					await expect(todayBlock).toContainText(medName, { timeout: 10000 });
 					const skipButton = todayBlock.getByRole("button", { name: /^Skip$/ }).first();
 					await expect(skipButton).toBeVisible({ timeout: 10000 });
@@ -753,10 +751,7 @@ test.describe("Button height contract", () => {
 						await page.reload();
 						await page.waitForLoadState("networkidle");
 						const todayBlock = page.locator(".day-block.today");
-						if (await todayBlock.evaluate((element) => element.classList.contains("collapsed"))) {
-							await todayBlock.locator(".day-divider.clickable").click();
-							await expect(todayBlock).not.toHaveClass(/collapsed/, { timeout: 10000 });
-						}
+						await expandDayBlock(todayBlock);
 						await expect(todayBlock).toContainText(takeMedName, { timeout: 10000 });
 						await expect(todayBlock).toContainText(skipMedName, { timeout: 10000 });
 

--- a/frontend/e2e/domain-safety.spec.ts
+++ b/frontend/e2e/domain-safety.spec.ts
@@ -4,6 +4,7 @@ import {
 	createMedicationViaAPI,
 	createShareTokenViaAPI,
 	deleteAllMedicationsViaAPI,
+	expandDayBlock,
 	expect,
 	navigateTo,
 	test,
@@ -221,9 +222,7 @@ test.describe("Domain safety flows", () => {
 		const markedDoseId = markedDoses[0].doseId;
 
 		const undoButton = todayBlock.getByRole("button", { name: /undo/i }).first();
-		if (!(await undoButton.isVisible().catch(() => false))) {
-			await todayBlock.locator(".day-divider.clickable").click();
-		}
+		await expandDayBlock(todayBlock);
 		await expect(undoButton).toBeVisible({ timeout: 10000 });
 		await undoButton.click();
 		await expect(todayBlock.getByRole("button", { name: /take/i }).first()).toBeVisible({ timeout: 10000 });

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { test as base, expect, type Page } from "@playwright/test";
+import { test as base, expect, type Locator, type Page } from "@playwright/test";
 
 /** Storage state path for authenticated sessions */
 export const authFile = path.join(import.meta.dirname, "..", ".auth", "user.json");
@@ -158,6 +158,26 @@ export async function navigateTo(page: Page, path: string): Promise<void> {
 	}
 	await waitForAppReady(page);
 	await page.waitForLoadState("networkidle");
+}
+
+export function relativeLocalDateTime(daysFromToday: number, hour?: number, minute = 0): string {
+	const date = new Date();
+	date.setDate(date.getDate() + daysFromToday);
+	if (hour !== undefined) {
+		date.setHours(hour, minute, 0, 0);
+	}
+	const pad = (value: number) => value.toString().padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+export async function expandDayBlock(dayBlock: Locator): Promise<void> {
+	await expect(dayBlock).toBeVisible({ timeout: 10000 });
+	if (await dayBlock.evaluate((element) => element.classList.contains("collapsed"))) {
+		const divider = dayBlock.locator(".day-divider.clickable");
+		await expect(divider).toBeVisible({ timeout: 10000 });
+		await divider.click();
+		await expect(dayBlock).not.toHaveClass(/collapsed/, { timeout: 10000 });
+	}
 }
 
 /**
@@ -373,7 +393,7 @@ export async function createMedicationViaAPI(data: {
 			{
 				usage: 1,
 				every: 1,
-				start: new Date().toISOString().slice(0, 16),
+				start: relativeLocalDateTime(0),
 				intakeRemindersEnabled: false,
 			},
 		],

--- a/frontend/e2e/mobile-modal-history.spec.ts
+++ b/frontend/e2e/mobile-modal-history.spec.ts
@@ -3,8 +3,10 @@ import {
 	createMedicationViaAPI,
 	createShareTokenViaAPI,
 	deleteAllMedicationsViaAPI,
+	expandDayBlock,
 	expect,
 	navigateTo,
+	relativeLocalDateTime,
 	test,
 } from "./fixtures";
 
@@ -80,10 +82,7 @@ test.describe("Mobile modal browser back", () => {
 		const uniqueSuffix = Date.now().toString(36);
 		const person = `Mobile Journal ${uniqueSuffix}`;
 		const medicationName = `Mobile Shared Journal ${uniqueSuffix}`;
-		const start = new Date();
-		start.setHours(8, 0, 0, 0);
-		const pad = (value: number) => value.toString().padStart(2, "0");
-		const startTime = `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())}T${pad(start.getHours())}:${pad(start.getMinutes())}`;
+		const startTime = relativeLocalDateTime(0, 8);
 
 		await deleteAllMedicationsViaAPI();
 		await createMedicationViaAPI({
@@ -108,11 +107,7 @@ test.describe("Mobile modal browser back", () => {
 			timeout: 15000,
 		});
 
-		const collapsedTodayDivider = page.locator(".day-block.today.collapsed .day-divider.clickable").first();
-		if (await collapsedTodayDivider.isVisible().catch(() => false)) {
-			await collapsedTodayDivider.click();
-			await expect(page.locator(".day-block.today")).not.toHaveClass(/collapsed/, { timeout: 10000 });
-		}
+		await expandDayBlock(page.locator(".day-block.today"));
 		const doseItem = page.locator(".dose-item").first();
 		await expect(doseItem).toBeVisible({ timeout: 15000 });
 		await doseItem.getByRole("button", { name: /Take|Nehmen/i }).click();

--- a/frontend/e2e/schedule.spec.ts
+++ b/frontend/e2e/schedule.spec.ts
@@ -1,5 +1,12 @@
 import { expect } from "@playwright/test";
-import { authFile, createMedicationViaAPI, deleteAllMedicationsViaAPI, navigateTo, test } from "./fixtures";
+import {
+	authFile,
+	createMedicationViaAPI,
+	deleteAllMedicationsViaAPI,
+	navigateTo,
+	relativeLocalDateTime,
+	test,
+} from "./fixtures";
 
 /**
  * Schedule / Timeline E2E Tests
@@ -12,13 +19,7 @@ test.describe("Schedule Timeline", () => {
 	test.describe.configure({ timeout: 60000 });
 
 	const seededName = "Schedule Smoke Seed";
-	const startThreeDaysAgo = (() => {
-		const d = new Date();
-		d.setDate(d.getDate() - 3);
-		d.setHours(8, 0, 0, 0);
-		const pad = (n: number) => n.toString().padStart(2, "0");
-		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-	})();
+	const startThreeDaysAgo = relativeLocalDateTime(-3, 8);
 
 	async function waitForSeededScheduleData(page: Parameters<Parameters<typeof test>[0]>[0]["page"]) {
 		await expect

--- a/frontend/e2e/share-schedule.spec.ts
+++ b/frontend/e2e/share-schedule.spec.ts
@@ -6,6 +6,7 @@ import {
 	deleteAllMedicationsViaAPI,
 	expect,
 	navigateTo,
+	relativeLocalDateTime,
 	type TestMedication,
 	test,
 } from "./fixtures";
@@ -26,12 +27,7 @@ test.describe("Share Schedule", () => {
 	const PERSON_ALICE = "Alice";
 	const PERSON_BOB = "Bob";
 
-	const todayMorning = (() => {
-		const d = new Date();
-		d.setHours(8, 0, 0, 0);
-		const pad = (n: number) => n.toString().padStart(2, "0");
-		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-	})();
+	const todayMorning = relativeLocalDateTime(0, 8);
 
 	const createdMeds: TestMedication[] = [];
 


### PR DESCRIPTION
Closes #1095

## Summary

Stabilizes date-sensitive Playwright fixture setup and expands intentionally collapsed day blocks before high-risk dose-action assertions.

## Validation

- CI-equivalent stable Chromium, one worker, affected specs with `--repeat-each=3`: 115 passed.
- `npm run lint`, `npm run check`, and `git diff --check` passed locally.

No product behavior changes.