### PR TITLE
chore: prepare release v1.33.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-backend",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "dependencies": {
         "@fastify/cookie": "^11.1.2",
         "@fastify/cors": "^11.3.0",
@@ -44,11 +44,11 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medassist-ng-backend",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: medassist-ng
 
 services:
   backend:
-    image: ghcr.io/danielvolz/medassist-ng-backend:1.33.0
+    image: ghcr.io/danielvolz/medassist-ng-backend:1.33.1
     container_name: medassist-ng-backend
     env_file:
       - .env
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   frontend:
-    image: ghcr.io/danielvolz/medassist-ng-frontend:1.33.0
+    image: ghcr.io/danielvolz/medassist-ng-frontend:1.33.1
     container_name: medassist-ng-frontend
     env_file:
       - .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medassist-ng-frontend",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medassist-ng-frontend",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.3.0",
         "@fontsource/ibm-plex-sans": "^5.3.0",
@@ -43,11 +43,11 @@
     },
     "../shared": {
       "name": "@medassist/shared",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medassist-ng-frontend",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.33.1",
   "type": "module",
   "scripts": {
     "dev": "npm --prefix ../shared run build && vite",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medassist/shared",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medassist/shared",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "typescript": "6.0.3",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medassist/shared",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #1102

Updates backend, frontend, and shared versions to 1.33.1, refreshes lockfile metadata, and pins production images to the release tag.