### PR TITLE
chore: modernize agent harness governance

### DIFF
--- a/.github/agents/complex-task.agent.md
+++ b/.github/agents/complex-task.agent.md
@@ -1,11 +1,13 @@
 ---
 name: complex-task
 description: Handles high-risk or hard-to-diagnose work involving migrations, security, production, architecture, or multi-domain behavior.
+user-invocable: false
 disable-model-invocation: false
+agents: []
 ---
 
 # Complex Task Agent
 
-Use this agent only after the complexity trigger is explicit. State the trigger, protect contracts and rollback paths, and keep the work split into reviewable slices. Use high reasoning, not xhigh, unless at least two independent high-risk triggers are present.
+Use this agent only after the coordinator provides an explicit complexity trigger. State the trigger, protect contracts and rollback paths, and keep the work split into reviewable slices. Return specialist needs to the coordinator instead of delegating recursively.
 
 Follow `AGENTS.md` for all security, testing, delegation, and release requirements.

--- a/.github/agents/engineering-orchestrator.agent.md
+++ b/.github/agents/engineering-orchestrator.agent.md
@@ -1,0 +1,37 @@
+---
+name: engineering-orchestrator
+description: Use as the default entry point for any MedAssist task; classifies complexity and routes work to the correct implementation tier or specialist.
+user-invocable: true
+argument-hint: Describe the engineering outcome, constraints, and any known failing behavior.
+tools: ['agent', 'read', 'search', 'execute']
+agents: ['model-router', 'fast-task', 'standard-task', 'complex-task', 'engineering-reviewer', 'testing-manager', 'release-manager', 'project-bot']
+---
+
+# Engineering Orchestrator
+
+Act as the single default entry point for trivial, standard, complex, testing, release, and project-management requests. Classify and route the work autonomously; do not routinely implement, test, or publish it yourself. Follow `AGENTS.md` as the canonical policy and load only skills triggered by the owned scope.
+
+## Workflow
+
+1. Restate the objective as observable acceptance criteria and use a read-only status command to inspect worktree safety.
+2. Route testing, release, and project-metadata requests directly to their specialist without generic tier classification.
+3. For all other work, ask `model-router` to select Fast, Standard, or Complex, then delegate exactly once to `fast-task`, `standard-task`, or `complex-task` respectively.
+4. Give the selected worker ownership of implementation. Include the objective, owned files or domain, evidence, constraints, expected output, cheapest falsifying check, and escalation trigger.
+5. Use up to three parallel subagents only for independent read-only research or review. Never assign concurrent writers to the same checkout or file set.
+6. Request `engineering-reviewer` only for material correctness, security, compatibility, architecture, or cross-domain risk.
+7. Send test planning, test changes, execution, and CI test triage directly to `testing-manager`.
+8. Send remote git, PR, merge, tag, release, and workflow-monitoring work directly to `release-manager`. Send metadata-only GitHub coordination to `project-bot`.
+9. Integrate concise evidence and stop when acceptance criteria and required gates pass.
+
+## Cost Controls
+
+- Route trivial work to `fast-task`; keep orchestration proportional and skip review or broad validation when risk does not justify it.
+- Prefer one focused worker over a committee. Add a worker only when its result can change a decision.
+- Do not ask multiple agents to rediscover the same context.
+- Do not enable recursive delegation. Subagents report back to this coordinator.
+- Allow at most one implementation repair pass after independent review. Escalate unresolved risk instead of looping.
+- Return summaries, evidence, uncertainty, and next action; do not pull raw logs or full transcripts into the parent context.
+
+## Completion Record
+
+Report the selected tier, changed scope, review findings, validation evidence, residual risk, and next owner. Never claim a specialist gate ran when it did not.

--- a/.github/agents/engineering-reviewer.agent.md
+++ b/.github/agents/engineering-reviewer.agent.md
@@ -1,0 +1,22 @@
+---
+name: engineering-reviewer
+description: Independently reviews MedAssist changes for correctness, regressions, security, compatibility, architecture, and missing tests without editing files.
+user-invocable: false
+argument-hint: Describe the change or diff to review and its intended behavior.
+tools: ['read', 'search', 'execute']
+agents: []
+---
+
+# Engineering Reviewer
+
+Review only; do not edit files, install dependencies, mutate git state, or perform remote operations. Follow `AGENTS.md` and load only domain skills triggered by the reviewed paths.
+
+## Review Method
+
+1. Establish the intended behavior and inspect the focused diff plus the nearest controlling code, contracts, and tests.
+2. Look for observable bugs, regressions, unsafe input or authorization behavior, compatibility breaks, ownership violations, stale paths, and missing deterministic coverage.
+3. Use read-only commands only when needed to inspect diffs, history, or diagnostics. Do not run broad test suites; testing belongs to `testing-manager`.
+4. Report findings first, ordered by severity, with precise file references and evidence.
+5. Separate blocking findings from optional improvements. Do not invent work merely to produce feedback.
+
+If no actionable finding exists, say so clearly and state any residual risk or unverified test surface. Return a compact result to the coordinator.

--- a/.github/agents/fast-task.agent.md
+++ b/.github/agents/fast-task.agent.md
@@ -1,11 +1,13 @@
 ---
 name: fast-task
 description: Handles deterministic, narrowly scoped tasks such as one-file documentation, copy, metadata, formatting, and read-only lookups.
+user-invocable: false
 disable-model-invocation: false
+agents: []
 ---
 
 # Fast Task Agent
 
-Work only on simple, tightly bounded tasks. Do not widen scope, spawn parallel work, or use a more expensive model by default.
+Work only on the objective and scope assigned by the coordinator. Do not widen scope, spawn parallel work, or use a more expensive model by default.
 
 Stop and request a standard-tier handoff if the task affects more than one domain, needs non-trivial debugging, changes runtime behavior, or touches auth, persistence, security, production, migrations, or releases. Follow `AGENTS.md` for repository rules.

--- a/.github/agents/model-router.agent.md
+++ b/.github/agents/model-router.agent.md
@@ -1,28 +1,18 @@
 ---
 name: model-router
-description: Classifies a request into the lowest safe model tier and routes it to the matching task agent before implementation.
+description: Classifies implementation work into the lowest safe model tier before a coordinator assigns the matching task agent.
+user-invocable: false
 disable-model-invocation: false
-handoffs:
-  - label: Fast Task
-    agent: fast-task
-    prompt: Handle this as a fast-tier task and stop if any escalation trigger appears.
-    send: true
-  - label: Standard Task
-    agent: standard-task
-    prompt: Handle this as a standard-tier task and document any escalation trigger.
-    send: true
-  - label: Complex Task
-    agent: complex-task
-    prompt: Handle this as a complex-tier task with high reasoning and explicit risk controls.
-    send: true
+tools: []
+agents: []
 ---
 
 # Cost-Aware Model Router
 
