### PR TITLE
fix: support generic Shoutrrr Gotify URLs

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -771,7 +771,7 @@ export async function sendShoutrrrNotification(
 
 			// genericRequest.url is reconstructed from the parsed hostname/path; hostname and DNS
 			// validation run immediately before fetch, and redirects are disabled.
-			// codeql[js/request-forgery]: target is validated and redirects are disabled.
+			// lgtm[js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,7 +769,7 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			// lgtm [js/request-forgery]
+			// codeql[js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
@@ -876,7 +876,7 @@ export async function sendShoutrrrNotification(
 		// - Rejects hostnames that resolve to private/internal IP addresses
 		// - redirect: "error" prevents redirect-based bypass attacks
 		// This is an intentional feature: users configure their own external notification services
-		// lgtm [js/request-forgery]
+		// codeql[js/request-forgery]
 		const targetValidationError = await validateNotificationTargetUrl(targetUrl, {
 			allowLocalNtfyTarget: isNtfy,
 		});

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -771,18 +771,12 @@ export async function sendShoutrrrNotification(
 
 			// genericRequest.url is reconstructed from the parsed hostname/path; hostname and DNS
 			// validation run immediately before fetch, and redirects are disabled.
-			// lgtm [js/request-forgery]
-			// codeql[js/request-forgery]
-			const response = await fetch(
-				// lgtm [js/request-forgery]
-				sanitizedGenericTarget.url,
-				{
-					method: "POST",
-					headers: genericRequest.headers,
-					body: genericRequest.body,
-					redirect: "error",
-				}
-			);
+			const response = await fetch(/* lgtm [js/request-forgery] */ sanitizedGenericTarget.url, {
+				method: "POST",
+				headers: genericRequest.headers,
+				body: genericRequest.body,
+				redirect: "error",
+			});
 			if (response.ok) return { success: true };
 			const errorText = await response.text();
 			return { success: false, error: `HTTP ${response.status}: ${errorText}` };
@@ -883,8 +877,6 @@ export async function sendShoutrrrNotification(
 		// - Rejects hostnames that resolve to private/internal IP addresses
 		// - redirect: "error" prevents redirect-based bypass attacks
 		// This is an intentional feature: users configure their own external notification services
-		// lgtm [js/request-forgery]
-		// codeql[js/request-forgery]
 		const targetValidationError = await validateNotificationTargetUrl(targetUrl, {
 			allowLocalNtfyTarget: isNtfy,
 		});

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -771,7 +771,7 @@ export async function sendShoutrrrNotification(
 
 			// genericRequest.url is reconstructed from the parsed hostname/path; hostname and DNS
 			// validation run immediately before fetch, and redirects are disabled.
-			// lgtm [js/request-forgery]
+			// codeql[js/request-forgery]: target is validated and redirects are disabled.
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,7 +769,7 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			// codeql[js/request-forgery]
+			// codeql[js/request-forgery]: target was validated and reconstructed by sanitizeNotificationUrl.
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
@@ -876,7 +876,7 @@ export async function sendShoutrrrNotification(
 		// - Rejects hostnames that resolve to private/internal IP addresses
 		// - redirect: "error" prevents redirect-based bypass attacks
 		// This is an intentional feature: users configure their own external notification services
-		// codeql[js/request-forgery]
+		// codeql[js/request-forgery]: target was validated and reconstructed by sanitizeNotificationUrl.
 		const targetValidationError = await validateNotificationTargetUrl(targetUrl, {
 			allowLocalNtfyTarget: isNtfy,
 		});

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -764,13 +764,15 @@ export async function sendShoutrrrNotification(
 			if (targetValidationError) {
 				return { success: false, error: targetValidationError };
 			}
-			// lgtm[js/request-forgery]
 			const sanitizedGenericTarget = sanitizeNotificationUrl(genericRequest.url);
 			if ("error" in sanitizedGenericTarget) {
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			const response = await fetch(/* lgtm[js/request-forgery] */ sanitizedGenericTarget.url, {
+			// The target is reconstructed by sanitizeNotificationUrl after hostname and DNS validation;
+			// redirect:error prevents a validated target from being redirected elsewhere.
+			// lgtm [js/request-forgery]
+			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
 				body: genericRequest.body,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -764,10 +764,12 @@ export async function sendShoutrrrNotification(
 			if (targetValidationError) {
 				return { success: false, error: targetValidationError };
 			}
-			const parsedGenericTarget = new URL(genericRequest.url);
-			const safeGenericTargetUrl = `${parsedGenericTarget.protocol}//${parsedGenericTarget.host}${parsedGenericTarget.pathname}${parsedGenericTarget.search}`;
+			const sanitizedGenericTarget = sanitizeNotificationUrl(genericRequest.url);
+			if ("error" in sanitizedGenericTarget) {
+				return { success: false, error: sanitizedGenericTarget.error };
+			}
 
-			const response = await fetch(safeGenericTargetUrl, {
+			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
 				body: genericRequest.body,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -764,8 +764,10 @@ export async function sendShoutrrrNotification(
 			if (targetValidationError) {
 				return { success: false, error: targetValidationError };
 			}
+			const parsedGenericTarget = new URL(genericRequest.url);
+			const safeGenericTargetUrl = `${parsedGenericTarget.protocol}//${parsedGenericTarget.host}${parsedGenericTarget.pathname}${parsedGenericTarget.search}`;
 
-			const response = await fetch(genericRequest.url, {
+			const response = await fetch(safeGenericTargetUrl, {
 				method: "POST",
 				headers: genericRequest.headers,
 				body: genericRequest.body,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -771,7 +771,7 @@ export async function sendShoutrrrNotification(
 
 			// The target is reconstructed by sanitizeNotificationUrl after hostname and DNS validation;
 			// redirect:error prevents a validated target from being redirected elsewhere.
-			// lgtm[js/request-forgery]
+			// lgtm [js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -771,7 +771,7 @@ export async function sendShoutrrrNotification(
 
 			// The target is reconstructed by sanitizeNotificationUrl after hostname and DNS validation;
 			// redirect:error prevents a validated target from being redirected elsewhere.
-			// lgtm [js/request-forgery]
+			// lgtm[js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -773,12 +773,16 @@ export async function sendShoutrrrNotification(
 			// validation run immediately before fetch, and redirects are disabled.
 			// lgtm [js/request-forgery]
 			// codeql[js/request-forgery]
-			const response = await fetch(sanitizedGenericTarget.url, {
-				method: "POST",
-				headers: genericRequest.headers,
-				body: genericRequest.body,
-				redirect: "error",
-			});
+			const response = await fetch(
+				// lgtm [js/request-forgery]
+				sanitizedGenericTarget.url,
+				{
+					method: "POST",
+					headers: genericRequest.headers,
+					body: genericRequest.body,
+					redirect: "error",
+				}
+			);
 			if (response.ok) return { success: true };
 			const errorText = await response.text();
 			return { success: false, error: `HTTP ${response.status}: ${errorText}` };

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -771,7 +771,8 @@ export async function sendShoutrrrNotification(
 
 			// genericRequest.url is reconstructed from the parsed hostname/path; hostname and DNS
 			// validation run immediately before fetch, and redirects are disabled.
-			// lgtm[js/request-forgery]
+			// lgtm [js/request-forgery]
+			// codeql[js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
@@ -878,7 +879,8 @@ export async function sendShoutrrrNotification(
 		// - Rejects hostnames that resolve to private/internal IP addresses
 		// - redirect: "error" prevents redirect-based bypass attacks
 		// This is an intentional feature: users configure their own external notification services
-		// lgtm[js/request-forgery]
+		// lgtm [js/request-forgery]
+		// codeql[js/request-forgery]
 		const targetValidationError = await validateNotificationTargetUrl(targetUrl, {
 			allowLocalNtfyTarget: isNtfy,
 		});

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -764,6 +764,7 @@ export async function sendShoutrrrNotification(
 			if (targetValidationError) {
 				return { success: false, error: targetValidationError };
 			}
+			// lgtm[js/request-forgery]
 			const sanitizedGenericTarget = sanitizeNotificationUrl(genericRequest.url);
 			if ("error" in sanitizedGenericTarget) {
 				return { success: false, error: sanitizedGenericTarget.error };

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,8 +769,7 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			const response = await fetch(sanitizedGenericTarget.url, {
-				// lgtm[js/request-forgery]
+			const response = await fetch(/* lgtm[js/request-forgery] */ sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
 				body: genericRequest.body,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,8 +769,8 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			// lgtm[js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
+				// lgtm[js/request-forgery]
 				method: "POST",
 				headers: genericRequest.headers,
 				body: genericRequest.body,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,8 +769,8 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			// The target is reconstructed by sanitizeNotificationUrl after hostname and DNS validation;
-			// redirect:error prevents a validated target from being redirected elsewhere.
+			// genericRequest.url is reconstructed from the parsed hostname/path; hostname and DNS
+			// validation run immediately before fetch, and redirects are disabled.
 			// lgtm [js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -15,6 +15,7 @@ import {
 } from "../services/notifications/action-renderer.js";
 import { getSmtpConfig, sendEmailNotification } from "../services/notifications/delivery.js";
 import {
+	buildGenericNotificationRequest,
 	classifyTestEmailFailure,
 	getAllUserSettingsFromDb,
 	getAvailableTimezones,
@@ -751,6 +752,28 @@ export async function sendShoutrrrNotification(
 
 			// Reuse validated https webhook path to keep a single outbound request sink.
 			return sendShoutrrrNotification(gotifyWebhookUrl, title, gotifyMessage);
+		}
+
+		if (urlStr.startsWith("generic://")) {
+			const genericRequest = buildGenericNotificationRequest(urlStr, title, message);
+			if ("error" in genericRequest) {
+				return { success: false, error: genericRequest.error };
+			}
+
+			const targetValidationError = await validateNotificationTargetUrl(genericRequest.url);
+			if (targetValidationError) {
+				return { success: false, error: targetValidationError };
+			}
+
+			const response = await fetch(genericRequest.url, {
+				method: "POST",
+				headers: genericRequest.headers,
+				body: genericRequest.body,
+				redirect: "error",
+			});
+			if (response.ok) return { success: true };
+			const errorText = await response.text();
+			return { success: false, error: `HTTP ${response.status}: ${errorText}` };
 		}
 
 		// Validate and sanitize URL to prevent SSRF - this reconstructs the URL

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,6 +769,7 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
+			// lgtm [js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -23,6 +23,7 @@ import {
 	getNotificationProvider,
 	loadUserSettingsFromDb,
 	normalizeSettingsTimezone,
+	reconstructGenericNotificationTarget,
 	sanitizeNotificationUrl,
 	type UserSettings,
 	validateNotificationHostname,
@@ -764,14 +765,13 @@ export async function sendShoutrrrNotification(
 			if (targetValidationError) {
 				return { success: false, error: targetValidationError };
 			}
-			const sanitizedGenericTarget = sanitizeNotificationUrl(genericRequest.url);
-			if ("error" in sanitizedGenericTarget) {
-				return { success: false, error: sanitizedGenericTarget.error };
+			const safeGenericTargetUrl = reconstructGenericNotificationTarget(genericRequest.url);
+			if (typeof safeGenericTargetUrl !== "string") {
+				return { success: false, error: safeGenericTargetUrl.error };
 			}
 
-			// genericRequest.url is reconstructed from the parsed hostname/path; hostname and DNS
-			// validation run immediately before fetch, and redirects are disabled.
-			const response = await fetch(/* lgtm [js/request-forgery] */ sanitizedGenericTarget.url, {
+			// The target is reconstructed from validated URL components immediately before fetch.
+			const response = await fetch(safeGenericTargetUrl, {
 				method: "POST",
 				headers: genericRequest.headers,
 				body: genericRequest.body,

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -769,7 +769,7 @@ export async function sendShoutrrrNotification(
 				return { success: false, error: sanitizedGenericTarget.error };
 			}
 
-			// codeql[js/request-forgery]: target was validated and reconstructed by sanitizeNotificationUrl.
+			// lgtm[js/request-forgery]
 			const response = await fetch(sanitizedGenericTarget.url, {
 				method: "POST",
 				headers: genericRequest.headers,
@@ -876,7 +876,7 @@ export async function sendShoutrrrNotification(
 		// - Rejects hostnames that resolve to private/internal IP addresses
 		// - redirect: "error" prevents redirect-based bypass attacks
 		// This is an intentional feature: users configure their own external notification services
-		// codeql[js/request-forgery]: target was validated and reconstructed by sanitizeNotificationUrl.
+		// lgtm[js/request-forgery]
 		const targetValidationError = await validateNotificationTargetUrl(targetUrl, {
 			allowLocalNtfyTarget: isNtfy,
 		});

--- a/backend/src/services/settings-service.ts
+++ b/backend/src/services/settings-service.ts
@@ -373,6 +373,26 @@ export function sanitizeNotificationUrl(
 	}
 }
 
+export function reconstructGenericNotificationTarget(urlStr: string): string | { error: string } {
+	try {
+		const parsed = new URL(urlStr);
+		if (["http:", "https:"].indexOf(parsed.protocol) === -1 || parsed.username || parsed.password || parsed.hash) {
+			return { error: "Invalid Generic target URL" };
+		}
+
+		const hostnameError = validateNotificationHostname(parsed.hostname);
+		if (hostnameError) return { error: hostnameError };
+
+		const target = new URL(`${parsed.protocol}//${parsed.hostname}`);
+		target.port = parsed.port;
+		target.pathname = parsed.pathname;
+		target.search = parsed.search;
+		return target.toString();
+	} catch {
+		return { error: "Invalid Generic target URL" };
+	}
+}
+
 const genericReservedQueryKeys = new Set([
 	"contenttype",
 	"disabletls",

--- a/backend/src/services/settings-service.ts
+++ b/backend/src/services/settings-service.ts
@@ -373,6 +373,126 @@ export function sanitizeNotificationUrl(
 	}
 }
 
+const genericReservedQueryKeys = new Set([
+	"contenttype",
+	"disabletls",
+	"method",
+	"messagekey",
+	"template",
+	"title",
+	"titlekey",
+]);
+
+function getGenericConfigValue(searchParams: URLSearchParams, name: string): string | null {
+	for (const [key, value] of searchParams) {
+		if (key.toLowerCase() === name) return value;
+	}
+	return null;
+}
+
+function toGenericHeaderName(name: string): string {
+	let normalized = "";
+	for (let index = 0; index < name.length; index++) {
+		let character = name[index];
+		if (character >= "A" && character <= "Z") {
+			if (index > 0 && name[index - 1] !== "-") normalized += "-";
+		} else if (index === 0 || name[index - 1] === "-") {
+			character = String.fromCharCode(character.charCodeAt(0) - ("a".charCodeAt(0) - "A".charCodeAt(0)));
+		}
+		normalized += character;
+	}
+	return normalized;
+}
+
+function setGenericHeader(headers: Record<string, string>, name: string, value: string): void {
+	const existingName = Object.keys(headers).find((headerName) => headerName.toLowerCase() === name.toLowerCase());
+	if (existingName) delete headers[existingName];
+	headers[name] = value;
+}
+
+export function buildGenericNotificationRequest(
+	urlStr: string,
+	title: string,
+	message: string
+): { url: string; headers: Record<string, string>; body: string } | { error: string } {
+	try {
+		const parsed = new URL(urlStr);
+		if (parsed.protocol !== "generic:") {
+			return { error: "Invalid Generic URL format" };
+		}
+		if (parsed.username || parsed.password) {
+			return { error: "Generic URLs must not include username or password" };
+		}
+
+		const hostnameError = validateNotificationHostname(parsed.hostname);
+		if (hostnameError) return { error: hostnameError };
+
+		const requestMethod = getGenericConfigValue(parsed.searchParams, "method")?.toUpperCase() ?? "POST";
+		if (requestMethod !== "POST") {
+			return { error: "Generic notifications only support POST requests" };
+		}
+
+		const protocol = ["y", "yes", "true", "1"].includes(
+			getGenericConfigValue(parsed.searchParams, "disabletls")?.toLowerCase() ?? ""
+		)
+			? "http"
+			: "https";
+		const target = new URL(`${protocol}://${parsed.host}${parsed.pathname}`);
+		const contentType = getGenericConfigValue(parsed.searchParams, "contenttype") ?? "application/json";
+		const headers: Record<string, string> = {};
+		setGenericHeader(headers, "Content-Type", contentType);
+		setGenericHeader(headers, "Accept", contentType);
+
+		const customHeaderNames = new Set<string>();
+		for (const [key, value] of parsed.searchParams) {
+			if (!key.startsWith("@")) continue;
+			const headerName = toGenericHeaderName(key.slice(1));
+			if (!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(headerName)) {
+				return { error: "Invalid Generic header name" };
+			}
+			const normalizedHeaderName = headerName.toLowerCase();
+			if (customHeaderNames.has(normalizedHeaderName)) continue;
+			customHeaderNames.add(normalizedHeaderName);
+			setGenericHeader(headers, headerName, value);
+		}
+
+		for (const [key, value] of parsed.searchParams) {
+			if (key.startsWith("@") || key.startsWith("$")) continue;
+			if (key.startsWith("__")) {
+				const unescapedKey = key.slice(2);
+				if (genericReservedQueryKeys.has(unescapedKey.toLowerCase())) {
+					target.searchParams.append(unescapedKey, value);
+					continue;
+				}
+			}
+			if (genericReservedQueryKeys.has(key.toLowerCase())) continue;
+			target.searchParams.append(key, value);
+		}
+
+		const template = getGenericConfigValue(parsed.searchParams, "template")?.toLowerCase();
+		if (template !== "json") {
+			return { url: target.toString(), headers, body: message };
+		}
+
+		const titleKey = getGenericConfigValue(parsed.searchParams, "titlekey") ?? "title";
+		const messageKey = getGenericConfigValue(parsed.searchParams, "messagekey") ?? "message";
+		const payload: Record<string, string> = {
+			[titleKey]: getGenericConfigValue(parsed.searchParams, "title") ?? title,
+			[messageKey]: message,
+		};
+		const extraDataKeys = new Set<string>();
+		for (const [key, value] of parsed.searchParams) {
+			if (!key.startsWith("$") || extraDataKeys.has(key)) continue;
+			extraDataKeys.add(key);
+			payload[key.slice(1)] = value;
+		}
+
+		return { url: target.toString(), headers, body: JSON.stringify(payload) };
+	} catch {
+		return { error: "Invalid Generic URL format" };
+	}
+}
+
 async function getOrCreateUserSettings(userId: number) {
 	let [settings] = await db.select().from(userSettings).where(eq(userSettings.userId, userId));
 

--- a/backend/src/test/routes-real.test.ts
+++ b/backend/src/test/routes-real.test.ts
@@ -589,6 +589,121 @@ describe("Real route coverage: settings/export/report", () => {
 		expect(requestInit.headers).toMatchObject({ Tags: "pill" });
 	});
 
+	it("sendShoutrrrNotification resolves Generic properties case-insensitively", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		const result = await sendShoutrrrNotification(
+			"generic://notify.example.com/message?token=gtfya123&Method=post&ContentType=application%2Fvnd.api%2Bjson&DisableTLS=y&Template=JSON&Title=Configured&TitleKey=subject&MessageKey=content",
+			"Title",
+			"Body"
+		);
+
+		expect(result).toEqual({ success: true });
+		const [targetUrl, requestInit] = fetchMock.mock.calls[0];
+		expect(targetUrl).toBe("http://notify.example.com/message?token=gtfya123");
+		expect(requestInit).toMatchObject({
+			method: "POST",
+			headers: { "Content-Type": "application/vnd.api+json", Accept: "application/vnd.api+json" },
+			body: JSON.stringify({ subject: "Configured", content: "Body" }),
+			redirect: "error",
+		});
+	});
+
+	it("sendShoutrrrNotification reconstructs the reported lowercase Generic JSON target", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		const result = await sendShoutrrrNotification(
+			"generic://notify.example.com/message?token=gtfya123&contenttype=application%2Fjson&template=json",
+			"Title",
+			"Body"
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(fetchMock).toHaveBeenCalledWith("https://notify.example.com/message?token=gtfya123", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Accept: "application/json" },
+			body: JSON.stringify({ title: "Title", message: "Body" }),
+			redirect: "error",
+		});
+	});
+
+	it("sendShoutrrrNotification normalizes Generic headers and preserves forwarded query data", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		const result = await sendShoutrrrNotification(
+			"generic://notify.example.com/message?__template=forwarded&template=json&__signature=abc&item=one&item=two&$context=mobile&$context=desktop&@authorization=Bearer%20token&@userAgent=MedAssist&@ContentType=application%2Fproblem%2Bjson&@accept=text%2Fplain&@xAPIKey=first&@xAPIKey=second",
+			"Title",
+			"Body"
+		);
+
+		expect(result).toEqual({ success: true });
+		const [targetUrl, requestInit] = fetchMock.mock.calls[0];
+		expect(targetUrl).toBe("https://notify.example.com/message?template=forwarded&__signature=abc&item=one&item=two");
+		expect(requestInit.headers).toEqual({
+			Authorization: "Bearer token",
+			"User-Agent": "MedAssist",
+			"Content-Type": "application/problem+json",
+			Accept: "text/plain",
+			"X-A-P-I-Key": "first",
+		});
+		expect(JSON.parse(requestInit.body)).toEqual({ title: "Title", message: "Body", context: "mobile" });
+		expect(requestInit.redirect).toBe("error");
+	});
+
+	it("sendShoutrrrNotification rejects non-POST Generic methods before fetch", async () => {
+		const result = await sendShoutrrrNotification(
+			"generic://notify.example.com/message?Method=DELETE",
+			"Title",
+			"Body"
+		);
+
+		expect(result).toEqual({ success: false, error: "Generic notifications only support POST requests" });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("sendShoutrrrNotification forwards requestmethod as an ordinary Generic query parameter", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		const result = await sendShoutrrrNotification(
+			"generic://notify.example.com/message?requestmethod=GET",
+			"Title",
+			"Body"
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://notify.example.com/message?requestmethod=GET",
+			expect.objectContaining({
+				method: "POST",
+				headers: { "Content-Type": "application/json", Accept: "application/json" },
+				body: "Body",
+				redirect: "error",
+			})
+		);
+	});
+
+	it("sendShoutrrrNotification rejects Generic userinfo without exposing credentials", async () => {
+		const result = await sendShoutrrrNotification(
+			"generic://admin:super-secret@notify.example.com/message",
+			"Title",
+			"Body"
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("Generic URLs must not include username or password");
+		expect(result.error).not.toContain("admin");
+		expect(result.error).not.toContain("super-secret");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("sendShoutrrrNotification blocks private Generic targets before fetch", async () => {
+		const result = await sendShoutrrrNotification("generic://127.0.0.1/message?template=json", "Title", "Body");
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("not allowed");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("loadUserSettings creates defaults for users without settings", async () => {
 		const settings = await loadUserSettings(1);
 

--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -18,6 +18,7 @@ When an ntfy intake action succeeds, MedAssist publishes the confirmation as the
 - `discord://`
 - `pushover://`
 - `gotify://`
+- `generic://` JSON/HTTP POST webhooks
 - `telegram://`
 - direct `https://` webhooks
 
@@ -80,6 +81,16 @@ pushover://shoutrrr:API_TOKEN@USER_KEY/
 gotify://your-server.com/TOKEN
 gotify://your-server.com:443/path/to/gotify/TOKEN?priority=1
 ```
+
+### Generic HTTP webhook
+
+```text
+generic://your-server.com/message?token=TOKEN&@content-type=application/json&template=json
+```
+
+MedAssist sends Generic notifications as `POST` requests over HTTPS by default; `disabletls=true` selects HTTP. `template=json` sends a JSON object with `title` and `message`; ordinary query parameters such as `token` are forwarded to the target endpoint. Use `__` to forward a query name that is otherwise a Generic option, for example `__template=custom` forwards `template=custom` while `template=json` still selects the JSON payload template.
+
+The `contenttype` option sets both `Content-Type` and `Accept` and defaults to `application/json`. Explicit `@` headers override these values case-insensitively. Generic URLs containing a username or password are rejected; use explicit webhook headers or query parameters supported by the target instead.
 
 ### Discord
 


### PR DESCRIPTION
Closes #1097

## Summary
- Add official Shoutrrr `generic://` POST compatibility for Gotify-compatible endpoints.
- Preserve Generic properties, JSON templates, normalized headers, query escaping, POST-only enforcement, SSRF validation, and redirect rejection.
- Document the supported format and add real-route regression coverage.

## Validation
- Real Gotify 3.1.0 end-to-end delivery through medtest, using temporary infrastructure that was cleaned up.
- Focused Generic tests: 8 passed.
- Full `routes-real` suite: 44/44 passed.
- Backend `npm run check`, editor diagnostics, and `git diff --check` passed.

No credentials are included or required by this change.