-Classify the request before implementation. Return the selected tier and a one-sentence rationale, then hand off to the corresponding task agent when handoffs are available.
+Classify the request before implementation. Return the selected tier, one-sentence rationale, triggered specialist ownership, and any concrete escalation condition. Do not implement or delegate.
 
 - **Fast**: one focused, deterministic task with no auth, persistence, security, production, migration, or cross-domain impact.
-- **Standard**: normal multi-file implementation, focused tests, routine refactor, or CI/release coordination.
+- **Standard**: normal multi-file implementation, bug fix, or routine refactor.
 - **Complex**: data migration, auth/security, production issue, architecture decision, multi-domain behavior change, or a focused failure after one standard-tier attempt.
 
-Never select the complex tier by default. Escalate one tier only when evidence requires it. Follow the canonical mapping and safety rules in `AGENTS.md`.
+Never classify testing, release, or project-metadata ownership; those route directly to their specialists. Never select the complex tier by default. Escalate one tier only when evidence requires it. Follow the canonical mapping and safety rules in `AGENTS.md`.

--- a/.github/agents/project-bot.agent.md
+++ b/.github/agents/project-bot.agent.md
@@ -1,7 +1,9 @@
 ---
 name: project-bot
 description: Handles GitHub issue, pull request, and Project board mutations for MedAssist-ng without owning product code changes or release actions.
+user-invocable: false
 argument-hint: Describe the project automation task, e.g. "move issue 714 to Ready", "sync project fields for PR 715", or "create a triage issue for the release smoke regression"
+agents: []
 ---
 
 # Project Bot Agent

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -2,7 +2,9 @@
 
 name: release-manager
 description: Manages the full release lifecycle - from branching and PRs through versioning and GitHub release notes. Use when code changes are complete and ready to ship.
+user-invocable: false
 argument-hint: Describe what was changed, e.g., "fix stock correction bug" or "new refill tracking feature"
+agents: []
 
 ---
 

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -17,10 +17,9 @@ You are the release manager for **MedAssist-ng**. Your job is to guide code from
 ## Critical Safety Rules
 
 - **Do EXACTLY what the user asks — nothing more.** If the user says "create a PR and merge to main", do only that. Do NOT also start a release. If the user says "do a release", do only the release. Never chain additional steps the user did not request.
-- **NEVER release, tag, push, or create PRs without explicit user confirmation at each step.** Always present your plan and wait for approval.
-- **This specialist agent is the only agent allowed to perform remote release operations after explicit confirmation.**
-- **Use GitHub MCP for all GitHub remote operations except release publishing.** Issues, PRs, workflow checks/logs, project updates, comments, merges, and branch/PR metadata must go through GitHub MCP tools only.
-- **Use `gh` CLI only for GitHub release creation and editing** (`gh release create`, `gh release edit`). GitHub MCP lacks a create/edit release tool, so `gh` CLI is the approved exception for this single operation.
+- **A complete user request authorizes the complete requested flow.** If the user asks to commit, push, create a PR, wait for CI, and merge, execute those steps without asking for another confirmation between them. Ask only when the request is genuinely ambiguous or an irreversible step was not requested.
+- **This specialist agent is the only agent allowed to perform remote release operations.**
+- **Use the available authenticated GitHub integration for remote operations.** Prefer GitHub MCP when available; use an authenticated GitHub CLI or API fallback when MCP is unavailable. Never report an unavailable preferred tool as a completed PR or merge.
 - **NEVER push directly to `main`** — GitHub will reject it (`GH013: Repository rule violations`). All changes go through Pull Requests.
 - **NEVER skip CI checks.** Wait for all status checks to pass before merging.
 - **Testing ownership belongs to `@testing-manager`**. Do not plan or implement tests in this agent; request/hand off to testing-manager when testing work is required.
@@ -67,7 +66,7 @@ This repository intentionally uses only two operational agents for CI/CD handoff
 
 ## Workspace Hygiene And Source-Of-Truth Rules
 
-- The authoritative comparison target is the actual remote default branch used for shipping, normally `github/main` or `origin/main`. Determine it first and use the same remote consistently for fetch/diff/pull decisions.
+- The authoritative comparison target is the actual remote default branch used for shipping. Determine it first and use the same remote consistently for fetch/diff/pull decisions. The remote may be named `upstream`, `origin`, `github`, or another local alias; `upstream` is a general concept here, not a required literal remote name.
 - Before any PR split or branch creation, run a source-of-truth audit:
 
     1. fetch the authoritative remote
@@ -204,15 +203,15 @@ When code changes (features or bug fixes) are complete:
     - Using `Closes #N` in the PR body ensures the issue is automatically closed on merge.
     - Always add an explicit issue comment with the PR link and short fix summary (do not rely on auto-close event only).
 
-4. **Present the PR URL to the user and wait for confirmation.**
+4. Present the PR URL in the progress report and continue monitoring it when the user requested the complete shipping flow.
 
 ### Step 4: Wait for CI and Merge
 
-1. Monitor CI status via GitHub MCP until all required checks complete.
+1. Monitor CI status through the available authenticated GitHub integration until all required checks complete.
    Required checks: all repository-required checks must pass.
 2. For release-relevant PRs (backend, frontend, shared, package, Docker, or workflow/runtime changes), also require the visible `Container Smoke` PR check to complete successfully. If it is missing, skipped for a smoke-relevant diff, or failed, treat CI as not green even if branch protection would allow a bypass merge.
 3. If CI fails: analyze the failure, fix it, push again, and re-check.
-4. Once CI is green, **ask the user for merge confirmation**, then merge the PR via GitHub MCP using squash merge and branch deletion.
+4. Once CI is green, merge the PR through the available authenticated GitHub integration using squash merge and branch deletion when the user's request includes merging. Do not ask for a redundant second confirmation.
 5. Re-sync the authoritative local `main` before using it again as a source of truth for any next PR or release step. Do not continue from a previously dirty workspace without another source-of-truth audit.
 6. If the requested end state is a clean local `main`, verify that `git status` is empty and that no task-related stash entry remains as hidden residue.
 7. Switch back to main and pull:

--- a/.github/agents/standard-task.agent.md
+++ b/.github/agents/standard-task.agent.md
@@ -1,11 +1,13 @@
 ---
 name: standard-task
-description: Handles normal engineering work including focused multi-file changes, tests, routine refactors, and CI coordination.
+description: Handles normal implementation work including bug fixes, focused multi-file changes, and routine refactors.
+user-invocable: false
 disable-model-invocation: false
+agents: []
 ---
 
 # Standard Task Agent
 
-Handle ordinary implementation and validation work with a focused plan. Keep scope reviewable and use the existing specialist agents when ownership rules require them.
+Handle the implementation scope assigned by the coordinator with a focused plan. Keep the change reviewable and return testing, release, or project-metadata needs to the coordinator for direct specialist routing.
 
 Escalate to the complex tier only for a data migration, auth/security concern, production incident, architecture decision, multi-domain behavior change, or after one evidence-backed standard-tier failure. Follow `AGENTS.md` for the canonical routing and repository rules.

--- a/.github/agents/testing-manager.agent.md
+++ b/.github/agents/testing-manager.agent.md
@@ -1,7 +1,9 @@
 ---
 name: testing-manager
 description: Owns testing strategy, test implementation, local validation, and CI test triage for backend, frontend, and Playwright E2E.
+user-invocable: false
 argument-hint: Describe what to test, e.g., "add tests for stock warning fix" or "analyze failing Playwright checks"
+agents: []
 ---
 
 # Testing Manager Agent

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,11 +13,6 @@ If `AGENTS.md` exists in the checkout or is provided in the session context, tre
 5. Identify triggered skills and read only the matching `.github/skills/*/SKILL.md` files before changing code.
 6. Keep work scoped to the user's current objective and existing repository patterns.
 
-<!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan.
-<!-- SPECKIT END -->
-
 ## Portable Safety Baseline
 
 - Use English for code, comments, docs, and commit messages.
@@ -48,10 +43,15 @@ shell commands, and other important information, read the current plan.
 
 ## Specialists
 
+- Use `engineering-orchestrator` as the single default entry point for every task; it classifies complexity and routes to the correct implementation tier or specialist.
+- Use `engineering-reviewer` for independent read-only correctness, security, compatibility, and architecture review.
 - Use `testing-manager` for test planning, test execution, and CI test triage.
 - Use `release-manager` for PR shipping, merge, release, and workflow monitoring.
 - Use `project-bot` for issue, PR metadata, and GitHub Project board coordination when no product code change is required.
-- Use `model-router` for implementation, testing, CI, and repository-operation routing when delegation is available.
+- Use `model-router` only to classify implementation work into the lowest capable `fast-task`, `standard-task`, or `complex-task` tier.
+- Route specialist work directly; do not send testing, release, or metadata-only work through a generic task worker.
+- Keep one implementation owner and one writer per file set. Limit normal parallel fan-out to three independent read-only workers and do not use nested delegation by default.
+- Allow at most one focused repair pass after independent review; unresolved or expanded risk returns to the coordinator or user.
 
 ## Validation
 

--- a/.github/skills/medassist-doc-sync-guard/SKILL.md
+++ b/.github/skills/medassist-doc-sync-guard/SKILL.md
@@ -21,7 +21,7 @@ Keep docs consistent with actual product behavior and avoid stale setup/run guid
 ## Candidate Documentation Files
 
 - `README.md`
-- `docs/PROJECT_SETUP.md`
+- `docs/DEVELOPMENT.md`
 - `docs/TECH_STACK.md`
 
 ## Anti-Patterns

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      agent-harness: ${{ steps.filter.outputs.agent-harness }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -59,6 +60,40 @@ jobs:
               - 'biome.json'
               - '.github/workflows/test.yml'
               - '.github/workflows/e2e.yml'
+            agent-harness:
+              - 'package.json'
+              - 'scripts/validate-agent-harness.mjs'
+              - 'scripts/validate-agent-harness.test.mjs'
+              - 'AGENTS.md'
+              - '.github/copilot-instructions.md'
+              - '.github/agents/**'
+              - '.github/skills/**'
+              - '.github/workflows/test.yml'
+
+  agent-harness:
+    name: Agent Harness
+    needs: changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Skip agent harness when unchanged
+        if: needs.changes.outputs.agent-harness != 'true'
+        run: echo "No agent-harness changes detected; required check passes without validation."
+
+      - name: Checkout repository
+        if: needs.changes.outputs.agent-harness == 'true'
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        if: needs.changes.outputs.agent-harness == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Validate agent harness
+        if: needs.changes.outputs.agent-harness == 'true'
+        run: npm run test:agent-harness && npm run validate:agent-harness
 
   # =============================================================================
   # Backend Tests (always emits the required check context)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ For explicit push, PR, merge, tag, or release requests, the normal agent's requi
 - Always clean up dead code from older or failed approaches before handoff. Do not leave unused fallback paths, duplicate logic, stale listeners, unreachable branches, commented-out implementations, or tests for behavior that is no longer part of the final fix.
 - Reuse existing UI patterns and components such as `ConfirmModal`, `MedicationAvatar`, and the existing style system.
 
+## CI Triage
+
+- Do not open a local browser, Chrome, or a browser automation session to inspect GitHub Actions, pull-request checks, workflow failures, logs, or artifacts.
+- Use `gh` or the GitHub API/MCP for CI triage, including check status, failed-job logs, artifacts, reruns, and PR metadata.
+- Open a browser only when validating a rendered product UI state that cannot be established from code, tests, or CI logs. A GitHub Actions URL is not a product UI validation target.
+
 ## Authenticated UI Verification
 
 When fixing or reviewing UI that lives behind login or depends on authenticated app state:
@@ -179,29 +185,42 @@ Skill files:
 
 ## Delegation
 
+- `@engineering-orchestrator` is the single default user entry point for every task. It classifies implementation complexity, routes specialist ownership directly, and coordinates without routinely implementing.
 - Testing ownership is `@testing-manager`: test planning, writing, execution, and CI test triage (`test.yml`, `e2e.yml`).
 - Release ownership is `@release-manager`: PR/release orchestration, merge flow, and workflow monitoring.
+- Independent review ownership is `@engineering-reviewer`: correctness, security, architecture, compatibility, and missing-test review without file edits.
 - Normal agents must not delegate release work to arbitrary subagents. Route push, PR, merge, tag, and release requests specifically to `@release-manager`.
 - If a required specialist is unavailable, hangs, or returns no useful status, continue locally only as far as needed to unblock the explicit request.
 - Fallback protocol: keep scope focused, document why fallback was used in `MEMORY.md`, report exact commands/results, and do not perform prohibited release actions.
 - CI failure triage and final release orchestration still return to the owner when available.
 
+## Agent Operating Model
+
+- Enter through `@engineering-orchestrator`; it routes trivial work to `fast-task` with minimal ceremony and adds coordination only when specialization, isolation, parallel read-only analysis, or an independent gate is justified.
+- Route once at task start. Do not route a specialist through a generic worker: testing goes directly to `@testing-manager`, release directly to `@release-manager`, and project metadata directly to `@project-bot`.
+- Keep one implementation owner and one writer per file set. Parallelize only independent read-only work or writes in explicitly isolated worktrees.
+- Limit normal fan-out to three workers. Nested delegation is off by default; enable it only for bounded divide-and-conquer work with an explicit depth and stopping condition.
+- Every handoff must include: objective, owned scope, relevant evidence, constraints, expected output, validation, and escalation trigger. Return findings and evidence, not raw logs or broad transcripts.
+- Use a producer-reviewer loop only for material risk. Allow one focused repair pass after review; unresolved or newly expanded risk returns to the coordinator or user instead of looping.
+- Stop when acceptance criteria and required gates pass. Do not spend tokens polishing unaffected code, repeating successful checks, or consulting extra agents without a decision they can change.
+- Treat instructions as guidance, not enforcement. Keep tool permissions least-privilege, use sandboxing where available, and retain CI, branch protection, and human review as final controls.
+
 ## Cost-Aware Model Orchestration
 
 This routing policy applies to Codex and GitHub Copilot. Classify the task before choosing a model, agent, or delegation path. Start with the lowest capable tier and escalate only when concrete evidence requires it.
 
-For implementation, test execution, CI coordination, or repository operations, classify the work through `model-router` before delegating to `fast-task`, `standard-task`, or `complex-task`. Read-only discovery and small governance edits may use the fast tier directly when no specialist action is required.
+For implementation work, classify the change through `model-router` before delegating to `fast-task`, `standard-task`, or `complex-task`. Route testing, release, and project-metadata work directly to their specialists without a generic tier hop. Read-only discovery and small governance edits may use the fast tier directly when no specialist action is required.
 
 | Tier | Use for | Required agent role |
 |---|---|---|
-| Fast | Targeted questions, read-only lookups, one-file copy or documentation edits, formatting, simple metadata updates, and deterministic commands | `fast-task` |
-| Standard | Normal bug fixes, focused tests, small multi-file changes, routine refactors, and PR/CI coordination | `standard-task` |
+| Fast | Targeted questions, read-only lookups, one-file copy or documentation edits, formatting, and deterministic commands | `fast-task` |
+| Standard | Normal bug fixes, small multi-file changes, and routine refactors | `standard-task` |
 | Complex | Data migrations, auth/security, production incidents, multi-domain behavior changes, architecture decisions, difficult root-cause analysis, or a scoped failure after one standard-tier attempt | `complex-task` |
 
 - Do not choose the complex tier merely because a task is broad, unfamiliar, or inconvenient. Split independent work first and keep each slice at the lowest viable tier.
 - Escalate exactly one tier when the current tier cannot establish a safe path, a focused check fails, or new evidence expands the scope. Record the evidence in the handoff; do not silently retry on an expensive model.
 - Personal model selection and reasoning defaults belong in local Codex configuration or individual developer tooling. They never relax security, testing, approval, or release rules.
-- PR creation, upstream push, release coordination, and workflow monitoring are `standard-task` work and must run through `@release-manager`. They are not a reason to use `complex-task`; select it only when the underlying change itself has a complex trigger.
+- PR creation, upstream push, release coordination, and workflow monitoring bypass generic task tiers and run directly through `@release-manager`.
 
 ## GitHub Project And Traceability
 
@@ -213,11 +232,13 @@ For implementation, test execution, CI coordination, or repository operations, c
 
 ## Delivery Workflow
 
-1. Confirm scope, issue/project availability, and worktree safety.
-2. Implement local changes.
-3. Hand off tests to `@testing-manager`, or use the fallback protocol when necessary.
-4. Hand off PR/merge/release work to `@release-manager`.
-5. After merge and issue closure, ensure traceability comments are present.
+1. Confirm acceptance criteria, worktree safety, and the lowest capable route.
+2. Load only triggered skills and gather the minimum evidence needed to identify the controlling path and a falsifying check.
+3. Assign one implementation owner; use parallel read-only discovery only when it reduces uncertainty or elapsed time.
+4. For material-risk changes, obtain an independent `@engineering-reviewer` pass and repair only actionable findings.
+5. Hand off test planning/execution to `@testing-manager`, or use the documented fallback protocol.
+6. Hand off PR/merge/release work to `@release-manager`; use `@project-bot` for metadata-only coordination.
+7. Record concise evidence: changed scope, checks and results, residual risk, and the next owner. After merge, verify issue/PR traceability.
 
 ## Local Commands
 
@@ -233,5 +254,5 @@ npm run build
 - `AGENTS.md`: canonical local governance, skill routing, and ownership.
 - `.github/copilot-instructions.md`: committed entry point for Copilot/cloud agents; it should stay short and defer to `AGENTS.md` when present.
 - `.github/skills/*/SKILL.md`: detailed skill rules, read only when triggered.
-- `.github/agents/*.agent.md`: Copilot specialist definitions and routing roles; ignored Spec Kit definitions are local generated integrations.
+- `.github/agents/*.agent.md`: thin Copilot coordinators, workers, and specialists; ignored Spec Kit definitions are local generated integrations.
 - `.codex/agents/*.toml`: local Codex custom-agent definitions; these are intentionally local-only.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
     "prepare": "husky",
     "lint": "cd shared && npm run check && cd ../backend && npm run lint && cd ../frontend && npm run lint",
     "lint:fix": "cd shared && npx biome check --write . && cd ../backend && npm run lint:fix && cd ../frontend && npm run lint:fix",
-    "check": "cd shared && npm run check && cd ../backend && npm run check && cd ../frontend && npm run check",
+    "check": "npm run validate:agent-harness && cd shared && npm run check && cd ../backend && npm run check && cd ../frontend && npm run check",
     "build": "cd shared && npm run build && cd ../backend && npm run build && cd ../frontend && npm run build",
     "test:domain": "cd backend && npm run test:domain && cd ../frontend && npm run test:e2e:domain",
+    "test:agent-harness": "node --test scripts/validate-agent-harness.test.mjs",
+    "validate:agent-harness": "node scripts/validate-agent-harness.mjs",
     "test:release-preflight": "node scripts/test-release-preflight.mjs",
     "release:preflight": "node scripts/release-preflight.mjs"
   },

--- a/scripts/validate-agent-harness.mjs
+++ b/scripts/validate-agent-harness.mjs
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const AGENT_DIRECTORY = ".github/agents";
+const SKILL_DIRECTORY = ".github/skills";
+const ORCHESTRATOR = "engineering-orchestrator";
+const REQUIRED_AGENTS = [
+  ORCHESTRATOR,
+  "model-router",
+  "fast-task",
+  "standard-task",
+  "complex-task",
+  "engineering-reviewer",
+  "testing-manager",
+  "release-manager",
+  "project-bot",
+];
+const ORCHESTRATOR_AGENTS = REQUIRED_AGENTS.filter((name) => name !== ORCHESTRATOR);
+const NON_RECURSIVE_AGENTS = ORCHESTRATOR_AGENTS;
+const HIDDEN_INTERNAL_AGENTS = [
+  "model-router",
+  "fast-task",
+  "standard-task",
+  "complex-task",
+  "engineering-reviewer",
+  "testing-manager",
+  "release-manager",
+  "project-bot",
+];
+const GENERATED_AGENT_NAMES = new Set(["medassist-feature-orchestrator"]);
+const execFileAsync = promisify(execFile);
+
+function parseScalar(value, filePath, lineNumber) {
+  const trimmed = value.trim();
+
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed === "[]") return [];
+
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const content = trimmed.slice(1, -1).trim();
+    if (!content) return [];
+
+    return content.split(",").map((entry) => {
+      const item = entry.trim();
+      const quote = item[0];
+      if ((quote !== "'" && quote !== '"') || item.at(-1) !== quote) {
+        throw new Error(`${filePath}:${lineNumber}: inline array entries must be quoted`);
+      }
+      return item.slice(1, -1);
+    });
+  }
+
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+
+  if (!trimmed) {
+    throw new Error(`${filePath}:${lineNumber}: frontmatter values must not be empty`);
+  }
+
+  return trimmed;
+}
+
+export function parseFrontmatter(source, filePath = "agent file") {
+  const lines = source.split(/\r?\n/);
+  if (lines[0] !== "---") {
+    throw new Error(`${filePath}:1: expected frontmatter opening delimiter ---`);
+  }
+
+  const closingIndex = lines.indexOf("---", 1);
+  if (closingIndex === -1) {
+    throw new Error(`${filePath}: missing frontmatter closing delimiter ---`);
+  }
+
+  const attributes = {};
+  for (let index = 1; index < closingIndex; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+
+    const match = /^([a-z][a-z0-9-]*):\s*(.*)$/.exec(line);
+    if (!match) {
+      throw new Error(`${filePath}:${index + 1}: unsupported frontmatter syntax: ${line}`);
+    }
+
+    const [, key, rawValue] = match;
+    if (Object.hasOwn(attributes, key)) {
+      throw new Error(`${filePath}:${index + 1}: duplicate frontmatter key ${key}`);
+    }
+    attributes[key] = parseScalar(rawValue, filePath, index + 1);
+  }
+
+  return {
+    attributes,
+    body: lines.slice(closingIndex + 1).join("\n"),
+  };
+}
+
+function sameMembers(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    expected.every((entry) => actual.includes(entry))
+  );
+}
+
+function requireBodyContract(errors, filePath, body, pattern, message) {
+  if (!pattern.test(body)) {
+    errors.push(`${filePath}: ${message}`);
+  }
+}
+
+async function readText(rootDir, relativePath, errors) {
+  try {
+    return await readFile(path.join(rootDir, relativePath), "utf8");
+  } catch (error) {
+    errors.push(`${relativePath}: unable to read file (${error.code ?? error.message})`);
+    return null;
+  }
+}
+
+function isManagedAgentPath(relativePath) {
+  const filename = path.posix.basename(relativePath);
+  const name = filename.replace(/\.agent\.md$/, "");
+  return (
+    relativePath.startsWith(`${AGENT_DIRECTORY}/`) &&
+    filename.endsWith(".agent.md") &&
+    !name.startsWith("speckit.") &&
+    !GENERATED_AGENT_NAMES.has(name)
+  );
+}
+
+async function listFixtureFiles(rootDir) {
+  const agentPaths = [];
+  const skillPaths = [];
+
+  try {
+    const entries = await readdir(path.join(rootDir, AGENT_DIRECTORY), { withFileTypes: true });
+    for (const entry of entries) {
+      const relativePath = `${AGENT_DIRECTORY}/${entry.name}`;
+      if (entry.isFile() && isManagedAgentPath(relativePath)) agentPaths.push(relativePath);
+    }
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+
+  try {
+    const entries = await readdir(path.join(rootDir, SKILL_DIRECTORY), { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const relativePath = `${SKILL_DIRECTORY}/${entry.name}/SKILL.md`;
+      try {
+        const skillEntries = await readdir(path.join(rootDir, SKILL_DIRECTORY, entry.name));
+        if (skillEntries.includes("SKILL.md")) skillPaths.push(relativePath);
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    }
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+
+  return { agentPaths, skillPaths };
+}
+
+async function listManagedFiles(rootDir) {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", rootDir, "ls-files", "-z", "--", `${AGENT_DIRECTORY}/*.agent.md`, `${SKILL_DIRECTORY}/*/SKILL.md`],
+      { encoding: "utf8" },
+    );
+    const trackedPaths = stdout.split("\0").filter(Boolean);
+    return {
+      agentPaths: trackedPaths.filter(isManagedAgentPath),
+      skillPaths: trackedPaths.filter(
+        (relativePath) =>
+          relativePath.startsWith(`${SKILL_DIRECTORY}/`) && relativePath.endsWith("/SKILL.md"),
+      ),
+    };
+  } catch {
+    return listFixtureFiles(rootDir);
+  }
+}
+
+function findDelegationCycles(agents, errors) {
+  const states = new Map();
+  const stack = [];
+  const reportedCycles = new Set();
+
+  function visit(agentName) {
+    states.set(agentName, "visiting");
+    stack.push(agentName);
+
+    const targets = agents.get(agentName)?.attributes.agents ?? [];
+    for (const target of targets) {
+      if (!agents.has(target)) continue;
+      if (states.get(target) === "visiting") {
+        const cycle = [...stack.slice(stack.indexOf(target)), target];
+        const signature = [...new Set(cycle)].sort().join("|");
+        if (!reportedCycles.has(signature)) {
+          reportedCycles.add(signature);
+          errors.push(`agent delegation graph: cycle detected: ${cycle.join(" -> ")}`);
+        }
+      } else if (!states.has(target)) {
+        visit(target);
+      }
+    }
+
+    stack.pop();
+    states.set(agentName, "visited");
+  }
+
+  for (const agentName of agents.keys()) {
+    if (!states.has(agentName)) visit(agentName);
+  }
+}
+
+function validateGovernanceDocument(errors, relativePath, source, { fallback = false } = {}) {
+  for (const [agentName, purpose] of [
+    ["engineering-orchestrator", "universal engineering coordination"],
+    ["engineering-reviewer", "independent engineering review"],
+    ["testing-manager", "testing ownership"],
+    ["release-manager", "release ownership"],
+    ["project-bot", "metadata-only GitHub coordination"],
+    ["model-router", "model-tier routing"],
+  ]) {
+    if (!source.includes(agentName)) {
+      errors.push(`${relativePath}: must name ${agentName} for ${purpose}`);
+    }
+  }
+
+  for (const [pattern, message] of [
+    [
+      /(?:route specialist work directly|testing (?:goes|work goes) directly to [`@]*testing-manager)/i,
+      "must preserve direct specialist routing",
+    ],
+    [
+      /(?:one implementation owner and one writer|one implementation owner;.*one writer)/i,
+      "must preserve one implementation owner and one writer per file set",
+    ],
+    [
+      /(?:independent read-only[\s\S]{0,200}fan-out to three|fan-out to three[\s\S]{0,200}independent read-only|up to three parallel subagents only for independent read-only)/i,
+      "must limit normal fan-out to three independent read-only workers",
+    ],
+    [/(?:one focused repair pass|one implementation repair pass)/i, "must allow at most one repair pass"],
+    [
+      /(?:lowest capable|lowest viable)[^.\n]{0,100} tier/i,
+      "must preserve lowest-capable-tier cost control",
+    ],
+  ]) {
+    requireBodyContract(errors, relativePath, source, pattern, message);
+  }
+
+  const indirectSpecialistPattern =
+    /(?:testing|test planning|release|metadata(?:-only)?(?: GitHub)?|project metadata)[^\n.]{0,100}(?:through|to) [`@]*(?:fast-task|standard-task|complex-task)/i;
+  if (indirectSpecialistPattern.test(source)) {
+    errors.push(`${relativePath}: must not route specialist work through a generic task worker`);
+  }
+
+  if (fallback && !/AGENTS\.md[^\n.]{0,100}canonical/i.test(source)) {
+    errors.push(`${relativePath}: must keep AGENTS.md canonical when the fallback is used`);
+  }
+}
+
+export async function validateAgentHarness({ rootDir = process.cwd() } = {}) {
+  const errors = [];
+  const agents = new Map();
+  const discovered = await listManagedFiles(rootDir);
+  const requiredAgentPaths = REQUIRED_AGENTS.map(
+    (name) => `${AGENT_DIRECTORY}/${name}.agent.md`,
+  );
+  const agentPaths = [...new Set([...discovered.agentPaths, ...requiredAgentPaths])].sort();
+
+  for (const relativePath of agentPaths) {
+    const expectedName = path.posix.basename(relativePath).replace(/\.agent\.md$/, "");
+    const source = await readText(rootDir, relativePath, errors);
+    if (source === null) continue;
+
+    try {
+      const parsed = parseFrontmatter(source, relativePath);
+      agents.set(expectedName, { ...parsed, relativePath });
+      if (parsed.attributes.name !== expectedName) {
+        errors.push(
+          `${relativePath}: frontmatter name must be ${expectedName}, received ${String(parsed.attributes.name)}`,
+        );
+      }
+      if (
+        typeof parsed.attributes.description !== "string" ||
+        parsed.attributes.description.trim().length === 0
+      ) {
+        errors.push(`${relativePath}: frontmatter description must be a non-empty string`);
+      }
+      if (!Array.isArray(parsed.attributes.agents)) {
+        errors.push(`${relativePath}: frontmatter agents must be an array`);
+      }
+    } catch (error) {
+      errors.push(error.message);
+    }
+  }
+
+  for (const relativePath of discovered.skillPaths.sort()) {
+    const expectedName = relativePath.split("/").at(-2);
+    const source = await readText(rootDir, relativePath, errors);
+    if (source === null) continue;
+
+    try {
+      const { attributes } = parseFrontmatter(source, relativePath);
+      if (attributes.name !== expectedName) {
+        errors.push(
+          `${relativePath}: frontmatter name must match skill folder ${expectedName}, received ${String(attributes.name)}`,
+        );
+      }
+      if (typeof attributes.description !== "string" || attributes.description.trim().length === 0) {
+        errors.push(`${relativePath}: frontmatter description must be a non-empty string`);
+      }
+    } catch (error) {
+      errors.push(error.message);
+    }
+  }
+
+  for (const agent of agents.values()) {
+    if (!Array.isArray(agent.attributes.agents)) continue;
+    for (const target of agent.attributes.agents) {
+      if (!agents.has(target)) {
+        errors.push(`${agent.relativePath}: agents references unknown managed agent ${String(target)}`);
+      }
+    }
+  }
+  findDelegationCycles(agents, errors);
+
+  const orchestrator = agents.get(ORCHESTRATOR);
+  if (orchestrator) {
+    if (orchestrator.attributes["user-invocable"] !== true) {
+      errors.push(`${orchestrator.relativePath}: user-invocable must be true`);
+    }
+    if (!sameMembers(orchestrator.attributes.agents, ORCHESTRATOR_AGENTS)) {
+      errors.push(
+        `${orchestrator.relativePath}: agents must contain exactly ${ORCHESTRATOR_AGENTS.join(", ")}`,
+      );
+    }
+
+    requireBodyContract(
+      errors,
+      orchestrator.relativePath,
+      orchestrator.body,
+      /ask `model-router` to select Fast, Standard, or Complex/i,
+      "must classify implementation complexity through model-router",
+    );
+    requireBodyContract(
+      errors,
+      orchestrator.relativePath,
+      orchestrator.body,
+      /directly to `testing-manager`/i,
+      "must route testing work directly to testing-manager",
+    );
+    requireBodyContract(
+      errors,
+      orchestrator.relativePath,
+      orchestrator.body,
+      /directly to `release-manager`/i,
+      "must route release work directly to release-manager",
+    );
+    requireBodyContract(
+      errors,
+      orchestrator.relativePath,
+      orchestrator.body,
+      /metadata-only GitHub coordination to `project-bot`/i,
+      "must route metadata-only GitHub work directly to project-bot",
+    );
+  }
+
+  for (const agentName of NON_RECURSIVE_AGENTS) {
+    const agent = agents.get(agentName);
+    if (agent && (!Array.isArray(agent.attributes.agents) || agent.attributes.agents.length !== 0)) {
+      errors.push(`${agent.relativePath}: agents must be [] to prevent recursive delegation`);
+    }
+  }
+
+  for (const agentName of HIDDEN_INTERNAL_AGENTS) {
+    const agent = agents.get(agentName);
+    if (agent && agent.attributes["user-invocable"] !== false) {
+      errors.push(`${agent.relativePath}: user-invocable must be false`);
+    }
+  }
+
+  const modelRouter = agents.get("model-router");
+  if (modelRouter && (!Array.isArray(modelRouter.attributes.tools) || modelRouter.attributes.tools.length !== 0)) {
+    errors.push(`${modelRouter.relativePath}: tools must be [] because the router only classifies work`);
+  }
+
+  const routingDocs = [
+    { relativePath: "AGENTS.md", fallback: false },
+    { relativePath: ".github/copilot-instructions.md", fallback: true },
+  ];
+  for (const { relativePath, fallback } of routingDocs) {
+    const source = await readText(rootDir, relativePath, errors);
+    if (source === null) continue;
+
+    validateGovernanceDocument(errors, relativePath, source, { fallback });
+  }
+
+  return errors;
+}
+
+async function main() {
+  const rootDir = path.resolve(process.argv[2] ?? process.cwd());
+  const errors = await validateAgentHarness({ rootDir });
+
+  if (errors.length === 0) {
+    console.log("Agent harness validation passed.");
+    return;
+  }
+
+  console.error(`Agent harness validation failed with ${errors.length} error(s):`);
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exitCode = 1;
+}
+
+const isDirectExecution = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/validate-agent-harness.test.mjs
+++ b/scripts/validate-agent-harness.test.mjs
@@ -1,0 +1,343 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+import { validateAgentHarness } from "./validate-agent-harness.mjs";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_PATH = new URL("./validate-agent-harness.mjs", import.meta.url).pathname;
+const ORCHESTRATOR_AGENTS = [
+  "model-router",
+  "fast-task",
+  "standard-task",
+  "complex-task",
+  "engineering-reviewer",
+  "testing-manager",
+  "release-manager",
+  "project-bot",
+];
+const ALL_AGENTS = ["engineering-orchestrator", ...ORCHESTRATOR_AGENTS];
+
+function agentSource(name, attributes = {}, body = `# ${name}\n`) {
+  const entries = {
+    name,
+    description: `Fixture definition for ${name}.`,
+    agents: [],
+    ...attributes,
+  };
+  const frontmatter = Object.entries(entries)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) return `${key}: [${value.map((item) => `'${item}'`).join(", ")}]`;
+      return `${key}: ${value}`;
+    })
+    .join("\n");
+  return `---\n${frontmatter}\n---\n\n${body}`;
+}
+
+async function createValidFixture(testContext) {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "medassist-agent-harness-"));
+  testContext.after(() => rm(rootDir, { recursive: true, force: true }));
+  await mkdir(path.join(rootDir, ".github/agents"), { recursive: true });
+  await mkdir(path.join(rootDir, ".github/skills/example-skill"), { recursive: true });
+
+  const orchestratorBody = `# Engineering Orchestrator
+
+Ask \`model-router\` to select Fast, Standard, or Complex.
+Route test planning directly to \`testing-manager\`.
+Route release work directly to \`release-manager\`.
+Send metadata-only GitHub coordination to \`project-bot\`.
+`;
+
+  for (const name of ALL_AGENTS) {
+    const attributes = {};
+    let body;
+    if (name === "engineering-orchestrator") {
+      attributes.agents = ORCHESTRATOR_AGENTS;
+      attributes["user-invocable"] = true;
+      body = orchestratorBody;
+    }
+    if (name !== "engineering-orchestrator") {
+      attributes["user-invocable"] = false;
+    }
+    if (name === "model-router") attributes.tools = [];
+
+    await writeFile(
+      path.join(rootDir, `.github/agents/${name}.agent.md`),
+      agentSource(name, attributes, body),
+    );
+  }
+
+  await writeFile(
+    path.join(rootDir, ".github/skills/example-skill/SKILL.md"),
+    "---\nname: example-skill\ndescription: Valid fixture skill for harness tests.\n---\n",
+  );
+
+  const governance = `${ALL_AGENTS.join("\n")}
+
+Route specialist work directly; do not send testing, release, or metadata-only work through a generic task worker.
+Keep one implementation owner and one writer per file set.
+Limit normal parallel fan-out to three independent read-only workers.
+Allow at most one focused repair pass after review.
+Start with the lowest capable tier.
+`;
+  await writeFile(path.join(rootDir, "AGENTS.md"), governance);
+  await writeFile(
+    path.join(rootDir, ".github/copilot-instructions.md"),
+    `Treat AGENTS.md as canonical when available.\n${governance}`,
+  );
+  return rootDir;
+}
+
+async function mutate(rootDir, relativePath, transform) {
+  const filePath = path.join(rootDir, relativePath);
+  const source = await readFile(filePath, "utf8");
+  await writeFile(filePath, transform(source));
+}
+
+function assertHasError(errors, expectedText) {
+  assert.ok(
+    errors.some((error) => error.includes(expectedText)),
+    `Expected an error containing "${expectedText}", received:\n${errors.join("\n")}`,
+  );
+}
+
+test("accepts a complete non-recursive harness with direct specialist routing", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  assert.deepEqual(await validateAgentHarness({ rootDir }), []);
+});
+
+test("reports malformed frontmatter with the file and line", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/agents/fast-task.agent.md", (source) =>
+    source.replace("description: Fixture", "description Fixture"),
+  );
+
+  const errors = await validateAgentHarness({ rootDir });
+  assertHasError(errors, ".github/agents/fast-task.agent.md:3: unsupported frontmatter syntax");
+});
+
+test("rejects an agent name that does not match its filename", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/agents/engineering-reviewer.agent.md", (source) =>
+    source.replace("name: engineering-reviewer", "name: reviewer"),
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    "frontmatter name must be engineering-reviewer, received reviewer",
+  );
+});
+
+test("discovers additional managed agents and rejects unknown references", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await writeFile(
+    path.join(rootDir, ".github/agents/additional-worker.agent.md"),
+    agentSource("additional-worker", { agents: ["missing-worker"] }),
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    "additional-worker.agent.md: agents references unknown managed agent missing-worker",
+  );
+});
+
+test("detects cycles across additional managed agents", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await writeFile(
+    path.join(rootDir, ".github/agents/worker-a.agent.md"),
+    agentSource("worker-a", { agents: ["worker-b"] }),
+  );
+  await writeFile(
+    path.join(rootDir, ".github/agents/worker-b.agent.md"),
+    agentSource("worker-b", { agents: ["worker-a"] }),
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    "agent delegation graph: cycle detected: worker-a -> worker-b -> worker-a",
+  );
+});
+
+test("ignores generated Spec Kit agent files in fixture discovery", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await writeFile(
+    path.join(rootDir, ".github/agents/speckit.plan.agent.md"),
+    "generated content without supported frontmatter",
+  );
+  await writeFile(
+    path.join(rootDir, ".github/agents/medassist-feature-orchestrator.agent.md"),
+    "generated content without supported frontmatter",
+  );
+
+  assert.deepEqual(await validateAgentHarness({ rootDir }), []);
+});
+
+test("validates every managed skill folder name and description", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mkdir(path.join(rootDir, ".github/skills/broken-skill"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, ".github/skills/broken-skill/SKILL.md"),
+    "---\nname: wrong-name\ndescription: ''\n---\n",
+  );
+
+  const errors = await validateAgentHarness({ rootDir });
+  assertHasError(errors, "frontmatter name must match skill folder broken-skill, received wrong-name");
+  assertHasError(errors, "broken-skill/SKILL.md: frontmatter description must be a non-empty string");
+});
+
+test("rejects missing or extra orchestrator delegation targets", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/agents/engineering-orchestrator.agent.md", (source) =>
+    source.replace("'engineering-reviewer', ", ""),
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    "agents must contain exactly model-router, fast-task, standard-task, complex-task, engineering-reviewer",
+  );
+});
+
+test("rejects recursive leaf delegation", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/agents/testing-manager.agent.md", (source) =>
+    source.replace("agents: []", "agents: ['standard-task']"),
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    ".github/agents/testing-manager.agent.md: agents must be [] to prevent recursive delegation",
+  );
+});
+
+test("keeps the classifier inert and internal agents hidden", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/agents/engineering-orchestrator.agent.md", (source) =>
+    source.replace("user-invocable: true", "user-invocable: false"),
+  );
+  await mutate(rootDir, ".github/agents/model-router.agent.md", (source) =>
+    source.replace("tools: []", "tools: ['execute']"),
+  );
+  await mutate(rootDir, ".github/agents/engineering-reviewer.agent.md", (source) =>
+    source.replace("user-invocable: false", "user-invocable: true"),
+  );
+  await mutate(rootDir, ".github/agents/fast-task.agent.md", (source) =>
+    source.replace("user-invocable: false", "user-invocable: true"),
+  );
+  await mutate(rootDir, ".github/agents/project-bot.agent.md", (source) =>
+    source.replace("user-invocable: false", "user-invocable: true"),
+  );
+
+  const errors = await validateAgentHarness({ rootDir });
+  assertHasError(errors, "engineering-orchestrator.agent.md: user-invocable must be true");
+  assertHasError(errors, "model-router.agent.md: tools must be [] because the router only classifies work");
+  assertHasError(errors, "engineering-reviewer.agent.md: user-invocable must be false");
+  assertHasError(errors, "fast-task.agent.md: user-invocable must be false");
+  assertHasError(errors, "project-bot.agent.md: user-invocable must be false");
+});
+
+for (const [label, text, expectedError] of [
+  ["testing", "directly to `testing-manager`", "must route testing work directly to testing-manager"],
+  ["release", "directly to `release-manager`", "must route release work directly to release-manager"],
+  [
+    "project metadata",
+    "metadata-only GitHub coordination to `project-bot`",
+    "must route metadata-only GitHub work directly to project-bot",
+  ],
+]) {
+  test(`enforces direct ${label} routing`, async (testContext) => {
+    const rootDir = await createValidFixture(testContext);
+    await mutate(rootDir, ".github/agents/engineering-orchestrator.agent.md", (source) =>
+      source.replace(text, "to `standard-task`"),
+    );
+
+    assertHasError(await validateAgentHarness({ rootDir }), expectedError);
+  });
+}
+
+for (const relativePath of ["AGENTS.md", ".github/copilot-instructions.md"]) {
+  test(`${relativePath} must preserve the routing role inventory`, async (testContext) => {
+    const rootDir = await createValidFixture(testContext);
+    await mutate(rootDir, relativePath, (source) => source.replace("engineering-reviewer\n", ""));
+
+    assertHasError(
+      await validateAgentHarness({ rootDir }),
+      `${relativePath}: must name engineering-reviewer for independent engineering review`,
+    );
+  });
+
+  for (const [contract, replacement, expectedError] of [
+    [
+      "Keep one implementation owner and one writer per file set.",
+      "Use any number of implementation owners and writers.",
+      "must preserve one implementation owner and one writer per file set",
+    ],
+    [
+      "Limit normal parallel fan-out to three independent read-only workers.",
+      "Parallel fan-out is unrestricted.",
+      "must limit normal fan-out to three independent read-only workers",
+    ],
+    [
+      "Allow at most one focused repair pass after review.",
+      "Allow repeated repair passes after review.",
+      "must allow at most one repair pass",
+    ],
+    [
+      "Start with the lowest capable tier.",
+      "Start with the complex tier.",
+      "must preserve lowest-capable-tier cost control",
+    ],
+  ]) {
+    test(`${relativePath} preserves ${expectedError}`, async (testContext) => {
+      const rootDir = await createValidFixture(testContext);
+      await mutate(rootDir, relativePath, (source) => source.replace(contract, replacement));
+
+      assertHasError(await validateAgentHarness({ rootDir }), `${relativePath}: ${expectedError}`);
+    });
+  }
+}
+
+test("rejects a fallback that contradicts direct specialist routing", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/copilot-instructions.md", (source) =>
+    `${source}\nWhen testing-manager is unavailable, route testing through standard-task.\n`,
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    ".github/copilot-instructions.md: must not route specialist work through a generic task worker",
+  );
+});
+
+test("fallback must keep AGENTS.md canonical", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/copilot-instructions.md", (source) =>
+    source.replace("Treat AGENTS.md as canonical", "Treat AGENTS.md as optional"),
+  );
+
+  assertHasError(
+    await validateAgentHarness({ rootDir }),
+    ".github/copilot-instructions.md: must keep AGENTS.md canonical when the fallback is used",
+  );
+});
+
+test("the CLI exits non-zero and prints actionable failures", async (testContext) => {
+  const rootDir = await createValidFixture(testContext);
+  await mutate(rootDir, ".github/agents/complex-task.agent.md", (source) =>
+    source.replace("agents: []", "agents: ['complex-task']"),
+  );
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [SCRIPT_PATH, rootDir]),
+    (error) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /Agent harness validation failed with 2 error/);
+      assert.match(error.stderr, /cycle detected: complex-task -> complex-task/);
+      assert.match(error.stderr, /complex-task\.agent\.md: agents must be \[\]/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
Closes #1099

## Summary
- add deterministic validation and mutation coverage for the managed agent harness
- establish explicit orchestrator, model-router, specialist, and project-governance routing
- align repository governance and CI with the harness contract
- repair release-manager instructions so a complete authorized shipping request continues through push, PR, CI, and merge without redundant confirmation

## Validation
- `npm run test:agent-harness`
- `npm run validate:agent-harness`
- `npm run check`
- `git diff --check github/main...HEAD`